### PR TITLE
Add slash to `Sys.getCwd()` like other sys targets

### DIFF
--- a/src/Sys.hx
+++ b/src/Sys.hx
@@ -1,11 +1,11 @@
 import haxe.io.Bytes;
-import haxe.io.Output;
-import haxe.io.Error;
 import haxe.io.Eof;
+import haxe.io.Error;
+import haxe.io.Output;
+import js.Node.process;
 import js.node.Buffer;
 import js.node.ChildProcess;
 import js.node.Fs;
-import js.Node.process;
 
 @:dce
 @:coreApi
@@ -46,7 +46,7 @@ class Sys {
 	}
 
 	public inline static function getCwd():String {
-		return process.cwd();
+		return haxe.io.Path.addTrailingSlash(process.cwd());
 	}
 
 	public static inline function setCwd(s:String):Void {


### PR DESCRIPTION
In order to make this consistent between targets:
https://github.com/HaxeFoundation/haxe/issues/10459