### PR TITLE
Add Os/Path/Url/Tls LTS constants and helpers

### DIFF
--- a/src/js/node/Os.hx
+++ b/src/js/node/Os.hx
@@ -46,6 +46,14 @@ extern class Os {
 	static function arch():String;
 
 	/**
+		Returns an estimate of the default amount of parallelism a program should use.
+		Always returns a value greater than zero.
+
+		@see https://nodejs.org/api/os.html#osavailableparallelism
+	**/
+	static function availableParallelism():Int;
+
+	/**
 		Returns an object containing commonly used operating system specific constants for error codes, process signals, and so on. The specific constants currently defined are described in OS Constants.
 
 		@see https://nodejs.org/api/os.html#os_os_constants
@@ -58,6 +66,14 @@ extern class Os {
 		@see https://nodejs.org/api/os.html#os_os_cpus
 	**/
 	static function cpus():Array<CPU>;
+
+	/**
+		The platform-specific file path of the null device.
+		`'\\.\nul'` on Windows and `'/dev/null'` on POSIX.
+
+		@see https://nodejs.org/api/os.html#osdevnull
+	**/
+	static var devNull(default, null):String;
 
 	/**
 		The `os.endianness()` method returns a string identifying the endianness of the CPU for which the Node.js binary was compiled.
@@ -100,6 +116,13 @@ extern class Os {
 		@see https://nodejs.org/api/os.html#os_os_loadavg
 	**/
 	static function loadavg():Array<Float>;
+
+	/**
+		Returns the machine type as a string, such as `arm`, `arm64`, `aarch64`, `mips`, `mips64`, `ppc64`, `ppc64le`, `s390`, `s390x`, `i386`, `i686`, `x86_64`.
+
+		@see https://nodejs.org/api/os.html#osmachine
+	**/
+	static function machine():String;
 
 	/**
 		The `os.networkInterfaces()` method returns an object containing only network interfaces that have been assigned a network address.
@@ -163,6 +186,15 @@ extern class Os {
 		@see https://nodejs.org/api/os.html#os_os_userinfo_options
 	**/
 	static function userInfo(?options:{encoding:String}):OsUserInfo;
+
+	/**
+		Returns a string identifying the kernel version.
+
+		On POSIX systems, the operating system release is determined by calling uname(3). On Windows, `RtlGetVersion()` is used, and if it is not available, `GetVersionExW()` will be used.
+
+		@see https://nodejs.org/api/os.html#osversion
+	**/
+	static function version():String;
 }
 
 /**

--- a/src/js/node/Os.hx
+++ b/src/js/node/Os.hx
@@ -118,7 +118,7 @@ extern class Os {
 	static function loadavg():Array<Float>;
 
 	/**
-		Returns the machine type as a string, such as `arm`, `arm64`, `aarch64`, `mips`, `mips64`, `ppc64`, `ppc64le`, `s390`, `s390x`, `i386`, `i686`, `x86_64`.
+		Returns the machine type as a string, such as `arm`, `arm64`, `aarch64`, `mips`, `mips64`, `ppc64`, `ppc64le`, `s390x`, `i386`, `i686`, `x86_64`.
 
 		@see https://nodejs.org/api/os.html#osmachine
 	**/

--- a/src/js/node/Path.hx
+++ b/src/js/node/Path.hx
@@ -83,6 +83,13 @@ extern class Path {
 	static function join(paths:haxe.extern.Rest<String>):String;
 
 	/**
+		The `path.matchesGlob()` method determines if `path` matches the `pattern`.
+
+		@see https://nodejs.org/api/path.html#pathmatchesglobpath-pattern
+	**/
+	static function matchesGlob(path:String, pattern:String):Bool;
+
+	/**
 		The `path.normalize()` method normalizes the given `path`, resolving `'..'` and `'.'` segments.
 
 		@see https://nodejs.org/api/path.html#path_path_normalize_path
@@ -189,6 +196,7 @@ private typedef PathModule = {
 	function dirname(path:String):String;
 	function basename(path:String, ?ext:String):String;
 	function extname(path:String):String;
+	function matchesGlob(path:String, pattern:String):Bool;
 	var sep(default, null):String;
 	var delimiter(default, null):String;
 	function parse(pathString:String):PathObject;

--- a/src/js/node/Tls.hx
+++ b/src/js/node/Tls.hx
@@ -170,11 +170,51 @@ extern class Tls {
 	static var CLIENT_RENEG_WINDOW:Int;
 
 	/**
+		The default value of the `ciphers` option of `Tls.createSecureContext`.
+		It can be assigned any of the supported OpenSSL ciphers.
+	**/
+	static var DEFAULT_CIPHERS:String;
+
+	/**
+		The default named curve to use for ECDH key agreement in a tls server.
+		The default value is `'auto'`.
+	**/
+	static var DEFAULT_ECDH_CURVE:String;
+
+	/**
+		The default value of the `maxVersion` option of `Tls.createSecureContext`.
+		It can be assigned any of the supported TLS protocol versions:
+		`'TLSv1.3'`, `'TLSv1.2'`, `'TLSv1.1'`, or `'TLSv1'`.
+	**/
+	static var DEFAULT_MAX_VERSION:String;
+
+	/**
+		The default value of the `minVersion` option of `Tls.createSecureContext`.
+		It can be assigned any of the supported TLS protocol versions:
+		`'TLSv1.3'`, `'TLSv1.2'`, `'TLSv1.1'`, or `'TLSv1'`.
+	**/
+	static var DEFAULT_MIN_VERSION:String;
+
+	/**
+		An immutable array of strings representing the root certificates (in PEM format)
+		from the bundled Mozilla CA store as supplied by the current Node.js version.
+	**/
+	static var rootCertificates(default, null):Array<String>;
+
+	/**
 		Size of slab buffer used by all tls servers and clients. Default: 10 * 1024 * 1024.
 
 		Don't change the defaults unless you know what you are doing.
 	**/
 	static var SLAB_BUFFER_SIZE:Int;
+
+	/**
+		Returns an array containing the CA certificates from various sources, depending on `type`.
+
+		Valid values for `type` are `'default'`, `'system'`, `'bundled'` and `'extra'`.
+		Default: `'default'`.
+	**/
+	static function getCACertificates(?type:String):Array<String>;
 
 	/**
 		Returns an array with the names of the supported SSL ciphers.

--- a/src/js/node/Tls.hx
+++ b/src/js/node/Tls.hx
@@ -213,8 +213,20 @@ extern class Tls {
 
 		Valid values for `type` are `'default'`, `'system'`, `'bundled'` and `'extra'`.
 		Default: `'default'`.
+
+		@see https://nodejs.org/api/tls.html#tlsgetcacertificatestype
 	**/
 	static function getCACertificates(?type:String):Array<String>;
+
+	/**
+		Sets the default CA certificates used by Node.js TLS clients.
+		If the provided certificates are parsed successfully, they become the default CA
+		certificate list returned by `getCACertificates()` and used by subsequent TLS
+		connections that don't specify their own CA certificates.
+
+		@see https://nodejs.org/api/tls.html#tlssetdefaultcacertificatescerts
+	**/
+	static function setDefaultCACertificates(certs:Array<EitherType<String, Buffer>>):Void;
 
 	/**
 		Returns an array with the names of the supported SSL ciphers.

--- a/src/js/node/Url.hx
+++ b/src/js/node/Url.hx
@@ -22,6 +22,7 @@
 
 package js.node;
 
+import haxe.extern.EitherType;
 import js.node.url.URL;
 
 /**
@@ -95,6 +96,66 @@ extern class Url {
 	**/
 	@:deprecated
 	static function resolve(from:String, to:String):String;
+
+	/**
+		This utility function converts a URL object into an ordinary options object as expected by the `http.request()` and `https.request()` APIs.
+
+		@see https://nodejs.org/api/url.html#urlurltohttpoptionsurl
+	**/
+	static function urlToHttpOptions(url:URL):UrlHttpOptions;
+}
+
+/**
+	Options object returned by `Url.urlToHttpOptions`, compatible with `http.request` / `https.request`.
+
+	@see https://nodejs.org/api/url.html#urlurltohttpoptionsurl
+**/
+typedef UrlHttpOptions = {
+	/**
+		Protocol to use.
+	**/
+	@:optional var protocol:String;
+
+	/**
+		A domain name or IP address of the server to issue the request to.
+	**/
+	@:optional var hostname:String;
+
+	/**
+		The fragment portion of the URL.
+	**/
+	@:optional var hash:String;
+
+	/**
+		The serialized query portion of the URL.
+	**/
+	@:optional var search:String;
+
+	/**
+		The path portion of the URL.
+	**/
+	@:optional var pathname:String;
+
+	/**
+		Request path. Should include query string if any.
+		E.g. `'/index.html?page=12'`.
+	**/
+	@:optional var path:String;
+
+	/**
+		The serialized URL.
+	**/
+	@:optional var href:String;
+
+	/**
+		Port of remote server.
+	**/
+	@:optional var port:EitherType<String, Int>;
+
+	/**
+		Basic authentication i.e. `'user:password'` to compute an Authorization header.
+	**/
+	@:optional var auth:String;
 }
 
 typedef UrlFormatOptions = {


### PR DESCRIPTION
## Summary
- Add missing `Os` APIs: `availableParallelism()`, `machine()`, `version()`, and `devNull`
- Add `Path.matchesGlob()` (including `posix`/`win32` `PathModule`) and `Url.urlToHttpOptions()` with `UrlHttpOptions`
- Add `Tls` LTS surfaces: `rootCertificates`, `DEFAULT_*` cipher/version/curve constants, and `getCACertificates()`

## Test plan
- [x] `haxe build.hxml` (Haxe 4.3.7)
- [x] `haxe completion.hxml` (Haxe 4.3.7)
- [ ] Spot-check against Node.js docs for the added symbols


Made with [Cursor](https://cursor.com)