### PR TITLE
Haxe 4 compile fixes

### DIFF
--- a/src/js/node/Assert.hx
+++ b/src/js/node/Assert.hx
@@ -32,7 +32,7 @@ extern class Assert {
 		Throws an `AssertionError`. If `message` is falsy, the error message is set as the values of `actual` and `expected` separated by the provided `operator`.
 		Otherwise, the error message is the value of `message`.
 	**/
-	static function fail<T>(actual:T, expected:T, message:String, operator:String):Void;
+	static function fail<T>(actual:T, expected:T, message:String, operator_:String):Void;
 
 	/**
 		Tests if value is truthy.

--- a/src/js/node/assert/AssertionError.hx
+++ b/src/js/node/assert/AssertionError.hx
@@ -24,7 +24,9 @@ package js.node.assert;
 typedef AssertionErrorOptions = {
 	@:optional var actual:Dynamic;
 	@:optional var expected:Dynamic;
+	#if (haxe_ver < 4)
 	@:optional var operator:String;
+	#end
 	@:optional var message:String;
 	@:optional var stackStartFunction:Dynamic;
 }
@@ -33,7 +35,7 @@ typedef AssertionErrorOptions = {
 extern class AssertionError extends js.Error {
 	var actual:Dynamic;
 	var expected:Dynamic;
-	var operator:String;
+	@:native("operator") var operator_:String;
 	var generatedMessage:Bool;
 	function new(options:AssertionErrorOptions);
 }


### PR DESCRIPTION
Looks like a couple of files weren't compiling with Haxe 4 due to the new `operator` keyword.