### PR TITLE
Don't define `nodejs` in macro context

### DIFF
--- a/extraParams.hxml
+++ b/extraParams.hxml
@@ -1,3 +1,2 @@
--D nodejs
 --macro allowPackage('sys')
---macro _hxnodejs.VersionWarning.include()
+--macro _hxnodejs.InitMacro.include()

--- a/src/_hxnodejs/InitMacro.hx
+++ b/src/_hxnodejs/InitMacro.hx
@@ -1,12 +1,15 @@
 package _hxnodejs;
 
 #if macro
-class VersionWarning {
+class InitMacro {
     static function include() {
         #if (!display && haxe_ver >= 3.3)
         if (!haxe.macro.Context.defined("hxnodejs_no_version_warning"))
             haxe.macro.Compiler.includeFile("_hxnodejs/version-warning.js");
         #end
+
+        // should behave like other target defines and not be defined in macro context
+        haxe.macro.Compiler.define("nodejs");
     }
 }
 #end


### PR DESCRIPTION
Otherwise, it's necessary to check for #if (nodejs && js), which seems redundant.
Renamed VerionWarning.hx to InitMacro.hx to avoid having two files.