### PR TITLE
Makes stream.Duplex implements IDuplex

### DIFF
--- a/src/js/node/stream/Duplex.hx
+++ b/src/js/node/stream/Duplex.hx
@@ -34,7 +34,7 @@ import js.node.Buffer;
 		- crypto streams
 **/
 @:jsRequire("stream", "Duplex")
-extern class Duplex<TSelf:Duplex<TSelf>> extends Readable<TSelf> implements Writable.IWritable {
+extern class Duplex<TSelf:Duplex<TSelf>> extends Readable<TSelf> implements IDuplex {
 	// --------- Writable interface implementation ---------
 
 	/**


### PR DESCRIPTION
`Duplex` only imlements `IWritable` and has an unused `IDuplex` interface
defined in it. Since `IDuplex` extends `IWritable`, it's seems logical to
make `Duplex` extends it.

Closes #70 