### PR TITLE
Do not drop view bounds when converting to bytes.

### DIFF
--- a/src/js/node/buffer/Buffer.hx
+++ b/src/js/node/buffer/Buffer.hx
@@ -480,7 +480,7 @@ extern class Buffer extends js.html.Uint8Array {
 		Any modifications done using the returned object will be reflected in the `this` buffer.
 	**/
 	inline function hxToBytes():haxe.io.Bytes {
-		return haxe.io.Bytes.ofData(buffer);
+		return haxe.io.Bytes.ofData(cast this);
 	}
 
 	/**


### PR DESCRIPTION
The `BytesData` really needs to be the underlying view and not the blob. This is not in line with how `Bytes` usually works in js (which possibly should be reconsidered), but it is necessary, because node packs small buffers onto the same `ArrayBuffer`. Also `slice` creates a new `Buffer` backed by the original `ArrayBuffer`.

I recently updated some code to use `hxToBytes`, introducing in weird bugs where the resulting `Bytes` sometimes get padded with junk. I think this is a pretty severe issue.