### PR TITLE
Add net BlockList/SocketAddress, buffer utils, cluster aliases

### DIFF
--- a/src/js/node/Cluster.hx
+++ b/src/js/node/Cluster.hx
@@ -169,6 +169,13 @@ extern class Cluster extends EventEmitter<Cluster> {
 	var isMaster(default, null):Bool;
 
 	/**
+		True if the process is a primary (alias of `isMaster`).
+		This is determined by the process.env.NODE_UNIQUE_ID.
+		If process.env.NODE_UNIQUE_ID is undefined, then `isPrimary` is true.
+	**/
+	var isPrimary(default, null):Bool;
+
+	/**
 		True if the process is not a master (it is the negation of `isMaster`).
 	**/
 	var isWorker(default, null):Bool;
@@ -188,6 +195,11 @@ extern class Cluster extends EventEmitter<Cluster> {
 			`setupMaster` must be called before any calls to `fork`
 	**/
 	function setupMaster(?settings:{?exec:String, ?args:Array<String>, ?silent:Bool}):Void;
+
+	/**
+		Alias of `setupMaster`.
+	**/
+	function setupPrimary(?settings:{?exec:String, ?args:Array<String>, ?silent:Bool}):Void;
 
 	/**
 		Spawn a new worker process.

--- a/src/js/node/Cluster.hx
+++ b/src/js/node/Cluster.hx
@@ -169,9 +169,11 @@ extern class Cluster extends EventEmitter<Cluster> {
 	var isMaster(default, null):Bool;
 
 	/**
-		True if the process is a primary (alias of `isMaster`).
+		True if the process is a primary.
 		This is determined by the process.env.NODE_UNIQUE_ID.
 		If process.env.NODE_UNIQUE_ID is undefined, then `isPrimary` is true.
+
+		`isMaster` is a deprecated alias of `isPrimary`.
 	**/
 	var isPrimary(default, null):Bool;
 
@@ -197,7 +199,9 @@ extern class Cluster extends EventEmitter<Cluster> {
 	function setupMaster(?settings:{?exec:String, ?args:Array<String>, ?silent:Bool}):Void;
 
 	/**
-		Alias of `setupMaster`.
+		Used to change the default `fork` behavior. Once called, the settings will be present in `settings`.
+
+		`setupMaster` is a deprecated alias of `setupPrimary`.
 	**/
 	function setupPrimary(?settings:{?exec:String, ?args:Array<String>, ?silent:Bool}):Void;
 

--- a/src/js/node/Net.hx
+++ b/src/js/node/Net.hx
@@ -23,8 +23,10 @@
 package js.node;
 
 import haxe.extern.EitherType;
+import js.node.net.BlockList as BlockListObject;
 import js.node.net.Server;
 import js.node.net.Socket;
+import js.node.net.SocketAddress as SocketAddressObject;
 
 typedef NetCreateServerOptions = {
 	> SocketOptionsBase,
@@ -122,4 +124,46 @@ extern class Net {
 		Returns true if input is a version 6 IP address, otherwise returns false.
 	**/
 	static function isIPv6(input:String):Bool;
+
+	/**
+		`BlockList` class constructor.
+
+		@see https://nodejs.org/api/net.html#class-netblocklist
+	**/
+	static var BlockList:Class<BlockListObject>;
+
+	/**
+		`SocketAddress` class constructor.
+
+		@see https://nodejs.org/api/net.html#class-netsocketaddress
+	**/
+	static var SocketAddress:Class<SocketAddressObject>;
+
+	/**
+		Gets the current default value of the `autoSelectFamily` option of `socket.connect(options)`.
+
+		@see https://nodejs.org/api/net.html#netgetdefaultautoselectfamily
+	**/
+	static function getDefaultAutoSelectFamily():Bool;
+
+	/**
+		Sets the default value of the `autoSelectFamily` option of `socket.connect(options)`.
+
+		@see https://nodejs.org/api/net.html#netsetdefaultautoselectfamilyvalue
+	**/
+	static function setDefaultAutoSelectFamily(value:Bool):Void;
+
+	/**
+		Gets the current default value of the `autoSelectFamilyAttemptTimeout` option of `socket.connect(options)`.
+
+		@see https://nodejs.org/api/net.html#netgetdefaultautoselectfamilyattempttimeout
+	**/
+	static function getDefaultAutoSelectFamilyAttemptTimeout():Int;
+
+	/**
+		Sets the default value of the `autoSelectFamilyAttemptTimeout` option of `socket.connect(options)`.
+
+		@see https://nodejs.org/api/net.html#netsetdefaultautoselectfamilyattempttimeoutvalue
+	**/
+	static function setDefaultAutoSelectFamilyAttemptTimeout(ms:Int):Void;
 }

--- a/src/js/node/buffer/Buffer.hx
+++ b/src/js/node/buffer/Buffer.hx
@@ -22,6 +22,7 @@
 
 package js.node.buffer;
 
+import haxe.extern.EitherType;
 import haxe.io.Bytes;
 import haxe.io.UInt8Array;
 #if haxe4
@@ -694,22 +695,24 @@ extern class Buffer extends Uint8Array {
 	/**
 		Returns `true` if the given `input` contains only valid UTF-8-encoded data, `false` otherwise.
 
+		`input` may be a `TypedArray`/`ArrayBufferView` or an `ArrayBuffer`.
 		This is a property on the `buffer` module returned by `require('buffer')`, not on the `Buffer` global or a `Buffer` instance.
 
 		@see https://nodejs.org/api/buffer.html#bufferisutf8input
 	**/
-	static inline function isUtf8(input:Uint8Array):Bool {
+	static inline function isUtf8(input:EitherType<ArrayBufferView, ArrayBuffer>):Bool {
 		return BufferModule.isUtf8(input);
 	}
 
 	/**
 		Returns `true` if the given `input` contains only valid ASCII-encoded data, `false` otherwise.
 
+		`input` may be a `TypedArray`/`ArrayBufferView` or an `ArrayBuffer`.
 		This is a property on the `buffer` module returned by `require('buffer')`, not on the `Buffer` global or a `Buffer` instance.
 
 		@see https://nodejs.org/api/buffer.html#bufferisasciiinput
 	**/
-	static inline function isAscii(input:Uint8Array):Bool {
+	static inline function isAscii(input:EitherType<ArrayBufferView, ArrayBuffer>):Bool {
 		return BufferModule.isAscii(input);
 	}
 
@@ -785,8 +788,8 @@ private extern class BufferModule {
 	static var INSPECT_MAX_BYTES:Int;
 	static var kMaxLength(default, never):Int;
 	static function transcode(source:Uint8Array, fromEnc:String, toEnc:String):Buffer;
-	static function isUtf8(input:Uint8Array):Bool;
-	static function isAscii(input:Uint8Array):Bool;
+	static function isUtf8(input:EitherType<ArrayBufferView, ArrayBuffer>):Bool;
+	static function isAscii(input:EitherType<ArrayBufferView, ArrayBuffer>):Bool;
 	static function atob(data:String):String;
 	static function btoa(data:String):String;
 	static var constants(default, never):BufferConstants;

--- a/src/js/node/buffer/Buffer.hx
+++ b/src/js/node/buffer/Buffer.hx
@@ -692,6 +692,50 @@ extern class Buffer extends Uint8Array {
 	};
 
 	/**
+		Returns `true` if the given `input` contains only valid UTF-8-encoded data, `false` otherwise.
+
+		This is a property on the `buffer` module returned by `require('buffer')`, not on the `Buffer` global or a `Buffer` instance.
+
+		@see https://nodejs.org/api/buffer.html#bufferisutf8input
+	**/
+	static inline function isUtf8(input:Uint8Array):Bool {
+		return BufferModule.isUtf8(input);
+	}
+
+	/**
+		Returns `true` if the given `input` contains only valid ASCII-encoded data, `false` otherwise.
+
+		This is a property on the `buffer` module returned by `require('buffer')`, not on the `Buffer` global or a `Buffer` instance.
+
+		@see https://nodejs.org/api/buffer.html#bufferisasciiinput
+	**/
+	static inline function isAscii(input:Uint8Array):Bool {
+		return BufferModule.isAscii(input);
+	}
+
+	/**
+		Decodes a string of Base64-encoded data into bytes, and encodes those bytes into a string using Latin-1 (ISO-8859-1).
+
+		This is a property on the `buffer` module returned by `require('buffer')`, not on the `Buffer` global or a `Buffer` instance.
+
+		@see https://nodejs.org/api/buffer.html#bufferatobdata
+	**/
+	static inline function atob(data:String):String {
+		return BufferModule.atob(data);
+	}
+
+	/**
+		Decodes a string into bytes using Latin-1 (ISO-8859), and encodes those bytes into a string using Base64.
+
+		This is a property on the `buffer` module returned by `require('buffer')`, not on the `Buffer` global or a `Buffer` instance.
+
+		@see https://nodejs.org/api/buffer.html#bufferbtoadata
+	**/
+	static inline function btoa(data:String):String {
+		return BufferModule.btoa(data);
+	}
+
+	/**
 		`buffer.constants` is a property on the `buffer` module returned by `require('buffer')`,
 		not on the `Buffer` global or a `Buffer` instance.
 
@@ -741,6 +785,10 @@ private extern class BufferModule {
 	static var INSPECT_MAX_BYTES:Int;
 	static var kMaxLength(default, never):Int;
 	static function transcode(source:Uint8Array, fromEnc:String, toEnc:String):Buffer;
+	static function isUtf8(input:Uint8Array):Bool;
+	static function isAscii(input:Uint8Array):Bool;
+	static function atob(data:String):String;
+	static function btoa(data:String):String;
 	static var constants(default, never):BufferConstants;
 }
 

--- a/src/js/node/net/BlockList.hx
+++ b/src/js/node/net/BlockList.hx
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.net;
+
+import haxe.extern.EitherType;
+
+/**
+	The `BlockList` object can be used with some network APIs to specify rules
+	for disabling inbound or outbound access to specific IP addresses, IP ranges, or IP subnets.
+**/
+@:jsRequire("net", "BlockList")
+extern class BlockList {
+	function new();
+
+	/**
+		Adds a rule to block the given IP address.
+
+		`type` is either `'ipv4'` or `'ipv6'`. Default: `'ipv4'`.
+	**/
+	function addAddress(address:EitherType<String, SocketAddress>, ?type:String):Void;
+
+	/**
+		Adds a rule to block a range of IP addresses from `start` (inclusive) to `end` (inclusive).
+
+		`type` is either `'ipv4'` or `'ipv6'`. Default: `'ipv4'`.
+	**/
+	function addRange(start:EitherType<String, SocketAddress>, end:EitherType<String, SocketAddress>, ?type:String):Void;
+
+	/**
+		Adds a rule to block a range of IP addresses specified as a subnet mask.
+
+		`prefix` is the number of CIDR prefix bits. For IPv4, this must be between 0 and 32.
+		For IPv6, this must be between 0 and 128.
+
+		`type` is either `'ipv4'` or `'ipv6'`. Default: `'ipv4'`.
+	**/
+	function addSubnet(net:EitherType<String, SocketAddress>, prefix:Int, ?type:String):Void;
+
+	/**
+		Returns `true` if the given IP address matches any of the rules added to the `BlockList`.
+
+		`type` is either `'ipv4'` or `'ipv6'`. Default: `'ipv4'`.
+	**/
+	function check(address:EitherType<String, SocketAddress>, ?type:String):Bool;
+
+	/**
+		The list of rules added to the blocklist.
+	**/
+	var rules(default, null):Array<String>;
+}

--- a/src/js/node/net/BlockList.hx
+++ b/src/js/node/net/BlockList.hx
@@ -33,6 +33,13 @@ extern class BlockList {
 	function new();
 
 	/**
+		Returns `true` if the `value` is a `net.BlockList`.
+
+		@see https://nodejs.org/api/net.html#blocklistisblocklistvalue
+	**/
+	static function isBlockList(value:Dynamic):Bool;
+
+	/**
 		Adds a rule to block the given IP address.
 
 		`type` is either `'ipv4'` or `'ipv6'`. Default: `'ipv4'`.
@@ -67,4 +74,22 @@ extern class BlockList {
 		The list of rules added to the blocklist.
 	**/
 	var rules(default, null):Array<String>;
+
+	/**
+		Loads rules from a JSON string or an array of rule strings (same format as `rules`).
+
+		Stability: 1 - Experimental.
+
+		@see https://nodejs.org/api/net.html#blocklistfromjsonvalue
+	**/
+	function fromJSON(value:EitherType<String, Array<String>>):Void;
+
+	/**
+		Returns the rules as a JSON-serializable array of strings (same format as `rules`).
+
+		Stability: 1 - Experimental.
+
+		@see https://nodejs.org/api/net.html#blocklisttojson
+	**/
+	function toJSON():Array<String>;
 }

--- a/src/js/node/net/SocketAddress.hx
+++ b/src/js/node/net/SocketAddress.hx
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.net;
+
+import haxe.extern.EitherType;
+
+/**
+	Represents a network endpoint as an IP address and port pair.
+
+	@see https://nodejs.org/api/net.html#class-netsocketaddress
+**/
+@:jsRequire("net", "SocketAddress")
+extern class SocketAddress {
+	/**
+		Creates a new `SocketAddress`.
+
+		@see https://nodejs.org/api/net.html#new-netsocketaddressoptions
+	**/
+	function new(?options:{
+		?address:String,
+		?family:EitherType<String, Int>,
+		?flowlabel:Int,
+		?port:Int
+	}):Void;
+
+	/**
+		The network address as either an IPv4 or IPv6 string.
+	**/
+	var address(default, null):String;
+
+	/**
+		Either `'ipv4'` or `'ipv6'`.
+	**/
+	var family(default, null):String;
+
+	/**
+		An IP port.
+	**/
+	var port(default, null):Int;
+
+	/**
+		An IPv6 flow-label used only if `family` is `'ipv6'`.
+	**/
+	var flowlabel(default, null):Int;
+}

--- a/src/js/node/net/SocketAddress.hx
+++ b/src/js/node/net/SocketAddress.hx
@@ -22,8 +22,6 @@
 
 package js.node.net;
 
-import haxe.extern.EitherType;
-
 /**
 	Represents a network endpoint as an IP address and port pair.
 
@@ -34,14 +32,26 @@ extern class SocketAddress {
 	/**
 		Creates a new `SocketAddress`.
 
+		`family` is either `'ipv4'` or `'ipv6'`. Default: `'ipv4'`.
+
 		@see https://nodejs.org/api/net.html#new-netsocketaddressoptions
 	**/
 	function new(?options:{
 		?address:String,
-		?family:EitherType<String, Int>,
+		?family:String,
 		?flowlabel:Int,
 		?port:Int
 	}):Void;
+
+	/**
+		Parses an IP address and optional port string into a `SocketAddress`.
+
+		`input` examples: `123.1.2.3:1234` or `[1::1]:1234`.
+		Returns `null`/`undefined` if parsing fails.
+
+		@see https://nodejs.org/api/net.html#socketaddressparseinput
+	**/
+	static function parse(input:String):Null<SocketAddress>;
 
 	/**
 		The network address as either an IPv4 or IPv6 string.


### PR DESCRIPTION
## Summary
- Add `net.BlockList` and `net.SocketAddress` externs, plus `Net` static class refs and autoSelectFamily default getters/setters.
- Add buffer module helpers `isUtf8`, `isAscii`, `atob`, and `btoa` via `BufferModule` wrappers.
- Add cluster aliases `isPrimary` and `setupPrimary`.

## Test plan
- [ ] `haxe completion.hxml` / targeted typecheck of `js.node.Net`, `js.node.net.BlockList`, `js.node.net.SocketAddress`, `js.node.buffer.Buffer`, `js.node.Cluster` on Haxe 4.3.x
- [ ] Confirm `require('net').BlockList` / `SocketAddress` and buffer/cluster aliases match Node LTS docs


Made with [Cursor](https://cursor.com)