### PR TITLE
Fix `sys.FileSystem.absolutePath`

### DIFF
--- a/src/sys/FileSystem.hx
+++ b/src/sys/FileSystem.hx
@@ -31,6 +31,8 @@ class FileSystem {
 	}
 
 	public static inline function absolutePath(relPath:String):String {
+		if (haxe.io.Path.isAbsolute(relPath))
+			return relPath;
 		return js.node.Path.resolve(relPath);
 	}
 


### PR DESCRIPTION
Previously, on Linux, `absolutePath("C:\\file")` would simply add `C:\file` to the current working directory. This was inconsistent with other Haxe targets. Now, it simply returns `C:\file`.

This is something that needs to be fixed in order for hxnodejs to pass the `sys` api tests in the Haxe compiler repository.