### PR TITLE
Make PassThrough's constructor public

### DIFF
--- a/src/js/node/stream/PassThrough.hx
+++ b/src/js/node/stream/PassThrough.hx
@@ -27,4 +27,6 @@ package js.node.stream;
     as a building block for novel sorts of streams.
 **/
 @:jsRequire("stream", "PassThrough")
-extern class PassThrough extends Transform<PassThrough> {}
+extern class PassThrough extends Transform<PassThrough> {
+    function new();
+}


### PR DESCRIPTION
It is possible to construct a PassThrough