### PR TITLE
Remove deprecated warnings

### DIFF
--- a/src/js/node/Url.hx
+++ b/src/js/node/Url.hx
@@ -56,9 +56,8 @@ extern class Url {
 		These are not, however, customizable in any way.
 		The `url.format(URL[, options])` method allows for basic customization of the output.
 
-		`format(urlObject:UrlObject)` and `format(urlObject:String)` are deprecated.
+		`format(urlObject:String)` are deprecated.
 	**/
-	@:overload(function(urlObject:UrlObject):String {})
 	@:overload(function(urlObject:String):String {})
 	static function format(url:URL, ?options:UrlFormatOptions):String;
 
@@ -67,20 +66,6 @@ extern class Url {
 		and that the URL control characters are correctly encoded when converting into a File URL.
 	**/
 	static function pathToFileURL(path:String):URL;
-
-	/**
-		Takes a URL string, parses it, and returns a URL object.
-
-		If `parseQueryString` is true, the `query` property will always be set to an object returned by the `Querystring.parse` method.
-		If false, the `query` property on the returned URL object will be an unparsed, undecoded string.
-		Defaults to false.
-
-		If `slashesDenoteHost` is true, the first token after the literal string `//` and preceding the next `/` will be interpreted as the host.
-		For instance, given `//foo/bar`, the result would be `{host: 'foo', pathname: '/bar'}` rather than `{pathname: '//foo/bar'}`.
-		Defaults to false.
-	**/
-	@:deprecated
-	static function parse(urlString:String, ?parseQueryString:Bool, ?slashesDenoteHost:Bool):UrlObject;
 
 	/**
 		Resolves a target URL relative to a base URL in a manner similar to that of a Web browser resolving an anchor tag HREF.

--- a/src/js/node/domain/Domain.hx
+++ b/src/js/node/domain/Domain.hx
@@ -31,7 +31,6 @@ import js.node.events.EventEmitter;
 **/
 @:deprecated
 @:enum abstract DomainEvent<T:Function>(Event<T>) to Event<T> {
-	var Error:DomainEvent<DomainError->Void> = "error";
 	var Dispose:DomainEvent<Void->Void> = "dispose";
 }
 


### PR DESCRIPTION
I removed `Url.hx` and `Domain.hx`'s deprecation warnings.

before:
```
$ haxe build.hxml
src/js/node/Url.hx:61: characters 32-41 : Warning : This typedef is deprecated in favor of { ?slashes : Null<Bool>, ?search : Null<String>, ?query : Null<haxe.extern.EitherType<String, haxe.DynamicAccess<String>>>, ?protocol : Null<String>, ?port : Null<String>, ?pathname : Null<String>, ?path : Null<String>, ?href : Null<String>, ?hostname : Null<String>, ?host : Null<String>, ?hash : Null<String>, ?auth : Null<String> }
src/js/node/Url.hx:83: characters 91-100 : Warning : This typedef is deprecated in favor of { ?slashes : Null<Bool>, ?search : Null<String>, ?query : Null<haxe.extern.EitherType<String, haxe.DynamicAccess<String>>>, ?protocol : Null<String>, ?port : Null<String>, ?pathname : Null<String>, ?path : Null<String>, ?href : Null<String>, ?hostname : Null<String>, ?host : Null<String>, ?hash : Null<String>, ?auth : Null<String> }
src/js/node/domain/Domain.hx:34: characters 24-35 : Warning : This typedef is deprecated in favor of { domainThrown : Bool, domainEmitter : js.node.events.IEventEmitter, domainBound : haxe.Function, domain : js.node.domain.Domain }
$
```

after:
```
$ haxe build.hxml
$
```

related is https://github.com/HaxeFoundation/hxnodejs/pull/155