### PR TITLE
haxelib.json: add the "extern" tag

### DIFF
--- a/haxelib.json
+++ b/haxelib.json
@@ -7,5 +7,5 @@
     "releasenote": "Update externs to node.js 6.9 LTS",
     "classPath": "src",
     "contributors": ["nadako"],
-    "tags": ["js", "nodejs", "async", "net", "web"]
+    "tags": ["js", "nodejs", "async", "net", "web", "extern"]
 }


### PR DESCRIPTION
I was expecting the lib to be on this list: http://lib.haxe.org/t/extern/