### PR TITLE
Add stream.finished/helpers and events utilities

### DIFF
--- a/src/js/node/Events.hx
+++ b/src/js/node/Events.hx
@@ -91,10 +91,17 @@ extern class Events {
 	static function setMaxListeners(n:Int, emitters:Rest<IEventEmitter>):Void;
 
 	/**
-		A class method that returns the number of listeners for the given `eventName`
-		registered on the given `emitter`.
+		Returns the currently set max amount of listeners for the given emitter.
 
-		@see https://nodejs.org/api/events.html#eventsemitterlistenercountemitter-eventname
+		@see https://nodejs.org/api/events.html#eventsgetmaxlistenersemitterortarget
+	**/
+	static function getMaxListeners(emitter:IEventEmitter):Int;
+
+	/**
+		Returns the number of listeners for the given `eventName` registered on the
+		given `emitter`.
+
+		@see https://nodejs.org/api/events.html#eventslistenercountemitterortarget-eventname
 	**/
 	static function listenerCount(emitter:IEventEmitter, eventName:Event<Function>):Int;
 }

--- a/src/js/node/Events.hx
+++ b/src/js/node/Events.hx
@@ -23,9 +23,11 @@
 package js.node;
 
 import haxe.Constraints.Function;
+import haxe.extern.Rest;
 import js.node.events.EventEmitter;
 #if haxe4
 import js.lib.Promise;
+import js.lib.Symbol;
 #else
 import js.Promise;
 #end
@@ -40,6 +42,30 @@ import js.Promise;
 @:jsRequire("events")
 extern class Events {
 	/**
+		This symbol shall be used to install a listener for only monitoring `'error'`
+		events. Listeners installed using this symbol are called before the regular
+		`'error'` listeners are called.
+
+		@see https://nodejs.org/api/events.html#eventserrormonitor
+	**/
+	#if haxe4
+	static final errorMonitor:Symbol;
+	#else
+	static var errorMonitor(default, never):Dynamic;
+	#end
+
+	/**
+		Value: `Symbol.for('nodejs.rejection')`
+
+		@see https://nodejs.org/api/events.html#eventscapturerejectionsymbol
+	**/
+	#if haxe4
+	static final captureRejectionSymbol:Symbol;
+	#else
+	static var captureRejectionSymbol(default, never):Dynamic;
+	#end
+
+	/**
 		Creates a `Promise` that is resolved when the `EventEmitter` emits the given
 		event or that is rejected when the `EventEmitter` emits `'error'`.
 		The `Promise` will resolve with an array of all the arguments emitted to the
@@ -48,4 +74,27 @@ extern class Events {
 		@see https://nodejs.org/api/events.html#events_events_once_emitter_name
 	**/
 	static function once<T:Function>(emitter:IEventEmitter, name:Event<T>):Promise<Array<Dynamic>>;
+
+	/**
+		Returns a copy of the array of listeners for the event named `name`.
+
+		@see https://nodejs.org/api/events.html#eventsgeteventlistenersemitter-name
+	**/
+	static function getEventListeners(emitter:IEventEmitter, name:Event<Function>):Array<Function>;
+
+	/**
+		Change the default `maxListeners` value for all `EventEmitter` instances,
+		and optionally apply that change to the given emitters.
+
+		@see https://nodejs.org/api/events.html#eventssetmaxlistenersn-eventtargets
+	**/
+	static function setMaxListeners(n:Int, emitters:Rest<IEventEmitter>):Void;
+
+	/**
+		A class method that returns the number of listeners for the given `eventName`
+		registered on the given `emitter`.
+
+		@see https://nodejs.org/api/events.html#eventsemitterlistenercountemitter-eventname
+	**/
+	static function listenerCount(emitter:IEventEmitter, eventName:Event<Function>):Int;
 }

--- a/src/js/node/Stream.hx
+++ b/src/js/node/Stream.hx
@@ -62,6 +62,70 @@ extern class Stream<TSelf:Stream<TSelf>> extends EventEmitter<TSelf> implements 
 	@:overload(function(readable:IReadable, writable1:IWritable, writable2:IWritable, writable3:IWritable, writable4:IWritable, writable5:IWritable,
 		writable6:IWritable, writable7:IWritable, writable8:IWritable, callback:Null<Error>->Void):Void {})
 	static function pipeline(readable:IReadable, streams:Rest<IWritable>):Promise<Void>;
+
+	/**
+		A module method to wait for a readable or writable stream to finish.
+
+		@see https://nodejs.org/api/stream.html#streamfinishedstream-options-callback
+	**/
+	@:overload(function(stream:IStream, callback:Null<Error>->Void):Void {})
+	@:overload(function(stream:IStream, options:StreamFinishedOptions, callback:Null<Error>->Void):Void {})
+	static function finished(stream:IStream, ?options:StreamFinishedOptions):Promise<Void>;
+
+	/**
+		Returns whether the stream is readable.
+
+		@see https://nodejs.org/api/stream.html#streamisreadablestream
+	**/
+	static function isReadable(stream:Dynamic):Bool;
+
+	/**
+		Returns whether the stream is writable.
+
+		@see https://nodejs.org/api/stream.html#streamiswritablestream
+	**/
+	static function isWritable(stream:Dynamic):Bool;
+
+	/**
+		Returns whether the stream has been destroyed.
+
+		@see https://nodejs.org/api/stream.html#streamisdestroyedstream
+	**/
+	static function isDestroyed(stream:Dynamic):Bool;
+
+	/**
+		Returns whether the stream has been read from or written to.
+
+		@see https://nodejs.org/api/stream.html#streamisdisturbedstream
+	**/
+	static function isDisturbed(stream:Dynamic):Bool;
+
+	/**
+		Returns whether the stream has encountered an error.
+
+		@see https://nodejs.org/api/stream.html#streamiserroredstream
+	**/
+	static function isErrored(stream:Dynamic):Bool;
+}
+
+/**
+	Options for `Stream.finished`.
+**/
+typedef StreamFinishedOptions = {
+	/**
+		If `true`, emit `'error'` as an `'error'` event instead of rejecting the Promise / calling the callback.
+	**/
+	@:optional var error:Bool;
+
+	/**
+		Makes `finished()` wait until the stream ends before calling the callback / resolving the Promise if the stream is readable.
+	**/
+	@:optional var readable:Bool;
+
+	/**
+		Makes `finished()` wait until the stream ends before calling the callback / resolving the Promise if the stream is writable.
+	**/
+	@:optional var writable:Bool;
 }
 
 /**

--- a/src/js/node/Stream.hx
+++ b/src/js/node/Stream.hx
@@ -23,6 +23,7 @@
 package js.node;
 
 import haxe.extern.Rest;
+import js.html.AbortSignal;
 import js.node.events.EventEmitter;
 import js.node.stream.Readable.IReadable;
 import js.node.stream.Writable.IWritable;
@@ -66,37 +67,45 @@ extern class Stream<TSelf:Stream<TSelf>> extends EventEmitter<TSelf> implements 
 	/**
 		A module method to wait for a readable or writable stream to finish.
 
+		The callback form returns a cleanup function that removes registered listeners.
+
 		@see https://nodejs.org/api/stream.html#streamfinishedstream-options-callback
 	**/
-	@:overload(function(stream:IStream, callback:Null<Error>->Void):Void {})
-	@:overload(function(stream:IStream, options:StreamFinishedOptions, callback:Null<Error>->Void):Void {})
+	@:overload(function(stream:IStream, callback:Null<Error>->Void):Void->Void {})
+	@:overload(function(stream:IStream, options:StreamFinishedOptions, callback:Null<Error>->Void):Void->Void {})
 	static function finished(stream:IStream, ?options:StreamFinishedOptions):Promise<Void>;
 
 	/**
 		Returns whether the stream is readable.
 
+		Returns `null` if `stream` is not a valid readable stream.
+
 		@see https://nodejs.org/api/stream.html#streamisreadablestream
 	**/
-	static function isReadable(stream:Dynamic):Bool;
+	static function isReadable(stream:Dynamic):Null<Bool>;
 
 	/**
 		Returns whether the stream is writable.
 
+		Returns `null` if `stream` is not a valid writable stream.
+
 		@see https://nodejs.org/api/stream.html#streamiswritablestream
 	**/
-	static function isWritable(stream:Dynamic):Bool;
+	static function isWritable(stream:Dynamic):Null<Bool>;
 
 	/**
 		Returns whether the stream has been destroyed.
 
-		@see https://nodejs.org/api/stream.html#streamisdestroyedstream
+		Exported by the `stream` module (undocumented helper; available since Node 16+).
 	**/
 	static function isDestroyed(stream:Dynamic):Bool;
 
 	/**
-		Returns whether the stream has been read from or written to.
+		Returns whether the stream has been read from or cancelled.
 
-		@see https://nodejs.org/api/stream.html#streamisdisturbedstream
+		Also available as `Readable.isDisturbed`.
+
+		@see https://nodejs.org/api/stream.html#streamreadableisdisturbedstream
 	**/
 	static function isDisturbed(stream:Dynamic):Bool;
 
@@ -113,19 +122,36 @@ extern class Stream<TSelf:Stream<TSelf>> extends EventEmitter<TSelf> implements 
 **/
 typedef StreamFinishedOptions = {
 	/**
-		If `true`, emit `'error'` as an `'error'` event instead of rejecting the Promise / calling the callback.
+		If set to `false`, then a call to `emit('error', err)` is not treated as finished.
+		Default: `true`.
 	**/
 	@:optional var error:Bool;
 
 	/**
-		Makes `finished()` wait until the stream ends before calling the callback / resolving the Promise if the stream is readable.
+		When set to `false`, the callback / Promise will resolve when the stream ends
+		even though the stream might still be readable.
+		Default: `true`.
 	**/
 	@:optional var readable:Bool;
 
 	/**
-		Makes `finished()` wait until the stream ends before calling the callback / resolving the Promise if the stream is writable.
+		When set to `false`, the callback / Promise will resolve when the stream ends
+		even though the stream might still be writable.
+		Default: `true`.
 	**/
 	@:optional var writable:Bool;
+
+	/**
+		Allows aborting the wait for the stream to finish. The underlying stream is not
+		aborted if the signal is aborted. The callback / Promise rejects with an `AbortError`.
+	**/
+	@:optional var signal:AbortSignal;
+
+	/**
+		If `true`, removes the listeners registered by this function before the Promise is fulfilled.
+		Only used by the Promise form of `finished`. Default: `false`.
+	**/
+	@:optional var cleanup:Bool;
 }
 
 /**

--- a/src/js/node/events/EventEmitter.hx
+++ b/src/js/node/events/EventEmitter.hx
@@ -118,10 +118,17 @@ extern class EventEmitter<TSelf:EventEmitter<TSelf>> implements IEventEmitter {
 	static function setMaxListeners(n:Int, emitters:Rest<IEventEmitter>):Void;
 
 	/**
+		Returns the currently set max amount of listeners for the given emitter.
+
+		@see https://nodejs.org/api/events.html#eventsgetmaxlistenersemitterortarget
+	**/
+	static function getMaxListeners(emitter:IEventEmitter):Int;
+
+	/**
 		A class method that returns the number of listeners for the given `eventName`
 		registered on the given `emitter`.
 
-		@see https://nodejs.org/api/events.html#eventsemitterlistenercountemitter-eventname
+		@see https://nodejs.org/api/events.html#eventslistenercountemitterortarget-eventname
 	**/
 	static function listenerCount(emitter:IEventEmitter, eventName:Event<Function>):Int;
 

--- a/src/js/node/events/EventEmitter.hx
+++ b/src/js/node/events/EventEmitter.hx
@@ -79,6 +79,53 @@ extern class EventEmitter<TSelf:EventEmitter<TSelf>> implements IEventEmitter {
 	static var defaultMaxListeners:Int;
 
 	/**
+		This symbol shall be used to install a listener for only monitoring `'error'`
+		events. Listeners installed using this symbol are called before the regular
+		`'error'` listeners are called.
+
+		@see https://nodejs.org/api/events.html#eventserrormonitor
+	**/
+	#if haxe4
+	static final errorMonitor:Symbol;
+	#else
+	static var errorMonitor(default, never):Dynamic;
+	#end
+
+	/**
+		Value: `Symbol.for('nodejs.rejection')`
+
+		@see https://nodejs.org/api/events.html#eventscapturerejectionsymbol
+	**/
+	#if haxe4
+	static final captureRejectionSymbol:Symbol;
+	#else
+	static var captureRejectionSymbol(default, never):Dynamic;
+	#end
+
+	/**
+		Returns a copy of the array of listeners for the event named `name`.
+
+		@see https://nodejs.org/api/events.html#eventsgeteventlistenersemitter-name
+	**/
+	static function getEventListeners(emitter:IEventEmitter, name:Event<Function>):Array<Function>;
+
+	/**
+		Change the default `maxListeners` value for all `EventEmitter` instances,
+		and optionally apply that change to the given emitters.
+
+		@see https://nodejs.org/api/events.html#eventssetmaxlistenersn-eventtargets
+	**/
+	static function setMaxListeners(n:Int, emitters:Rest<IEventEmitter>):Void;
+
+	/**
+		A class method that returns the number of listeners for the given `eventName`
+		registered on the given `emitter`.
+
+		@see https://nodejs.org/api/events.html#eventsemitterlistenercountemitter-eventname
+	**/
+	static function listenerCount(emitter:IEventEmitter, eventName:Event<Function>):Int;
+
+	/**
 		Alias for `emitter.on(eventName, listener)`.
 
 		@see https://nodejs.org/api/events.html#events_emitter_addlistener_eventname_listener

--- a/src/js/node/stream/Readable.hx
+++ b/src/js/node/stream/Readable.hx
@@ -286,6 +286,13 @@ extern class Readable<TSelf:Readable<TSelf>> extends Stream<TSelf> implements IR
 	// --------- static API  --------------------------------------------------
 	// TODO @:overload(function<T>(iterable:AsyncIterator<T>, ?options:ReadableNewOptions):IReadable {})
 	static function from<T>(iterable:Iterator<T>, ?options:ReadableNewOptions):IReadable;
+
+	/**
+		Returns whether the stream has been read from or cancelled.
+
+		@see https://nodejs.org/api/stream.html#streamreadableisdisturbedstream
+	**/
+	static function isDisturbed(stream:Dynamic):Bool;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add `Stream.finished` (callback and Promise overloads) plus `isReadable` / `isWritable` / `isDestroyed` / `isDisturbed` / `isErrored` helpers
- Add events utilities on `Events` and matching `EventEmitter` statics: `errorMonitor`, `captureRejectionSymbol`, `getEventListeners`, `setMaxListeners`, `listenerCount`

## Test plan
- [ ] `haxe completion.hxml` succeeds
- [ ] Spot-check typings against Node docs for `stream.finished` / helpers and `events` statics

Made with [Cursor](https://cursor.com)