### PR TITLE
Change deprecated '@:enum abstract' to 'enum abstract' to get rid of …

### DIFF
--- a/src/js/node/ChildProcess.hx
+++ b/src/js/node/ChildProcess.hx
@@ -136,7 +136,7 @@ typedef ChildProcessSpawnOptionsStdio = EitherType<ChildProcessSpawnOptionsStdio
 /**
 	A shorthand for the `stdio` argument in `ChildProcessSpawnOptions`
 **/
-@:enum abstract ChildProcessSpawnOptionsStdioSimple(String) from String to String {
+enum abstract ChildProcessSpawnOptionsStdioSimple(String) from String to String {
 	/**
 		Equivalent to ['ignore', 'ignore', 'ignore']
 	**/
@@ -156,7 +156,7 @@ typedef ChildProcessSpawnOptionsStdio = EitherType<ChildProcessSpawnOptionsStdio
 /**
 	Enumeration of possible `stdio` behaviours.
 **/
-@:enum abstract ChildProcessSpawnOptionsStdioBehaviour(String) from String to String {
+enum abstract ChildProcessSpawnOptionsStdioBehaviour(String) from String to String {
 	/**
 		Create a pipe between the child process and the parent process.
 		The parent end of the pipe is exposed to the parent as a property on the child_process object as ChildProcess.stdio[fd].
@@ -281,8 +281,8 @@ extern class ChildProcessExecError extends Error {
 	and `error.code` will be the exit code of the child process, and `error.signal` will be set
 	to the signal that terminated the process (see `ChildProcessExecError`).
 **/
-typedef ChildProcessExecCallback = #if (haxe_ver >= 4) (error : Null<ChildProcessExecError>, stdout : EitherType<Buffer, String>, stderr : EitherType<Buffer,
-	String>) -> Void; #else Null<ChildProcessExecError>->EitherType<Buffer, String>->EitherType<Buffer, String>->Void; #end
+typedef ChildProcessExecCallback = #if (haxe_ver >= 4) (error:Null<ChildProcessExecError>, stdout:EitherType<Buffer, String>,
+		stderr:EitherType<Buffer, String>) -> Void; #else Null<ChildProcessExecError>->EitherType<Buffer, String>->EitherType<Buffer, String>->Void; #end
 
 /**
 	Object returned from the `spawnSync` method.

--- a/src/js/node/Cluster.hx
+++ b/src/js/node/Cluster.hx
@@ -26,7 +26,7 @@ import haxe.DynamicAccess;
 import js.node.cluster.Worker;
 import js.node.events.EventEmitter;
 
-@:enum abstract ClusterEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
+enum abstract ClusterEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 	/**
 		When a new worker is forked the cluster module will emit a 'fork' event.
 		This can be used to log worker activity, and create your own timeout.
@@ -104,7 +104,7 @@ typedef ListeningEventAddress = {
 	var addressType:ListeningEventAddressType;
 }
 
-@:enum abstract ListeningEventAddressType(haxe.extern.EitherType<Int, String>) to haxe.extern.EitherType<Int, String> {
+enum abstract ListeningEventAddressType(haxe.extern.EitherType<Int, String>) to haxe.extern.EitherType<Int, String> {
 	var TCPv4 = 4;
 	var TCPv6 = 6;
 	var Unix = -1;
@@ -113,7 +113,7 @@ typedef ListeningEventAddress = {
 }
 
 @:jsRequire("cluster")
-@:enum extern abstract ClusterSchedulingPolicy(Int) {
+extern enum abstract ClusterSchedulingPolicy(Int) {
 	var SCHED_NONE;
 	var SCHED_RR;
 }

--- a/src/js/node/Crypto.hx
+++ b/src/js/node/Crypto.hx
@@ -36,7 +36,7 @@ import js.Error;
 /**
 	Enumerations of crypto algorighms to be used.
 **/
-@:enum abstract CryptoAlgorithm(String) from String to String {
+enum abstract CryptoAlgorithm(String) from String to String {
 	var SHA1 = "sha1";
 	var MD5 = "md5";
 	var SHA256 = "sha256";
@@ -46,7 +46,7 @@ import js.Error;
 /**
 	Enumeration of supported group names for `Crypto.getDiffieHellman`.
 **/
-@:enum abstract DiffieHellmanGroupName(String) from String to String {
+enum abstract DiffieHellmanGroupName(String) from String to String {
 	var Modp1 = "modp1";
 	var Modp2 = "modp2";
 	var Modp5 = "modp5";

--- a/src/js/node/Dns.hx
+++ b/src/js/node/Dns.hx
@@ -32,7 +32,7 @@ import js.Error;
 /**
 	Enumeration of possible Int `options` values for `Dns.lookup`.
 **/
-@:enum abstract DnsAddressFamily(Int) from Int to Int {
+enum abstract DnsAddressFamily(Int) from Int to Int {
 	var IPv4 = 4;
 	var IPv6 = 6;
 }
@@ -63,7 +63,7 @@ typedef DnsLookupOptions = {
 /**
 	Enumeration of possible `rrtype` value for `Dns.resolve`.
 **/
-@:enum abstract DnsRrtype(String) from String to String {
+enum abstract DnsRrtype(String) from String to String {
 	/**
 		IPV4 addresses, default
 	**/
@@ -133,7 +133,7 @@ extern class DnsError extends Error {
 	Each DNS query can return one of the following error codes
 **/
 @:jsRequire("dns")
-@:enum extern abstract DnsErrorCode(String) {
+extern enum abstract DnsErrorCode(String) {
 	/**
 		DNS server returned answer with no data.
 	**/
@@ -255,10 +255,12 @@ extern class DnsError extends Error {
 	var CANCELLED;
 }
 
-typedef DnsLookupCallbackSingle = #if (haxe_ver >= 4) (err : DnsError, address : String, family : DnsAddressFamily) -> Void; #else DnsError->String->
-	DnsAddressFamily->Void #end
-typedef DnsLookupCallbackAll = #if (haxe_ver >= 4) (err : DnsError, addresses : Array<DnsLookupCallbackAllEntry>) -> Void; #else DnsError->
-	Array<DnsLookupCallbackAllEntry>->Void; #end
+typedef DnsLookupCallbackSingle = #if (haxe_ver >= 4) (err:DnsError, address:String,
+		family:DnsAddressFamily) -> Void; #else DnsError->String->DnsAddressFamily->Void #end
+
+typedef DnsLookupCallbackAll = #if (haxe_ver >= 4) (err:DnsError,
+		addresses:Array<DnsLookupCallbackAllEntry>) -> Void; #else DnsError->Array<DnsLookupCallbackAllEntry>->Void; #end
+
 typedef DnsLookupCallbackAllEntry = {address:String, family:DnsAddressFamily};
 
 /**

--- a/src/js/node/Fs.hx
+++ b/src/js/node/Fs.hx
@@ -168,7 +168,7 @@ typedef FsCreateWriteStreamOptions = {
 /**
 	Enumeration of possible symlink types
 **/
-@:enum abstract SymlinkType(String) from String to String {
+enum abstract SymlinkType(String) from String to String {
 	var Dir = "dir";
 	var File = "file";
 	var Junction = "junction";
@@ -184,7 +184,7 @@ typedef FsCreateWriteStreamOptions = {
 	On Linux, positional writes don't work when the file is opened in append mode.
 	The kernel ignores the position argument and always appends the data to the end of the file.
 **/
-@:enum abstract FsOpenFlag(String) from String to String {
+enum abstract FsOpenFlag(String) from String to String {
 	/**
 		Open file for reading.
 		An exception occurs if the file does not exist.

--- a/src/js/node/Net.hx
+++ b/src/js/node/Net.hx
@@ -60,7 +60,7 @@ typedef NetConnectOptionsUnix = {
 /**
 	Enumeration of possible values for `Net.isIP` return.
 **/
-@:enum abstract NetIsIPResult(Int) to Int {
+enum abstract NetIsIPResult(Int) to Int {
 	var Invalid = 0;
 	var IPv4 = 4;
 	var IPv6 = 6;

--- a/src/js/node/Os.hx
+++ b/src/js/node/Os.hx
@@ -298,7 +298,7 @@ typedef NetworkInterfaceAddressInfo = {
 	var cidr:Null<String>;
 }
 
-@:enum abstract Endianness(String) to String {
+enum abstract Endianness(String) to String {
 	var BigEndian = "BE";
 	var LittleEndian = "LE";
 }

--- a/src/js/node/Process.hx
+++ b/src/js/node/Process.hx
@@ -38,7 +38,7 @@ import js.Error;
 /**
 	Enumeration of events emitted by the Process class.
 **/
-@:enum abstract ProcessEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
+enum abstract ProcessEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 	/**
 		Emitted when the process is about to exit.
 		There is no way to prevent the exiting of the event loop at this point,

--- a/src/js/node/Readline.hx
+++ b/src/js/node/Readline.hx
@@ -170,7 +170,7 @@ typedef ReadlineCompleterCallback = String->Array<EitherType<Array<String>, Stri
 
 	@see https://nodejs.org/api/readline.html#readline_readline_clearline_stream_dir_callback
 **/
-@:enum abstract ClearLineDirection(Int) from Int to Int {
+enum abstract ClearLineDirection(Int) from Int to Int {
 	/**
 		to the left from cursor.
 	**/

--- a/src/js/node/child_process/ChildProcess.hx
+++ b/src/js/node/child_process/ChildProcess.hx
@@ -35,7 +35,7 @@ import js.Error;
 /**
 	Enumeration of events emitted by `ChildProcess` objects.
 **/
-@:enum abstract ChildProcessEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
+enum abstract ChildProcessEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 	/**
 		Emitted when:
 			1. The process could not be spawned, or

--- a/src/js/node/cluster/Worker.hx
+++ b/src/js/node/cluster/Worker.hx
@@ -31,7 +31,7 @@ import js.lib.Error;
 import js.Error;
 #end
 
-@:enum abstract WorkerEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
+enum abstract WorkerEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 	var Message:WorkerEvent<Dynamic->Dynamic->Void> = "message";
 	var Online:WorkerEvent<Void->Void> = "online";
 	var Listening:WorkerEvent<ListeningEventAddress->Void> = "listening";

--- a/src/js/node/crypto/ECDH.hx
+++ b/src/js/node/crypto/ECDH.hx
@@ -25,7 +25,7 @@ package js.node.crypto;
 import haxe.extern.EitherType;
 import js.node.Buffer;
 
-@:enum abstract ECDHFormat(String) from String to String {
+enum abstract ECDHFormat(String) from String to String {
 	var Compressed = "compressed";
 	var Uncompressed = "uncompressed";
 	var Hybrid = "hybrid";

--- a/src/js/node/dgram/Socket.hx
+++ b/src/js/node/dgram/Socket.hx
@@ -33,7 +33,7 @@ import js.Error;
 /**
 	Enumeration of events for the `Socket` object.
 **/
-@:enum abstract SocketEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
+enum abstract SocketEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 	/**
 		Emitted when a new datagram is available on a socket.
 		Listener arguments:
@@ -77,7 +77,7 @@ typedef MessageListener = Buffer->MessageRemoteInfo->Void;
 /**
 	Enumeration of possible datagram socket types
 **/
-@:enum abstract SocketType(String) from String to String {
+enum abstract SocketType(String) from String to String {
 	var Udp4 = "udp4";
 	var Udp6 = "udp6";
 }

--- a/src/js/node/domain/Domain.hx
+++ b/src/js/node/domain/Domain.hx
@@ -30,7 +30,7 @@ import js.node.events.EventEmitter;
 	Enumeration of events emitted by `Domain` objects.
 **/
 @:deprecated
-@:enum abstract DomainEvent<T:Function>(Event<T>) to Event<T> {
+enum abstract DomainEvent<T:Function>(Event<T>) to Event<T> {
 	var Error:DomainEvent<DomainError->Void> = "error";
 	var Dispose:DomainEvent<Void->Void> = "dispose";
 }

--- a/src/js/node/events/EventEmitter.hx
+++ b/src/js/node/events/EventEmitter.hx
@@ -32,7 +32,7 @@ import js.lib.Symbol;
 /**
 	Enumeration of events emitted by all `EventEmitter` instances.
 **/
-@:enum abstract EventEmitterEvent<T:Function>(Event<T>) to Event<T> {
+enum abstract EventEmitterEvent<T:Function>(Event<T>) to Event<T> {
 	/**
 		The `EventEmitter` instance will emit its own `'newListener'` event before
 		a listener is added to its internal array of listeners.

--- a/src/js/node/fs/FSWatcher.hx
+++ b/src/js/node/fs/FSWatcher.hx
@@ -33,7 +33,7 @@ import js.Error;
 /**
 	Enumeration of possible types of changes for 'change' event.
 **/
-@:enum abstract FSWatcherChangeType(String) from String to String {
+enum abstract FSWatcherChangeType(String) from String to String {
 	var Change = "change";
 	var Rename = "rename";
 }
@@ -41,7 +41,7 @@ import js.Error;
 /**
 	Enumeration of the events emitted by `FSWatcher`.
 **/
-@:enum abstract FSWatcherEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
+enum abstract FSWatcherEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 	/**
 		Emitted when something changes in a watched directory or file. See more details in `Fs.watch`.
 

--- a/src/js/node/fs/ReadStream.hx
+++ b/src/js/node/fs/ReadStream.hx
@@ -25,7 +25,7 @@ package js.node.fs;
 import js.node.Fs.FsPath;
 import js.node.events.EventEmitter.Event;
 
-@:enum abstract ReadStreamEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
+enum abstract ReadStreamEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 	/**
 		Emitted when the `ReadStream`'s file is opened.
 

--- a/src/js/node/fs/WriteStream.hx
+++ b/src/js/node/fs/WriteStream.hx
@@ -25,7 +25,7 @@ package js.node.fs;
 import js.node.Fs.FsPath;
 import js.node.events.EventEmitter.Event;
 
-@:enum abstract WriteStreamEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
+enum abstract WriteStreamEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 	/**
 		Emitted when the `WriteStream`'s file is opened.
 

--- a/src/js/node/http/ClientRequest.hx
+++ b/src/js/node/http/ClientRequest.hx
@@ -31,7 +31,7 @@ import js.node.stream.Writable;
 /**
 	Enumeration of events emitted by `ClientRequest`
 **/
-@:enum abstract ClientRequestEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
+enum abstract ClientRequestEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 	/**
 		Emitted when the request has been aborted by the client.
 		This event is only emitted on the first call to `abort()`.

--- a/src/js/node/http/IncomingMessage.hx
+++ b/src/js/node/http/IncomingMessage.hx
@@ -35,7 +35,7 @@ import js.Error;
 /**
 	Enumeration of events emitted by the `IncomingMessage` objects in addition to its parent class events.
 **/
-@:enum abstract IncomingMessageeEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
+enum abstract IncomingMessageeEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 	/**
 		Emitted when the request has been aborted.
 	**/

--- a/src/js/node/http/Method.hx
+++ b/src/js/node/http/Method.hx
@@ -26,7 +26,7 @@ package js.node.http;
 	Enumeration of possible HTTP methods as described in
 	http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html
 **/
-@:enum abstract Method(String) from String to String {
+enum abstract Method(String) from String to String {
 	var Acl = "ACL";
 	var Bind = "BIND";
 	var Checkout = "CHECKOUT";

--- a/src/js/node/http/Server.hx
+++ b/src/js/node/http/Server.hx
@@ -35,7 +35,7 @@ import js.Error;
 	Enumeration of events emitted by `http.Server` class in addition to
 	its parent `net.Server` class.
 **/
-@:enum abstract ServerEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
+enum abstract ServerEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 	/**
 		Emitted each time a request with an HTTP Expect: `100-continue` is received.
 		If this event is not listened for, the server will automatically respond with a `100 Continue` as appropriate.

--- a/src/js/node/http/ServerResponse.hx
+++ b/src/js/node/http/ServerResponse.hx
@@ -30,7 +30,7 @@ import js.node.stream.Writable;
 /**
 	Enumeration of events emitted by the `ServerResponse` objects in addition to its parent class events.
 **/
-@:enum abstract ServerResponseEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
+enum abstract ServerResponseEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 	/**
 		Indicates that the underlying connection was terminated.
 	**/

--- a/src/js/node/net/Server.hx
+++ b/src/js/node/net/Server.hx
@@ -34,7 +34,7 @@ import js.Error;
 /**
 	Enumeration of events emitted by the `Server` objects
 **/
-@:enum abstract ServerEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
+enum abstract ServerEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 	/**
 		Emitted when the server has been bound after calling `Server.listen`.
 	**/

--- a/src/js/node/net/Socket.hx
+++ b/src/js/node/net/Socket.hx
@@ -34,7 +34,7 @@ import js.Error;
 /**
 	Enumeration of events for `Socket` objects.
 **/
-@:enum abstract SocketEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
+enum abstract SocketEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 	/**
 		Emitted after resolving the hostname but before connecting.
 		Not applicable to UNIX sockets.
@@ -198,7 +198,7 @@ typedef SocketAdress = {
 /**
 	Enumeration of possible socket family values.
 **/
-@:enum abstract SocketAdressFamily(String) to String {
+enum abstract SocketAdressFamily(String) to String {
 	var IPv4 = "IPv4";
 	var IPv6 = "IPv6";
 }

--- a/src/js/node/readline/Interface.hx
+++ b/src/js/node/readline/Interface.hx
@@ -28,7 +28,7 @@ import js.node.events.EventEmitter;
 /**
 	Enumeration of events emitted by the `Interface` objects.
 **/
-@:enum abstract InterfaceEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
+enum abstract InterfaceEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 	/**
 		The `'close'` event is emitted when one of the following occur:
 

--- a/src/js/node/repl/REPLServer.hx
+++ b/src/js/node/repl/REPLServer.hx
@@ -33,7 +33,7 @@ import js.Error;
 /**
 	Enumeration of events emitted by the `REPLServer` objects.
 **/
-@:enum abstract REPLServerEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
+enum abstract REPLServerEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 	/**
 		The `'exit'` event is emitted when the REPL is exited either by receiving the `.exit` command as input,
 		the user pressing `<ctrl>-C` twice to signal `SIGINT`, or by pressing `<ctrl>-D` to signal 'end' on the input stream.

--- a/src/js/node/stream/Duplex.hx
+++ b/src/js/node/stream/Duplex.hx
@@ -37,7 +37,7 @@ import js.Error;
 
 	@see https://nodejs.org/api/stream.html#stream_writable_streams
 **/
-@:enum abstract DuplexEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
+enum abstract DuplexEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 	// Writable stream events -------------------------------------------------
 	// var Close:DuplexEvent<Void->Void> = "close";
 

--- a/src/js/node/stream/Readable.hx
+++ b/src/js/node/stream/Readable.hx
@@ -37,7 +37,7 @@ import js.Error;
 
 	@see https://nodejs.org/api/stream.html#stream_readable_streams
 **/
-@:enum abstract ReadableEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
+enum abstract ReadableEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 	/**
 		The `'close'` event is emitted when the stream and any of its underlying
 		resources (a file descriptor, for example) have been closed.

--- a/src/js/node/stream/Writable.hx
+++ b/src/js/node/stream/Writable.hx
@@ -40,7 +40,7 @@ import js.html.Uint8Array;
 
 	@see https://nodejs.org/api/stream.html#stream_writable_streams
 **/
-@:enum abstract WritableEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
+enum abstract WritableEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 	/**
 		The `'close'` event is emitted when the stream and any of its underlying resources
 		(a file descriptor, for example) have been closed.

--- a/src/js/node/tls/SecurePair.hx
+++ b/src/js/node/tls/SecurePair.hx
@@ -27,7 +27,7 @@ import js.node.events.EventEmitter;
 /**
 	Events emitted by `SecurePair`.
 **/
-@:enum abstract SecurePairEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
+enum abstract SecurePairEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 	/**
 		The event is emitted from the `SecurePair` once the pair has successfully established a secure connection.
 

--- a/src/js/node/tls/Server.hx
+++ b/src/js/node/tls/Server.hx
@@ -35,7 +35,7 @@ import js.Error;
 /**
 	Enumeration of events emitted by `Server` in addition to its parent classes.
 **/
-@:enum abstract ServerEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
+enum abstract ServerEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 	/**
 		This event is emitted after a new connection has been successfully handshaked.
 	**/

--- a/src/js/node/tls/TLSSocket.hx
+++ b/src/js/node/tls/TLSSocket.hx
@@ -36,7 +36,7 @@ import js.Error;
 /**
 	Enumeration of events emitted by `TLSSocket` objects in addition to its parent class events.
 **/
-@:enum abstract TLSSocketEvent<T:Function>(Event<T>) to Event<T> {
+enum abstract TLSSocketEvent<T:Function>(Event<T>) to Event<T> {
 	/**
 		This event is emitted after a new connection has been successfully handshaked.
 

--- a/src/js/node/tty/WriteStream.hx
+++ b/src/js/node/tty/WriteStream.hx
@@ -27,7 +27,7 @@ import js.node.events.EventEmitter;
 /**
 	Enumeration of events emitted by `WriteStream` objects in addition to its parents.
 **/
-@:enum abstract WriteStreamEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
+enum abstract WriteStreamEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 	/**
 		Emitted by refreshSize() when either of the columns or rows properties has changed.
 	**/


### PR DESCRIPTION
Fixes issue #189