### PR TITLE
added ArrayBuffer alias

### DIFF
--- a/src/js/html/ArrayBuffer.hx
+++ b/src/js/html/ArrayBuffer.hx
@@ -1,0 +1,3 @@
+package js.html;
+
+typedef ArrayBuffer = js.node.buffer.Buffer;


### PR DESCRIPTION
without this alias, `BytesBuffer` will fail at this line: https://github.com/HaxeFoundation/haxe/blob/development/std/haxe/io/BytesBuffer.hx#L210