### PR TITLE
Fs.existsSync should not be deprecated

### DIFF
--- a/src/js/node/Fs.hx
+++ b/src/js/node/Fs.hx
@@ -980,7 +980,6 @@ extern class Fs {
 	/**
 		Synchronous version of `exists`.
 	**/
-	@:deprecated("Use Fs.statSync or Fs.accessSync instead.")
 	static function existsSync(path:FsPath):Bool;
 
 	/**


### PR DESCRIPTION
While `fs.exists` is deprecated, `fs.existsSync` is not.

Nodejs justification:
> The callback parameter to fs.exists() accepts parameters that are inconsistent with other Node.js callbacks. fs.existsSync() does not use a callback.
> https://nodejs.org/api/fs.html#fs_fs_existssync_path