### PR TITLE
Add new methods and classes to the `util` module

### DIFF
--- a/src/js/node/Util.hx
+++ b/src/js/node/Util.hx
@@ -399,7 +399,7 @@ typedef StyleTextOptions = {
 
 		Default: `process.stdout`.
 	**/
-	@:optional var stream:Stream<Stream>;
+	@:optional var stream:Stream<Dynamic>;
 
 	/**
 		Value indicating whether `stream` is checked to see if it can handle colors.

--- a/src/js/node/Util.hx
+++ b/src/js/node/Util.hx
@@ -23,8 +23,11 @@
 package js.node;
 
 import haxe.Constraints.Function;
+import haxe.DynamicAccess;
 import haxe.extern.EitherType;
 import haxe.extern.Rest;
+import js.lib.Map;
+import js.node.Stream;
 import js.node.stream.Readable;
 import js.node.stream.Writable;
 #if haxe4
@@ -90,6 +93,13 @@ extern class Util {
 		@see https://nodejs.org/api/util.html#util_util_getsystemerrorname_err
 	**/
 	static function getSystemErrorName(err:Int):String;
+
+	/**
+		Returns a map of all system error codes available from the Node.js API.
+
+		@see https://nodejs.org/api/util.html#utilgetsystemerrormap
+	**/
+	static function getSystemErrorMap():Map<Int, String>;
 
 	/**
 		Inherit the prototype methods from one `constructor` into another.
@@ -231,6 +241,13 @@ extern class Util {
 	static function log(args:Rest<Dynamic>):Void;
 
 	/**
+		Parses the raw contents of an `.env` file.
+
+		@see https://nodejs.org/api/util.html#utilparseenvcontent
+	**/
+	static function parseEnv(content:String):DynamicAccess<String>;
+
+	/**
 		Deprecated predecessor of console.log.
 	**/
 	@:deprecated("Use js.Node.console.log instead")
@@ -247,6 +264,28 @@ extern class Util {
 	**/
 	@:deprecated("Use `readableStream.pipe(writableStream)` instead")
 	static function pump(readableStream:IReadable, writableStream:IWritable, ?callback:Error->Void):Void;
+
+	/**
+		Removes any ANSI escape codes from the specified string.
+
+		@see https://nodejs.org/api/util.html#utilstripvtcontrolcharactersstr
+	**/
+	static function stripVTControlCharacters(str:String):String;
+
+	/**
+		Returns a formatted text considering the `format` passed for printing in a terminal.
+
+		@see https://nodejs.org/api/util.html#utilstyletextformat-text-options
+	**/
+	static function styleText(format:EitherType<String, Array<String>>, text:String, ?options:StyleTextOptions):String;
+
+	/**
+		Returns the `string` after replacing any surrogate code points (or equivalently, any unpaired surrogate code units)
+		with the Unicode "replacement character" U+FFFD.
+
+		@see https://nodejs.org/api/util.html#utiltousvstringstring
+	**/
+	static function toUSVString(string:String):String;
 }
 
 /**
@@ -349,4 +388,23 @@ typedef InspectOptions = {
 		Default: `false`.
 	**/
 	@:optional var getters:EitherType<Bool, String>;
+}
+
+/**
+	Options object used by `Util.styleText`.
+**/
+typedef StyleTextOptions = {
+	/**
+		A stream that will be validated if it can be colored.
+
+		Default: `process.stdout`.
+	**/
+	@:optional var stream:Stream<Stream>;
+
+	/**
+		Value indicating whether `stream` is checked to see if it can handle colors.
+
+		Default: `true`.
+	**/
+	@:optional var validateStream:Bool;
 }

--- a/src/js/node/util/MIMEParams.hx
+++ b/src/js/node/util/MIMEParams.hx
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.util;
+
+import js.lib.Iterator;
+import js.lib.KeyValue;
+
+/**
+	The `MIMEParams` API provides read and write access to the parameters of a `MIMEType`.
+
+	@see https://nodejs.org/api/util.html#class-utilmimeparams
+**/
+@:jsRequire("util", "MIMEParams")
+extern class MIMEParams {
+	/**
+		Creates a new `MIMEParams` object with empty parameters.
+	**/
+	function new();
+
+	/**
+		Remove all name-value pairs whose name is `name`.
+	**/
+	function delete(name:String):Void;
+
+	/**
+		Returns an iterator over each of the name-value pairs in the parameters.
+	**/
+	function entries():Iterator<KeyValue<String, String>>;
+
+	/**
+		Returns the value of the first name-value pair whose name is `name`. If there are no such pairs, `null` is returned.
+	**/
+	function get(name:String):Null<String>;
+
+	/**
+		Returns a value indicating whether there is at least one name-value pair whose name is `name`.
+	**/
+	function has(name:String):Bool;
+
+	/**
+		Returns an iterator over the names of each name-value pair.
+	**/
+	function keys():Iterator<String>;
+
+	/**
+		Sets the value in the `MIMEParams` object associated with `name` to `value`.
+		If there are any pre-existing name-value pairs whose names are `name`, set the first such pair's value to `value`.
+	**/
+	function set(name:String, value:String):Void;
+
+	/**
+		Returns an iterator over the values of each name-value pair.
+	**/
+	function values():Iterator<String>;
+}

--- a/src/js/node/util/MIMEType.hx
+++ b/src/js/node/util/MIMEType.hx
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.util;
+
+import haxe.extern.EitherType;
+
+/**
+	An implementation of [the MIMEType class](https://bmeck.github.io/node-proposal-mime-api/).
+
+	@see https://nodejs.org/api/util.html#class-utilmimetype
+**/
+@:jsRequire("util", "MIMEType")
+extern class MIMEType {
+	/**
+		Gets the essence of the MIME.
+	**/
+	final essence:String;
+
+	/**
+		Gets the `MIMEParams` object representing the parameters of the MIME.
+	**/
+	final params:MIMEParams;
+
+	/**
+		Gets and sets the subtype portion of the MIME.
+	**/
+	var subtype:String;
+
+	/**
+		Gets and sets the type portion of the MIME.
+	**/
+	var type:String;
+
+	/**
+		Creates a new `MIMEType` object by parsing the `input`.
+	**/
+	function new(input:EitherType<String, {toString:() -> String}>);
+
+	/**
+		Alias for `toString()`.
+	**/
+	function toJSON():String;
+
+	/**
+		Returns the serialized MIME.
+	**/
+	function toString():String;
+}


### PR DESCRIPTION
This PR adds some missing items to the `util` module:
- the `getSystemErrorMap()`, `parseEnv()`, `stripVTControlCharacters()`, `styleText()` and `toUSVString()` methods
- the `MIMEParams` and `MIMEType` classes