### PR TITLE
Fix file system bugs

### DIFF
--- a/src/sys/FileSystem.hx
+++ b/src/sys/FileSystem.hx
@@ -63,17 +63,15 @@ class FileSystem {
 	}
 
 	public static inline function deleteDirectory(path:String):Void {
-		if (exists(path)) {
-			for (file in readDirectory(path)) {
-				var curPath = path + "/" + file;
-				if (isDirectory(curPath)) {
-					deleteDirectory(curPath);
-				} else {
-					deleteFile(curPath);
-				}
+		for (file in readDirectory(path)) {
+			var curPath = path + "/" + file;
+			if (isDirectory(curPath)) {
+				deleteDirectory(curPath);
+			} else {
+				deleteFile(curPath);
 			}
-			js.node.Fs.rmdirSync(path);
 		}
+		js.node.Fs.rmdirSync(path);
 	}
 
 	public static inline function readDirectory(path:String):Array<String> {

--- a/src/sys/io/File.hx
+++ b/src/sys/io/File.hx
@@ -34,6 +34,9 @@ class File {
 	}
 
 	public static inline function update(path:String, binary:Bool = true):FileOutput {
+		if (!FileSystem.exists(path)) {
+			write(path).close();
+		}
 		return new FileOutput(Fs.openSync(path, ReadWrite));
 	}
 

--- a/src/sys/io/File.hx
+++ b/src/sys/io/File.hx
@@ -6,7 +6,7 @@ import js.node.Fs;
 // @:coreApi
 class File {
 	public static inline function append(path:String, binary:Bool = true):FileOutput {
-		return new FileOutput(Fs.openSync(path, AppendCreate));
+		return new FileOutput(Fs.openSync(path, AppendCreate), true);
 	}
 
 	public static inline function write(path:String, binary:Bool = true):FileOutput {

--- a/src/sys/io/FileOutput.hx
+++ b/src/sys/io/FileOutput.hx
@@ -10,23 +10,25 @@ import js.node.Fs;
 class FileOutput extends haxe.io.Output {
 	var fd:Int;
 	var pos:Int;
+	var isAppend:Bool;
 
 	@:allow(sys.io.File)
-	function new(fd:Int) {
+	function new(fd:Int, isAppend:Bool = false) {
 		this.fd = fd;
 		pos = 0;
+		this.isAppend = isAppend;
 	}
 
 	override public function writeByte(b:Int):Void {
 		var buf = Buffer.alloc(1);
 		buf[0] = b;
-		Fs.writeSync(fd, buf, 0, 1, pos);
+		Fs.writeSync(fd, buf, 0, 1, isAppend ? null : pos);
 		pos++;
 	}
 
 	override public function writeBytes(s:Bytes, pos:Int, len:Int):Int {
 		var buf = Buffer.hxFromBytes(s);
-		var wrote = Fs.writeSync(fd, buf, pos, len, this.pos);
+		var wrote = Fs.writeSync(fd, buf, pos, len, isAppend ? null : this.pos);
 		this.pos += wrote;
 		return wrote;
 	}


### PR DESCRIPTION
- Fix File.append on macos
Closes https://github.com/HaxeFoundation/haxe/issues/12573
According to the posix standard, when using pwrite (in our case, passing this.pos to writeSync), the O_APPEND flag is ignored.
[Linux doesn't comply](https://man7.org/linux/man-pages/man2/pread.2.html#BUGS) with this, but Mac does, so we have to make the code compatible by passing null as the position which means write will be used instead of pwrite.
See:
https://pubs.opengroup.org/onlinepubs/9799919799/functions/pwrite.html
> The pwrite() function shall be equivalent to write(), except that it writes into a given position and does not change the file offset (regardless of whether O_APPEND is set)
- ~~Revert #85, because haxe specifies that `deleteDirectory` only works on empty directories. It also didn't throw if the folder didn't exist.
See: https://api.haxe.org/sys/FileSystem.html#deleteDirectory~~
See: https://github.com/HaxeFoundation/haxe/issues/5585
- Make deleteDirectory fail if a directory doesn't exist, see: https://github.com/HaxeFoundation/haxe/issues/5742

- Create file in File.update if it doesn't exist
This is specified by haxe and other targets also do this.