### PR TITLE
Update `util` extern to v10

### DIFF
--- a/src/js/Node.hx
+++ b/src/js/Node.hx
@@ -25,6 +25,27 @@ import haxe.Constraints.Function;
 
 import js.node.*;
 import js.node.console.Console;
+#if haxe4
+import js.lib.Int8Array;
+import js.lib.Int16Array;
+import js.lib.Int32Array;
+import js.lib.Uint8Array;
+import js.lib.Uint8ClampedArray;
+import js.lib.Uint16Array;
+import js.lib.Uint32Array;
+import js.lib.Float32Array;
+import js.lib.Float64Array;
+#else
+import js.html.Int8Array;
+import js.html.Int16Array;
+import js.html.Int32Array;
+import js.html.Uint8Array;
+import js.html.Uint8ClampedArray;
+import js.html.Uint16Array;
+import js.html.Uint32Array;
+import js.html.Float32Array;
+import js.html.Float64Array;
+#end
 
 /**
 	Node.js globals
@@ -162,3 +183,15 @@ extern class IntervalObject extends TimerObject {}
 	Object returned by `setImmediate`.
 **/
 extern class ImmediateObject {}
+
+abstract TypedArray(Dynamic) 
+	from Uint8Array to Uint8Array
+	from Uint8ClampedArray to Uint8ClampedArray
+	from Uint16Array to Uint16Array
+	from Uint32Array to Uint32Array
+	from Int8Array to Int8Array
+	from Int16Array to Int16Array
+	from Int32Array to Int32Array
+	from Float32Array to Float32Array
+	from Float64Array to Float64Array
+{ }

--- a/src/js/node/util/Inspect.hx
+++ b/src/js/node/util/Inspect.hx
@@ -27,34 +27,34 @@ import js.node.Util.InspectOptions;
 
 @:jsRequire("util", "inspect")
 extern class Inspect {
-    /**
-        Return a string representation of `object`, which is useful for debugging.
-        An optional `options` object may be passed that alters certain aspects of the formatted string.
+	/**
+		Return a string representation of `object`, which is useful for debugging.
+		An optional `options` object may be passed that alters certain aspects of the formatted string.
 
-        Objects also may define their own `inspect(depth:Int)` function which `inspect` will invoke and
-        use the result of when inspecting the object.
-    **/
-    @:selfCall
-    static function inspect(object:Dynamic, ?options:InspectOptions):String;
+		Objects also may define their own `inspect(depth:Int)` function which `inspect` will invoke and
+		use the result of when inspecting the object.
+	**/
+	@:selfCall
+	static function inspect(object:Dynamic, ?options:InspectOptions):String;
 
-    /**
-        a map assigning each style a color from `inspect_colors`.
-        Highlighted styles and their default values are:
-            number (yellow)
-            boolean (yellow)
-            string (green)
-            date (magenta)
-            regexp (red)
-            null (bold)
-            undefined (grey)
-            special - only function at this time (cyan)
-            name (intentionally no styling)
-    **/
-    static var styles:DynamicAccess<String>;
+	/**
+		a map assigning each style a color from `inspect_colors`.
+		Highlighted styles and their default values are:
+			number (yellow)
+			boolean (yellow)
+			string (green)
+			date (magenta)
+			regexp (red)
+			null (bold)
+			undefined (grey)
+			special - only function at this time (cyan)
+			name (intentionally no styling)
+	**/
+	static var styles:DynamicAccess<String>;
 
-    /**
-        Predefined color codes are: white, grey, black, blue, cyan, green, magenta, red and yellow.
-        There are also bold, italic, underline and inverse codes.
-    **/
-    static var colors:DynamicAccess<Array<Int>>;
+	/**
+		Predefined color codes are: white, grey, black, blue, cyan, green, magenta, red and yellow.
+		There are also bold, italic, underline and inverse codes.
+	**/
+	static var colors:DynamicAccess<Array<Int>>;
 }

--- a/src/js/node/util/Inspect.hx
+++ b/src/js/node/util/Inspect.hx
@@ -22,19 +22,27 @@
 package js.node.util;
 
 import haxe.DynamicAccess;
-
 import js.node.Util.InspectOptions;
 
 @:jsRequire("util", "inspect")
 extern class Inspect {
 	/**
-		Return a string representation of `object`, which is useful for debugging.
-		An optional `options` object may be passed that alters certain aspects of the formatted string.
+		The `inspect()` method returns a string representation of `object` that is intended for debugging.
+		The output of `inspect` may change at any time and should not be depended upon programmatically.
+		Additional `options` may be passed that alter certain aspects of the formatted string.
+		`inspect()` will use the constructor's name and/or `@@toStringTag` to make an identifiable tag for an inspected value.
 
-		Objects also may define their own `inspect(depth:Int)` function which `inspect` will invoke and
-		use the result of when inspecting the object.
+		Values may supply their own custom `inspect(depth, opts)` functions, when called these receive the current `depth`
+		in the recursive inspection, as well as the options object passed to `inspect()`.
+
+		Using the `showHidden` option allows to inspect WeakMap and WeakSet entries.
+		If there are more entries than `maxArrayLength`, there is no guarantee which entries are displayed.
+		That means retrieving the same WeakSet entries twice might actually result in a different output.
+		Besides this any item might be collected at any point of time by the garbage collectorif there is no strong reference
+		left to that object. Therefore there is no guarantee to get a reliable output.
 	**/
 	@:selfCall
+	@:overload(function(object:Dynamic, ?showHidden:Bool, ?depth:Int, ?colors:Bool):String {})
 	static function inspect(object:Dynamic, ?options:InspectOptions):String;
 
 	/**
@@ -57,4 +65,22 @@ extern class Inspect {
 		There are also bold, italic, underline and inverse codes.
 	**/
 	static var colors:DynamicAccess<Array<Int>>;
+
+	/**
+		The `defaultOptions` value allows customization of the default options used by `Util.inspect`.
+		This is useful for functions like `Console.log` or `Util.format` which implicitly call into `Util.inspect`
+		It shall be set to an object containing one or more valid `Util.inspect()` options.
+		Setting option properties directly is also supported.
+	**/
+	static var defaultOptions:InspectOptions;
+
+	/**
+		In addition to being accessible through `Inspect.custom`, this symbol is registered globally
+		and can be accessed in any environment as `Symbol.for_('nodejs.util.inspect.custom')`.
+	**/
+	#if haxe4
+	static final custom:js.lib.Symbol;
+	#else
+	static var custom(default,never):Dynamic;
+	#end
 }

--- a/src/js/node/util/Promisify.hx
+++ b/src/js/node/util/Promisify.hx
@@ -48,8 +48,8 @@ extern class Promisify {
 		A `<symbol>` that can be used to declare custom promisified variants of functions.
 	**/
 	#if haxe4
-	static final custom: js.lib.Symbol;
+	static final custom:js.lib.Symbol;
 	#else
-	static var custom(default, never): Dynamic;
+	static var custom(default,never):Dynamic;
 	#end
 }

--- a/src/js/node/util/TextDecoder.hx
+++ b/src/js/node/util/TextDecoder.hx
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C)2014-2019 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+package js.node.util;
+
+#if haxe4
+import js.lib.ArrayBuffer;
+import js.lib.DataView;
+#else
+import js.html.ArrayBuffer;
+import js.html.DataView;
+#end
+
+/**
+	An implementation of the WHATWG Encoding Standard TextDecoder API.
+**/
+@:jsRequire("util", "TextDecoder")
+extern class TextDecoder {
+	/**
+		Creates an new `TextDecoder` instance.
+		
+		The `encoding` may specify one of the supported encodings or an alias.
+	**/
+	function new(?encoding:String, ?options:TextDecoderOptions);
+
+	/**
+		Decodes the `input` and returns a string.
+		If `options.stream` is `true`, any incomplete byte sequences occurring at the end of the `input`
+		are buffered internally and emitted after the next call to `decode()`.
+
+		If `fatal` is `true`, decoding errors that occur will result in a `TypeError` being thrown.
+	**/
+	@:overload(function(?input:DataView, ?options:TextDecodeOptions):String {})
+	@:overload(function(?input:js.Node.TypedArray, ?options:TextDecodeOptions):String {})
+	function decode(?input:ArrayBuffer, ?options:TextDecodeOptions):String;
+
+	/**
+		The encoding supported by the `TextDecoder` instance.
+	**/
+	var encoding(default,null):String;
+
+	/**
+		The value will be `true` if decoding errors result in a `TypeError` being thrown.
+	**/
+	var fatal(default,null):Bool;
+
+	/**
+		The value will be `true` if the decoding result will include the byte order mark.
+	**/
+	var ignoreBOM(default,null):Bool;
+}
+
+typedef TextDecoderOptions = {
+	/**
+		`true` if decoding failures are fatal. This option is only supported when ICU is enabled (see Internationalization).
+		
+		Default: `false`.
+	**/
+	@:optional var fatal:Bool;
+
+	/**
+		When `true`, the TextDecoder will include the byte order mark in the decoded result.
+		
+		When `false`, the byte order mark will be removed from the output.
+		
+		This option is only used when encoding is 'utf-8', 'utf-16be' or 'utf-16le'.
+		
+		Default: `false`.
+	**/
+	@:optional var ignoreBOM:Bool;
+}
+
+typedef TextDecodeOptions = {
+	/**
+		true if additional chunks of data are expected.
+		
+		Default: false.
+	**/
+	@:optional var stream:Bool;
+}

--- a/src/js/node/util/TextEncoder.hx
+++ b/src/js/node/util/TextEncoder.hx
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C)2014-2019 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+package js.node.util;
+
+#if haxe4
+import js.lib.Uint8Array;
+#else
+import js.html.Uint8Array;
+#end
+
+/**
+	An implementation of the WHATWG Encoding Standard `TextEncoder` API.
+	All instances of `TextEncoder` only support UTF-8 encoding.
+**/
+@:jsRequire("util", "TextEncoder")
+extern class TextEncoder {
+	function new();
+
+	/**
+		UTF-8 encodes the `input` string and returns a `Uint8Array` containing the encoded bytes.
+	**/
+	function encode(?input:String):Uint8Array;
+
+	/**
+		The encoding supported by the `TextEncoder` instance. Always set to 'utf-8'.
+	**/
+	var encoding(default,null):String;
+}

--- a/src/js/node/util/Types.hx
+++ b/src/js/node/util/Types.hx
@@ -1,0 +1,245 @@
+/*
+ * Copyright (C)2014-2019 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+package js.node.util;
+
+/**
+	`Types` provides a number of type checks for different kinds of built-in objects.
+	Unlike `Syntax.instanceof` or `Object.prototype.toString.call(value)`, these checks do not
+	inspect properties of the object that are accessible from JavaScript (like their prototype),
+	and usually have the overhead of calling into C++.
+
+	The result generally does not make any guarantees about what kinds of properties or behavior
+	a value exposes in JavaScript. They are primarily useful for addon developers who prefer to do
+	type checking in JavaScript.
+**/
+@:jsRequire("util", "types")
+extern class Types {
+	/**
+		Returns `true` if the value is a built-in ArrayBuffer or SharedArrayBuffer instance.
+	**/
+	static function isAnyArrayBuffer(value:Dynamic):Bool;
+
+	/**
+		Returns `true` if the value is an arguments object.
+	**/
+	static function isArgumentsObject(value:Dynamic):Bool;
+
+	/**
+		Returns `true` if the value is a built-in ArrayBuffer instance.
+		
+		This does not include SharedArrayBuffer instances. Usually, it is desirable to test for both.
+	**/
+	static function isArrayBuffer(value:Dynamic):Bool;
+
+	/**
+		Returns `true` if the value is an async function.
+		
+		Note that this only reports back what the JavaScript engine is seeing; in particular, the return value may not match
+		the original source code if a transpilation tool was used.
+	**/
+	static function isAsyncFunction(value:Dynamic):Bool;
+
+	/**
+		Returns `true` if the value is a BigInt64Array instance.
+	**/
+	static function isBigInt64Array(value:Dynamic):Bool;
+
+	/**
+		Returns `true` if the value is a BigUint64Array instance.
+	**/
+	static function isBigUint64Array(value:Dynamic):Bool;
+
+	/**
+		Returns `true` if the value is a boolean object,
+		e.g. created by `new Boolean()`.
+	**/
+	static function isBooleanObject(value:Dynamic):Bool;
+
+	/**
+		Returns `true` if the value is any boxed primitive object,
+		e.g. created by `new Boolean()`, `new String()` or `Object(Symbol())`.
+	**/
+	static function isBoxedPrimitive(value:Dynamic):Bool;
+
+	/**
+		Returns `true` if the value is a built-in DataView instance.
+	**/
+	static function isDataView(value:Dynamic):Bool;
+
+	/**
+		Returns `true` if the value is a built-in Date instance.
+	**/
+	static function isDate(value:Dynamic):Bool;
+
+	/**
+		Returns `true` if the value is a native External value.
+	**/
+	static function isExternal(value:Dynamic):Bool;
+
+	/**
+		Returns `true` if the value is a built-in Float32Array instance.
+	**/
+	static function isFloat32Array(value:Dynamic):Bool;
+
+	/**
+		Returns `true` if the value is a built-in Float64Array instance.
+	**/
+	static function isFloat64Array(value:Dynamic):Bool;
+
+	/**
+		Returns `true` if the value is a generator function.
+		
+		Note that this only reports back what the JavaScript engine is seeing; in particular, 
+		the return value may not match the original source code if a transpilation tool was used.
+	**/
+	static function isGeneratorFunction(value:Dynamic):Bool;
+
+	/**
+		Returns `true` if the value is a generator object as returned from a built-in generator function.
+		
+		Note that this only reports back what the JavaScript engine is seeing; in particular,
+		the return value may not match the original source code if a transpilation tool was used.
+	**/
+	static function isGeneratorObject(value:Dynamic):Bool;
+
+	/**
+		Returns `true` if the value is a built-in Int8Array instance.
+	**/
+	static function isInt8Array(value:Dynamic):Bool;
+
+	/**
+		Returns `true` if the value is a built-in Int16Array instance.
+	**/
+	static function isInt16Array(value:Dynamic):Bool;
+
+	/**
+		Returns `true` if the value is a built-in Int32Array instance.
+	**/
+	static function isInt32Array(value:Dynamic):Bool;
+
+	/**
+		Returns `true` if the value is a built-in Map instance.
+	**/
+	static function isMap(value:Dynamic):Bool;
+
+	/**
+		Returns `true` if the value is an iterator returned for a built-in Map instance.
+	**/
+	static function isMapIterator(value:Dynamic):Bool;
+
+	/**
+		Returns `true` if the value is an instance of a Module Namespace Object.
+	**/
+	static function isModuleNamespaceObject(value:Dynamic):Bool;
+
+	/**
+		Returns `true` if the value is an instance of a built-in Error type.
+	**/
+	static function isNativeError(value:Dynamic):Bool;
+
+	/**
+		Returns `true` if the value is a number object, e.g. created by `new Number()`.
+	**/
+	static function isNumberObject(value:Dynamic):Bool;
+
+	/**
+		Returns `true` if the value is a built-in Promise.
+	**/
+	static function isPromise(value:Dynamic):Bool;
+
+	/**
+		Returns `true` if the value is a Proxy instance.
+	**/
+	static function isProxy(value:Dynamic):Bool;
+
+	/**
+		Returns `true` if the value is a regular expression object.
+	**/
+	static function isRegExp(value:Dynamic):Bool;
+
+	/**
+		Returns `true` if the value is a built-in Set instance.
+	**/
+	static function isSet(value:Dynamic):Bool;
+
+	/**
+		Returns `true` if the value is an iterator returned for a built-in Set instance.
+	**/
+	static function isSetIterator(value:Dynamic):Bool;
+
+	/**
+		Returns `true` if the value is a built-in SharedArrayBuffer instance.
+		
+		This does not include ArrayBuffer instances. Usually, it is desirable to test for both.
+	**/
+	static function isSharedArrayBuffer(value:Dynamic):Bool;
+
+	/**
+		Returns `true` if the value is a string object, e.g. created by `new String()`.
+	**/
+	static function isStringObject(value:Dynamic):Bool;
+
+	/**
+		Returns `true` if the value is a symbol object, created by calling `Object()` on a `Symbol` primitive.
+	**/
+	static function isSymbolObject(value:Dynamic):Bool;
+
+	/**
+		Returns `true` if the value is a built-in TypedArray instance.
+	**/
+	static function isTypedArray(value:Dynamic):Bool;
+
+	/**
+		Returns `true` if the value is a built-in Uint8Array instance.
+	**/
+	static function isUint8Array(value:Dynamic):Bool;
+
+	/**
+		Returns `true` if the value is a built-in Uint8ClampedArray instance.
+	**/
+	static function isUint8ClampedArray(value:Dynamic):Bool;
+
+	/**
+		Returns `true` if the value is a built-in Uint16Array instance.
+	**/
+	static function isUint16Array(value:Dynamic):Bool;
+
+	/**
+		Returns `true` if the value is a built-in Uint32Array instance.
+	**/
+	static function isUint32Array(value:Dynamic):Bool;
+
+	/**
+		Returns `true` if the value is a built-in WeakMap instance.
+	**/
+	static function isWeakMap(value:Dynamic):Bool;
+
+	/**
+		Returns `true` if the value is a built-in WeakSet instance.
+	**/
+	static function isWeakSet(value:Dynamic):Bool;
+
+	/**
+		Returns `true` if the value is a built-in WebAssembly.Module instance.
+	**/
+	static function isWebAssemblyCompiledModule(value:Dynamic):Bool;
+}


### PR DESCRIPTION
If this PR is merged, `util` extern becomes completely v10.

Changes:

* Update `util.Inspect`
    * https://nodejs.org/dist/latest-v10.x/docs/api/util.html#util_util_inspect_custom
* Add `util.TextDecoder`
    * https://nodejs.org/dist/latest-v10.x/docs/api/util.html#util_class_util_textdecoder
* Add `util.TextEncoder`
    * https://nodejs.org/dist/latest-v10.x/docs/api/util.html#util_class_util_textencoder
* Add `util.Types`
    * https://nodejs.org/dist/latest-v10.x/docs/api/util.html#util_util_types
* Fix coding style
