### PR TITLE
Handle null as value for `Sys.putEnv()`

### DIFF
--- a/src/Sys.hx
+++ b/src/Sys.hx
@@ -27,8 +27,11 @@ class Sys {
 		return process.env[s];
 	}
 
-	public static inline function putEnv(s:String, v:String):Void {
-		process.env[s] = v;
+	public static inline function putEnv(s:String, v:Null<String>):Void {
+		if (v == null)
+			process.env.remove(s);
+		else
+			process.env[s] = v;
 	}
 
 	public static function environment():Map<String, String> {


### PR DESCRIPTION
Running `Sys.putEnv("VARIABLE", null);` now unsets `VARIABLE` like on other sys targets.

See: https://github.com/HaxeFoundation/haxe/issues/10395