### PR TITLE
Change HttpRequestOptions.headers to DynamicAccess

### DIFF
--- a/src/js/node/Http.hx
+++ b/src/js/node/Http.hx
@@ -95,7 +95,7 @@ typedef HttpRequestOptions = {
 
 			Sending an Authorization header will override using the auth option to compute basic authentication.
 	**/
-	@:optional var headers:Dynamic<haxe.extern.EitherType<String,Array<String>>>;
+	@:optional var headers:DynamicAccess<haxe.extern.EitherType<String,Array<String>>>;
 
 	/**
 		Basic authentication i.e. 'user:password' to compute an Authorization header.


### PR DESCRIPTION
Change the type to match `HttpOptions.headers` and better access to the headers.

Same as #61 and #62 