### PR TITLE
Change IncomingMessage.headers to EitherType

### DIFF
--- a/src/js/node/http/IncomingMessage.hx
+++ b/src/js/node/http/IncomingMessage.hx
@@ -53,7 +53,7 @@ extern class IncomingMessage extends Readable<IncomingMessage> {
 		The request/response headers object.
 		Read only map of header names and values. Header names are lower-cased
 	**/
-	var headers(default,null):DynamicAccess<String>;
+	var headers(default,null):DynamicAccess<haxe.extern.EitherType<String, Array<String>>>;
 
 	/**
 		The request/response trailers object.


### PR DESCRIPTION
Follow the change of API for `HttpOptions.headers` to support Array headers.

Closes #61