### PR TITLE
Make it possible to use `hxnodejs` as a dependency in NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "hxnodejs",
+  "private": true
+}


### PR DESCRIPTION
Adding a simple (private) package.json makes it possible for me to use `hxnodejs` as a dev dependency in NPM-based projects (such as OpenFL/NPM). This is a minor addition that should just make it easier to use the library.

Thank you :smile: