### PR TITLE
Add Event, EventTarget, CustomEvent, DOMException externs

### DIFF
--- a/src/js/node/web/CustomEvent.hx
+++ b/src/js/node/web/CustomEvent.hx
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.web;
+
+/**
+	A browser-compatible implementation of `CustomEvent`.
+
+	@see https://nodejs.org/api/events.html#class-customevent
+	@see https://nodejs.org/api/globals.html#class-customevent
+**/
+@:native("CustomEvent")
+extern class CustomEvent extends Event {
+	/**
+		Custom data passed when initializing the event.
+	**/
+	var detail(default, null):Dynamic;
+
+	function new(type:String, ?eventInitDict:CustomEventInit):Void;
+}
+
+/**
+	Options passed to the `CustomEvent` constructor.
+**/
+typedef CustomEventInit = {
+	/**
+		Not used in Node.js. Default: `false`.
+	**/
+	@:optional var bubbles:Bool;
+
+	/**
+		When `true`, `preventDefault()` can cancel the event. Default: `false`.
+	**/
+	@:optional var cancelable:Bool;
+
+	/**
+		Not used in Node.js. Default: `false`.
+	**/
+	@:optional var composed:Bool;
+
+	/**
+		Custom data exposed as `detail`.
+	**/
+	@:optional var detail:Dynamic;
+}

--- a/src/js/node/web/DOMException.hx
+++ b/src/js/node/web/DOMException.hx
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.web;
+
+/**
+	The WHATWG `DOMException` class.
+
+	@see https://nodejs.org/api/globals.html#class-domexception
+**/
+@:native("DOMException")
+extern class DOMException {
+	static inline var INDEX_SIZE_ERR:Int = 1;
+	static inline var DOMSTRING_SIZE_ERR:Int = 2;
+	static inline var HIERARCHY_REQUEST_ERR:Int = 3;
+	static inline var WRONG_DOCUMENT_ERR:Int = 4;
+	static inline var INVALID_CHARACTER_ERR:Int = 5;
+	static inline var NO_DATA_ALLOWED_ERR:Int = 6;
+	static inline var NO_MODIFICATION_ALLOWED_ERR:Int = 7;
+	static inline var NOT_FOUND_ERR:Int = 8;
+	static inline var NOT_SUPPORTED_ERR:Int = 9;
+	static inline var INUSE_ATTRIBUTE_ERR:Int = 10;
+	static inline var INVALID_STATE_ERR:Int = 11;
+	static inline var SYNTAX_ERR:Int = 12;
+	static inline var INVALID_MODIFICATION_ERR:Int = 13;
+	static inline var NAMESPACE_ERR:Int = 14;
+	static inline var INVALID_ACCESS_ERR:Int = 15;
+	static inline var VALIDATION_ERR:Int = 16;
+	static inline var TYPE_MISMATCH_ERR:Int = 17;
+	static inline var SECURITY_ERR:Int = 18;
+	static inline var NETWORK_ERR:Int = 19;
+	static inline var ABORT_ERR:Int = 20;
+	static inline var URL_MISMATCH_ERR:Int = 21;
+	static inline var QUOTA_EXCEEDED_ERR:Int = 22;
+	static inline var TIMEOUT_ERR:Int = 23;
+	static inline var INVALID_NODE_TYPE_ERR:Int = 24;
+	static inline var DATA_CLONE_ERR:Int = 25;
+
+	/**
+		One of the strings associated with an error name.
+	**/
+	var name(default, null):String;
+
+	/**
+		A message or description associated with the given error name.
+	**/
+	var message(default, null):String;
+
+	/**
+		One of the legacy error codes, or `0` if none match.
+		New DOM exceptions put this info in `name` instead.
+	**/
+	var code(default, null):Int;
+
+	function new(?message:String, ?name:String):Void;
+}

--- a/src/js/node/web/Event.hx
+++ b/src/js/node/web/Event.hx
@@ -1,0 +1,161 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.web;
+
+/**
+	A browser-compatible implementation of the `Event` class.
+
+	@see https://nodejs.org/api/events.html#class-event
+	@see https://nodejs.org/api/globals.html#class-event
+**/
+@:native("Event")
+extern class Event {
+	static inline var NONE:Int = 0;
+	static inline var CAPTURING_PHASE:Int = 1;
+	static inline var AT_TARGET:Int = 2;
+	static inline var BUBBLING_PHASE:Int = 3;
+
+	/**
+		The event type identifier.
+	**/
+	var type(default, null):String;
+
+	/**
+		The `EventTarget` dispatching the event.
+	**/
+	var target(default, null):EventTarget;
+
+	/**
+		Alias for `target`.
+	**/
+	var currentTarget(default, null):EventTarget;
+
+	/**
+		Returns `0` while an event is not being dispatched, `2` while it is being dispatched.
+		This is not used in Node.js and is provided purely for completeness.
+	**/
+	var eventPhase(default, null):Int;
+
+	/**
+		Always returns `false` in Node.js. Provided purely for completeness.
+	**/
+	var bubbles(default, null):Bool;
+
+	/**
+		True if the event was created with the `cancelable` option.
+	**/
+	var cancelable(default, null):Bool;
+
+	/**
+		Stability: 3 - Legacy: Use `defaultPrevented` instead.
+
+		True if the event has not been canceled.
+	**/
+	var returnValue:Bool;
+
+	/**
+		Is `true` if `cancelable` is `true` and `preventDefault()` has been called.
+	**/
+	var defaultPrevented(default, null):Bool;
+
+	/**
+		Always returns `false` in Node.js. Provided purely for completeness.
+	**/
+	var composed(default, null):Bool;
+
+	/**
+		The `"abort"` event is emitted with `isTrusted` set to `true`.
+		The value is `false` in all other cases.
+	**/
+	var isTrusted(default, null):Bool;
+
+	/**
+		The millisecond timestamp when the `Event` object was created.
+	**/
+	var timeStamp(default, null):Float;
+
+	/**
+		Stability: 3 - Legacy: Use `stopPropagation()` instead.
+
+		Alias for `stopPropagation()` if set to `true`.
+	**/
+	var cancelBubble:Bool;
+
+	/**
+		Stability: 3 - Legacy: Use `target` instead.
+
+		Alias for `target`.
+	**/
+	var srcElement(default, null):EventTarget;
+
+	function new(type:String, ?eventInitDict:EventInit):Void;
+
+	/**
+		Returns an array containing the current `EventTarget` as the only entry,
+		or empty if the event is not being dispatched.
+		This is not used in Node.js and is provided purely for completeness.
+	**/
+	function composedPath():Array<EventTarget>;
+
+	/**
+		Sets the `defaultPrevented` property to `true` if `cancelable` is `true`.
+	**/
+	function preventDefault():Void;
+
+	/**
+		Stops the invocation of event listeners after the current one completes.
+	**/
+	function stopImmediatePropagation():Void;
+
+	/**
+		This is not used in Node.js and is provided purely for completeness.
+	**/
+	function stopPropagation():Void;
+
+	/**
+		Stability: 3 - Legacy: The WHATWG spec considers it deprecated.
+
+		Redundant with event constructors and incapable of setting `composed`.
+	**/
+	function initEvent(type:String, ?bubbles:Bool, ?cancelable:Bool):Void;
+}
+
+/**
+	Options passed to the `Event` constructor.
+**/
+typedef EventInit = {
+	/**
+		Not used in Node.js. Default: `false`.
+	**/
+	@:optional var bubbles:Bool;
+
+	/**
+		When `true`, `preventDefault()` can cancel the event. Default: `false`.
+	**/
+	@:optional var cancelable:Bool;
+
+	/**
+		Not used in Node.js. Default: `false`.
+	**/
+	@:optional var composed:Bool;
+}

--- a/src/js/node/web/EventTarget.hx
+++ b/src/js/node/web/EventTarget.hx
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.web;
+
+import haxe.Constraints.Function;
+import haxe.extern.EitherType;
+
+/**
+	A browser-compatible implementation of the `EventTarget` class.
+
+	@see https://nodejs.org/api/events.html#class-eventtarget
+	@see https://nodejs.org/api/globals.html#class-eventtarget
+**/
+@:native("EventTarget")
+extern class EventTarget {
+	function new():Void;
+
+	/**
+		Adds a new handler for the `type` event.
+		Any given `listener` is added only once per `type` and per `capture` option value.
+	**/
+	@:overload(function(type:String, listener:EventListener, ?options:EitherType<AddEventListenerOptions, Bool>):Void {})
+	function addEventListener(type:String, listener:Function, ?options:EitherType<AddEventListenerOptions, Bool>):Void;
+
+	/**
+		Removes the `listener` from the list of handlers for event `type`.
+	**/
+	@:overload(function(type:String, listener:EventListener, ?options:EitherType<EventListenerOptions, Bool>):Void {})
+	function removeEventListener(type:String, listener:Function, ?options:EitherType<EventListenerOptions, Bool>):Void;
+
+	/**
+		Dispatches the `event` to the list of handlers for `event.type`.
+
+		@return `true` if either event's `cancelable` attribute value is false
+			or its `preventDefault()` method was not invoked, otherwise `false`.
+	**/
+	function dispatchEvent(event:Event):Bool;
+}
+
+/**
+	An object with a `handleEvent` method, usable as an event listener.
+**/
+typedef EventListener = {
+	function handleEvent(event:Event):Void;
+}
+
+/**
+	Options for `EventTarget.removeEventListener`.
+**/
+typedef EventListenerOptions = {
+	/**
+		Not directly used by Node.js except as part of the listener registration key.
+		Default: `false`.
+	**/
+	@:optional var capture:Bool;
+}
+
+/**
+	Options for `EventTarget.addEventListener`.
+**/
+typedef AddEventListenerOptions = {
+	/**
+		Not directly used by Node.js except as part of the listener registration key.
+		Default: `false`.
+	**/
+	@:optional var capture:Bool;
+
+	/**
+		When `true`, the listener is automatically removed when it is first invoked.
+		Default: `false`.
+	**/
+	@:optional var once:Bool;
+
+	/**
+		When `true`, serves as a hint that the listener will not call `preventDefault()`.
+		Default: `false`.
+	**/
+	@:optional var passive:Bool;
+
+	/**
+		The listener will be removed when the given `AbortSignal` object's `abort()` method is called.
+
+		Typed as `Dynamic` so this module does not hard-depend on the AbortSignal externs;
+		use `js.node.web.AbortSignal` when that module is available.
+	**/
+	@:optional var signal:Dynamic;
+}


### PR DESCRIPTION
## Summary
- Add Node.js v24 web Event API externs under `js.node.web`: `Event`, `EventTarget`, `CustomEvent`, `DOMException`
- No `Node.hx` wiring in this PR (type files only)
- Skips experimental `CloseEvent`

## Test plan
- [ ] `haxe build.hxml` with Haxe 4.3.x
- [ ] Spot-check constructing `Event` / `EventTarget` / `CustomEvent` / `DOMException` against Node 24 globals docs


Made with [Cursor](https://cursor.com)