### PR TITLE
Add Sys.programPath()

### DIFF
--- a/src/Sys.hx
+++ b/src/Sys.hx
@@ -73,8 +73,12 @@ class Sys {
         return process.uptime();
     }
 
-    public static inline function executablePath():String {
+    @:deprecated("Use programPath instead") public static inline function executablePath():String {
         return process.argv[0];
+    }
+    
+    public static inline function programPath():String {
+        return js.Node.__filename;
     }
 
     /**


### PR DESCRIPTION
See https://github.com/HaxeFoundation/haxe/commit/c4ee4ab60d3715f3a96fa7b21ac3b71db7a6c0e9

And this makes me wonder why only the standard library of nodejs is not included in the haxe repo, causing us to patch separately...