### PR TITLE
Add zlib Brotli compress/decompress APIs

### DIFF
--- a/src/js/node/Zlib.hx
+++ b/src/js/node/Zlib.hx
@@ -92,8 +92,15 @@ typedef BrotliOptions = {
 
 	/**
 		The maximum length of the output that can be produced by zlib streams.
+		Default: `buffer.kMaxLength`
 	**/
 	@:optional var maxOutputLength:Int;
+
+	/**
+		If `true`, returns an object with `buffer` and `engine`.
+		Default: `false`
+	**/
+	@:optional var info:Bool;
 }
 
 /**

--- a/src/js/node/Zlib.hx
+++ b/src/js/node/Zlib.hx
@@ -22,6 +22,7 @@
 
 package js.node;
 
+import haxe.DynamicAccess;
 import haxe.extern.EitherType;
 import js.node.Buffer;
 import js.node.zlib.*;
@@ -66,8 +67,39 @@ typedef ZlibOptions = {
 }
 
 /**
-	This provides bindings to Gzip/Gunzip, Deflate/Inflate, and DeflateRaw/InflateRaw classes.
-	Each class takes the same options, and is a readable/writable Stream.
+	Options for Brotli compression and decompression.
+**/
+typedef BrotliOptions = {
+	/**
+		default: `zlib.constants.BROTLI_OPERATION_PROCESS`
+	**/
+	@:optional var flush:Int;
+
+	/**
+		default: `zlib.constants.BROTLI_OPERATION_FINISH`
+	**/
+	@:optional var finishFlush:Int;
+
+	/**
+		default: 16*1024
+	**/
+	@:optional var chunkSize:Int;
+
+	/**
+		Key-value object containing indexed Brotli parameters.
+	**/
+	@:optional var params:DynamicAccess<Int>;
+
+	/**
+		The maximum length of the output that can be produced by zlib streams.
+	**/
+	@:optional var maxOutputLength:Int;
+}
+
+/**
+	This provides bindings to Gzip/Gunzip, Deflate/Inflate, DeflateRaw/InflateRaw,
+	and BrotliCompress/BrotliDecompress classes.
+	Each class takes options, and is a readable/writable Stream.
 **/
 @:jsRequire("zlib")
 extern class Zlib {
@@ -172,6 +204,22 @@ extern class Zlib {
 	static function createUnzip(?options:ZlibOptions):Unzip;
 
 	/**
+		Returns a new `BrotliCompress` object with an `options`.
+	**/
+	static function createBrotliCompress(?options:BrotliOptions):BrotliCompress;
+
+	/**
+		Returns a new `BrotliDecompress` object with an `options`.
+	**/
+	static function createBrotliDecompress(?options:BrotliOptions):BrotliDecompress;
+
+	/**
+		Computes a 32-bit Cyclic Redundancy Check checksum of `data`.
+		If `value` is given, it is used as the starting value of the checksum.
+	**/
+	static function crc32(data:EitherType<String, Buffer>, ?value:Int):Int;
+
+	/**
 		Compress a string with `Deflate`.
 	**/
 	@:overload(function(buf:EitherType<String, Buffer>, options:ZlibOptions, callback:Error->Buffer->Void):Void {})
@@ -247,4 +295,26 @@ extern class Zlib {
 		Decompress a raw Buffer with `Unzip` (synchronous version).
 	**/
 	static function unzipSync(buf:EitherType<String, Buffer>, ?options:ZlibOptions):Buffer;
+
+	/**
+		Compress a string with `BrotliCompress`.
+	**/
+	@:overload(function(buf:EitherType<String, Buffer>, options:BrotliOptions, callback:Error->Buffer->Void):Void {})
+	static function brotliCompress(buf:EitherType<String, Buffer>, callback:Error->Buffer->Void):Void;
+
+	/**
+		Compress a string with `BrotliCompress` (synchronous version).
+	**/
+	static function brotliCompressSync(buf:EitherType<String, Buffer>, ?options:BrotliOptions):Buffer;
+
+	/**
+		Decompress a Buffer with `BrotliDecompress`.
+	**/
+	@:overload(function(buf:EitherType<String, Buffer>, options:BrotliOptions, callback:Error->Buffer->Void):Void {})
+	static function brotliDecompress(buf:EitherType<String, Buffer>, callback:Error->Buffer->Void):Void;
+
+	/**
+		Decompress a Buffer with `BrotliDecompress` (synchronous version).
+	**/
+	static function brotliDecompressSync(buf:EitherType<String, Buffer>, ?options:BrotliOptions):Buffer;
 }

--- a/src/js/node/zlib/BrotliCompress.hx
+++ b/src/js/node/zlib/BrotliCompress.hx
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.zlib;
+
+/**
+	Compress data using the Brotli algorithm.
+**/
+@:jsRequire("zlib", "BrotliCompress")
+extern class BrotliCompress extends Zlib {}

--- a/src/js/node/zlib/BrotliDecompress.hx
+++ b/src/js/node/zlib/BrotliDecompress.hx
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.zlib;
+
+/**
+	Decompress a Brotli stream.
+**/
+@:jsRequire("zlib", "BrotliDecompress")
+extern class BrotliDecompress extends Zlib {}


### PR DESCRIPTION
## Summary
- Add `BrotliCompress` / `BrotliDecompress` externs mirroring Gzip/Gunzip
- Extend `js.node.Zlib` with `BrotliOptions`, create helpers, and brotli compress/decompress (sync + async)
- Add `crc32` binding

## Test plan
- [x] `haxe -cp src -D nodejs js.node.Zlib js.node.zlib.BrotliCompress js.node.zlib.BrotliDecompress --no-output`
- [ ] Spot-check against Node.js zlib docs for option field names


Made with [Cursor](https://cursor.com)