### PR TITLE
Add the `File.append()` method.

### DIFF
--- a/src/sys/io/File.hx
+++ b/src/sys/io/File.hx
@@ -5,6 +5,10 @@ import js.node.Fs;
 @:dce
 // @:coreApi
 class File {
+	public static inline function append(path:String, binary:Bool = true):FileOutput {
+		return new FileOutput(Fs.openSync(path, AppendCreate));
+	}
+
 	public static inline function write(path:String, binary:Bool = true):FileOutput {
 		return new FileOutput(Fs.openSync(path, WriteCreate));
 	}


### PR DESCRIPTION
Fixes #120, based on the suggestion by @sebpatu.