### PR TITLE
Add fetch, Request, Response, Headers, FormData, Blob, File externs

### DIFF
--- a/src/js/node/web/AbortSignal.hx
+++ b/src/js/node/web/AbortSignal.hx
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.web;
+
+import haxe.Constraints.Function;
+
+/**
+	Used to notify observers when `AbortController.abort()` is called.
+
+	Extends `js.node.web.EventTarget`. Prefer these Node web externs over the
+	incomplete Haxe standard library `js.html.AbortSignal`.
+
+	@see https://nodejs.org/api/globals.html#class-abortsignal
+**/
+@:native("AbortSignal")
+extern class AbortSignal extends EventTarget {
+	/**
+		Returns a new already aborted `AbortSignal`.
+	**/
+	static function abort(?reason:Dynamic):AbortSignal;
+
+	/**
+		Returns a new `AbortSignal` which will be aborted in `delay` milliseconds.
+	**/
+	static function timeout(delay:Float):AbortSignal;
+
+	/**
+		Returns a new `AbortSignal` which will be aborted if any of the provided
+		signals are aborted. Its `reason` will be set to whichever signal caused the abort.
+	**/
+	static function any(signals:Array<AbortSignal>):AbortSignal;
+
+	/**
+		True after the associated `AbortController` has been aborted.
+	**/
+	var aborted(default, null):Bool;
+
+	/**
+		An optional reason specified when the `AbortSignal` was triggered.
+	**/
+	var reason(default, null):Dynamic;
+
+	/**
+		An optional callback function that may be set by user code to be notified
+		when `AbortController.abort()` has been called.
+	**/
+	var onabort:Function;
+
+	/**
+		If `aborted` is `true`, throws `reason`.
+	**/
+	function throwIfAborted():Void;
+}

--- a/src/js/node/web/Blob.hx
+++ b/src/js/node/web/Blob.hx
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.web;
+
+import haxe.extern.EitherType;
+#if haxe4
+import js.lib.ArrayBuffer;
+import js.lib.ArrayBufferView;
+import js.lib.Promise;
+import js.lib.Uint8Array;
+#else
+import js.html.ArrayBuffer;
+import js.html.ArrayBufferView;
+import js.Promise;
+import js.html.Uint8Array;
+#end
+
+/**
+	Encapsulates immutable, raw data that can be safely shared across workers.
+
+	Available as a global and via `require('node:buffer').Blob`.
+
+	@see https://nodejs.org/api/buffer.html#class-blob
+	@see https://nodejs.org/api/globals.html#class-blob
+**/
+@:native("Blob")
+extern class Blob {
+	/**
+		The total size of the `Blob` in bytes.
+	**/
+	var size(default, null):Int;
+
+	/**
+		The content-type of the `Blob`.
+	**/
+	var type(default, null):String;
+
+	function new(?sources:Array<BlobPart>, ?options:BlobPropertyBag):Void;
+
+	/**
+		Returns a promise that fulfills with an `ArrayBuffer` containing a copy of the `Blob` data.
+	**/
+	function arrayBuffer():Promise<ArrayBuffer>;
+
+	/**
+		Returns a promise that fulfills with a `Uint8Array` containing a copy of the `Blob` data.
+	**/
+	function bytes():Promise<Uint8Array>;
+
+	/**
+		Creates and returns a new `Blob` containing a subset of this `Blob`'s data.
+	**/
+	function slice(?start:Int, ?end:Int, ?type:String):Blob;
+
+	/**
+		Returns a new `ReadableStream` that allows the content of the `Blob` to be read.
+
+		Typed as `Dynamic` until web streams externs are added.
+	**/
+	function stream():Dynamic;
+
+	/**
+		Returns a promise that fulfills with the contents of the `Blob` decoded as a UTF-8 string.
+	**/
+	function text():Promise<String>;
+}
+
+/**
+	A part accepted by the `Blob` / `File` constructors.
+**/
+typedef BlobPart = EitherType<String, EitherType<ArrayBuffer, EitherType<ArrayBufferView, Blob>>>;
+
+/**
+	Options for the `Blob` constructor.
+**/
+typedef BlobPropertyBag = {
+	/**
+		One of `'transparent'` or `'native'`. When `'native'`, line endings in string
+		source parts are converted to the platform native line-ending.
+	**/
+	@:optional var endings:String;
+
+	/**
+		The Blob content-type (MIME media type). No validation is performed.
+	**/
+	@:optional var type:String;
+}

--- a/src/js/node/web/Event.hx
+++ b/src/js/node/web/Event.hx
@@ -1,0 +1,161 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.web;
+
+/**
+	A browser-compatible implementation of the `Event` class.
+
+	@see https://nodejs.org/api/events.html#class-event
+	@see https://nodejs.org/api/globals.html#class-event
+**/
+@:native("Event")
+extern class Event {
+	static inline var NONE:Int = 0;
+	static inline var CAPTURING_PHASE:Int = 1;
+	static inline var AT_TARGET:Int = 2;
+	static inline var BUBBLING_PHASE:Int = 3;
+
+	/**
+		The event type identifier.
+	**/
+	var type(default, null):String;
+
+	/**
+		The `EventTarget` dispatching the event.
+	**/
+	var target(default, null):EventTarget;
+
+	/**
+		Alias for `target`.
+	**/
+	var currentTarget(default, null):EventTarget;
+
+	/**
+		Returns `0` while an event is not being dispatched, `2` while it is being dispatched.
+		This is not used in Node.js and is provided purely for completeness.
+	**/
+	var eventPhase(default, null):Int;
+
+	/**
+		Always returns `false` in Node.js. Provided purely for completeness.
+	**/
+	var bubbles(default, null):Bool;
+
+	/**
+		True if the event was created with the `cancelable` option.
+	**/
+	var cancelable(default, null):Bool;
+
+	/**
+		Stability: 3 - Legacy: Use `defaultPrevented` instead.
+
+		True if the event has not been canceled.
+	**/
+	var returnValue:Bool;
+
+	/**
+		Is `true` if `cancelable` is `true` and `preventDefault()` has been called.
+	**/
+	var defaultPrevented(default, null):Bool;
+
+	/**
+		Always returns `false` in Node.js. Provided purely for completeness.
+	**/
+	var composed(default, null):Bool;
+
+	/**
+		The `"abort"` event is emitted with `isTrusted` set to `true`.
+		The value is `false` in all other cases.
+	**/
+	var isTrusted(default, null):Bool;
+
+	/**
+		The millisecond timestamp when the `Event` object was created.
+	**/
+	var timeStamp(default, null):Float;
+
+	/**
+		Stability: 3 - Legacy: Use `stopPropagation()` instead.
+
+		Alias for `stopPropagation()` if set to `true`.
+	**/
+	var cancelBubble:Bool;
+
+	/**
+		Stability: 3 - Legacy: Use `target` instead.
+
+		Alias for `target`.
+	**/
+	var srcElement(default, null):EventTarget;
+
+	function new(type:String, ?eventInitDict:EventInit):Void;
+
+	/**
+		Returns an array containing the current `EventTarget` as the only entry,
+		or empty if the event is not being dispatched.
+		This is not used in Node.js and is provided purely for completeness.
+	**/
+	function composedPath():Array<EventTarget>;
+
+	/**
+		Sets the `defaultPrevented` property to `true` if `cancelable` is `true`.
+	**/
+	function preventDefault():Void;
+
+	/**
+		Stops the invocation of event listeners after the current one completes.
+	**/
+	function stopImmediatePropagation():Void;
+
+	/**
+		This is not used in Node.js and is provided purely for completeness.
+	**/
+	function stopPropagation():Void;
+
+	/**
+		Stability: 3 - Legacy: The WHATWG spec considers it deprecated.
+
+		Redundant with event constructors and incapable of setting `composed`.
+	**/
+	function initEvent(type:String, ?bubbles:Bool, ?cancelable:Bool):Void;
+}
+
+/**
+	Options passed to the `Event` constructor.
+**/
+typedef EventInit = {
+	/**
+		Not used in Node.js. Default: `false`.
+	**/
+	@:optional var bubbles:Bool;
+
+	/**
+		When `true`, `preventDefault()` can cancel the event. Default: `false`.
+	**/
+	@:optional var cancelable:Bool;
+
+	/**
+		Not used in Node.js. Default: `false`.
+	**/
+	@:optional var composed:Bool;
+}

--- a/src/js/node/web/EventTarget.hx
+++ b/src/js/node/web/EventTarget.hx
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.web;
+
+import haxe.Constraints.Function;
+import haxe.extern.EitherType;
+
+/**
+	A browser-compatible implementation of the `EventTarget` class.
+
+	@see https://nodejs.org/api/events.html#class-eventtarget
+	@see https://nodejs.org/api/globals.html#class-eventtarget
+**/
+@:native("EventTarget")
+extern class EventTarget {
+	function new():Void;
+
+	/**
+		Adds a new handler for the `type` event.
+		Any given `listener` is added only once per `type` and per `capture` option value.
+	**/
+	@:overload(function(type:String, listener:EventListener, ?options:EitherType<AddEventListenerOptions, Bool>):Void {})
+	function addEventListener(type:String, listener:Function, ?options:EitherType<AddEventListenerOptions, Bool>):Void;
+
+	/**
+		Removes the `listener` from the list of handlers for event `type`.
+	**/
+	@:overload(function(type:String, listener:EventListener, ?options:EitherType<EventListenerOptions, Bool>):Void {})
+	function removeEventListener(type:String, listener:Function, ?options:EitherType<EventListenerOptions, Bool>):Void;
+
+	/**
+		Dispatches the `event` to the list of handlers for `event.type`.
+
+		@return `true` if either event's `cancelable` attribute value is false
+			or its `preventDefault()` method was not invoked, otherwise `false`.
+	**/
+	function dispatchEvent(event:Event):Bool;
+}
+
+/**
+	An object with a `handleEvent` method, usable as an event listener.
+**/
+typedef EventListener = {
+	function handleEvent(event:Event):Void;
+}
+
+/**
+	Options for `EventTarget.removeEventListener`.
+**/
+typedef EventListenerOptions = {
+	/**
+		Not directly used by Node.js except as part of the listener registration key.
+		Default: `false`.
+	**/
+	@:optional var capture:Bool;
+}
+
+/**
+	Options for `EventTarget.addEventListener`.
+**/
+typedef AddEventListenerOptions = {
+	/**
+		Not directly used by Node.js except as part of the listener registration key.
+		Default: `false`.
+	**/
+	@:optional var capture:Bool;
+
+	/**
+		When `true`, the listener is automatically removed when it is first invoked.
+		Default: `false`.
+	**/
+	@:optional var once:Bool;
+
+	/**
+		When `true`, serves as a hint that the listener will not call `preventDefault()`.
+		Default: `false`.
+	**/
+	@:optional var passive:Bool;
+
+	/**
+		The listener will be removed when the given `AbortSignal` object's `abort()` method is called.
+
+		Typed as `Dynamic` so this module does not hard-depend on the AbortSignal externs;
+		use `js.node.web.AbortSignal` when that module is available.
+	**/
+	@:optional var signal:Dynamic;
+}

--- a/src/js/node/web/Fetch.hx
+++ b/src/js/node/web/Fetch.hx
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.web;
+
+import haxe.extern.EitherType;
+import js.node.web.Request.RequestInit;
+#if haxe4
+import js.lib.Promise;
+#else
+import js.Promise;
+#end
+
+/**
+	Browser-compatible `fetch()` (undici), exposed as a static on `globalThis`.
+
+	Usage: `Fetch.fetch(url)` / `Fetch.fetch(url, init)`.
+
+	@see https://nodejs.org/api/globals.html#fetch
+**/
+@:native("globalThis")
+extern class Fetch {
+	/**
+		Starts the process of fetching a resource from the network.
+	**/
+	@:overload(function(input:Request, ?init:RequestInit):Promise<Response> {})
+	static function fetch(input:String, ?init:RequestInit):Promise<Response>;
+}

--- a/src/js/node/web/File.hx
+++ b/src/js/node/web/File.hx
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.web;
+
+import js.node.web.Blob.BlobPart;
+
+/**
+	Provides information about files. Extends `Blob`.
+
+	Available as a global and via `require('node:buffer').File`.
+
+	@see https://nodejs.org/api/buffer.html#class-file
+	@see https://nodejs.org/api/globals.html#class-file
+**/
+@:native("File")
+extern class File extends Blob {
+	/**
+		The name of the file.
+	**/
+	var name(default, null):String;
+
+	/**
+		The last modified date of the file (milliseconds since UNIX epoch).
+	**/
+	var lastModified(default, null):Float;
+
+	function new(sources:Array<BlobPart>, fileName:String, ?options:FilePropertyBag):Void;
+}
+
+/**
+	Options for the `File` constructor.
+**/
+typedef FilePropertyBag = {
+	/**
+		One of `'transparent'` or `'native'`.
+	**/
+	@:optional var endings:String;
+
+	/**
+		The File content-type.
+	**/
+	@:optional var type:String;
+
+	/**
+		The last modified date of the file. Default: `Date.now()`.
+	**/
+	@:optional var lastModified:Float;
+}

--- a/src/js/node/web/FormData.hx
+++ b/src/js/node/web/FormData.hx
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.web;
+
+import haxe.extern.EitherType;
+import js.node.Iterator;
+import js.node.KeyValue;
+
+/**
+	A browser-compatible `FormData` implementation (undici / fetch).
+
+	@see https://nodejs.org/api/globals.html#class-formdata
+**/
+@:native("FormData")
+extern class FormData {
+	function new():Void;
+
+	/**
+		Appends a new value onto an existing key, or adds the key if it does not exist.
+	**/
+	@:overload(function(name:String, value:Blob, ?filename:String):Void {})
+	function append(name:String, value:String):Void;
+
+	/**
+		Deletes a key/value pair.
+	**/
+	function delete(name:String):Void;
+
+	/**
+		Returns the first value associated with a given key.
+	**/
+	function get(name:String):Null<EitherType<String, EitherType<Blob, File>>>;
+
+	/**
+		Returns all values associated with a given key.
+	**/
+	function getAll(name:String):Array<EitherType<String, EitherType<Blob, File>>>;
+
+	/**
+		Returns whether a key exists.
+	**/
+	function has(name:String):Bool;
+
+	/**
+		Sets a new value for an existing key, or adds the key if it does not exist.
+	**/
+	@:overload(function(name:String, value:Blob, ?filename:String):Void {})
+	function set(name:String, value:String):Void;
+
+	function entries():Iterator<KeyValue<String, EitherType<String, EitherType<Blob, File>>>>;
+	function keys():Iterator<String>;
+	function values():Iterator<EitherType<String, EitherType<Blob, File>>>;
+	function forEach(callback:EitherType<String, EitherType<Blob, File>>->String->FormData->Void, ?thisArg:Dynamic):Void;
+}

--- a/src/js/node/web/Headers.hx
+++ b/src/js/node/web/Headers.hx
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.web;
+
+import haxe.DynamicAccess;
+import haxe.extern.EitherType;
+import js.node.Iterator;
+import js.node.KeyValue;
+
+/**
+	HTTP headers for `fetch` / `Request` / `Response` (undici).
+
+	@see https://nodejs.org/api/globals.html#class-headers
+**/
+@:native("Headers")
+extern class Headers {
+	@:overload(function(?init:Array<Array<String>>):Void {})
+	@:overload(function(?init:DynamicAccess<String>):Void {})
+	function new(?init:Headers):Void;
+
+	/**
+		Appends a new value onto an existing header, or adds the header if it does not exist.
+	**/
+	function append(name:String, value:String):Void;
+
+	/**
+		Deletes a header.
+	**/
+	function delete(name:String):Void;
+
+	/**
+		Returns the value of a header with the given name, or `null` if not present.
+	**/
+	function get(name:String):Null<String>;
+
+	/**
+		Returns an array containing the values of all `Set-Cookie` headers.
+	**/
+	function getSetCookie():Array<String>;
+
+	/**
+		Returns whether a header with the given name exists.
+	**/
+	function has(name:String):Bool;
+
+	/**
+		Sets a new value for an existing header, or adds the header if it does not exist.
+	**/
+	function set(name:String, value:String):Void;
+
+	function entries():Iterator<KeyValue<String, String>>;
+	function keys():Iterator<String>;
+	function values():Iterator<String>;
+	function forEach(callback:String->String->Headers->Void, ?thisArg:Dynamic):Void;
+}

--- a/src/js/node/web/Request.hx
+++ b/src/js/node/web/Request.hx
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.web;
+
+import haxe.DynamicAccess;
+import haxe.extern.EitherType;
+import js.node.url.URLSearchParams;
+#if haxe4
+import js.lib.ArrayBuffer;
+import js.lib.ArrayBufferView;
+import js.lib.Promise;
+import js.lib.Uint8Array;
+#else
+import js.html.ArrayBuffer;
+import js.html.ArrayBufferView;
+import js.Promise;
+import js.html.Uint8Array;
+#end
+
+/**
+	The Fetch API `Request` interface (undici).
+
+	@see https://nodejs.org/api/globals.html#class-request
+**/
+@:native("Request")
+extern class Request {
+	var method(default, null):String;
+	var url(default, null):String;
+	var headers(default, null):Headers;
+	var destination(default, null):String;
+	var referrer(default, null):String;
+	var referrerPolicy(default, null):String;
+	var mode(default, null):String;
+	var credentials(default, null):String;
+	var cache(default, null):String;
+	var redirect(default, null):String;
+	var integrity(default, null):String;
+	var keepalive(default, null):Bool;
+	var signal(default, null):AbortSignal;
+	var duplex(default, null):String;
+
+	/**
+		A `ReadableStream` of the body contents, or `null`.
+		Typed as `Dynamic` until web streams externs are added.
+	**/
+	var body(default, null):Dynamic;
+
+	var bodyUsed(default, null):Bool;
+
+	@:overload(function(input:Request, ?init:RequestInit):Void {})
+	function new(input:String, ?init:RequestInit):Void;
+
+	function clone():Request;
+	function arrayBuffer():Promise<ArrayBuffer>;
+	function blob():Promise<Blob>;
+	function bytes():Promise<Uint8Array>;
+	function formData():Promise<FormData>;
+	function json():Promise<Dynamic>;
+	function text():Promise<String>;
+}
+
+/**
+	Init options for `Request` / `fetch`.
+**/
+typedef RequestInit = {
+	@:optional var method:String;
+	@:optional var headers:EitherType<Headers, EitherType<Array<Array<String>>, DynamicAccess<String>>>;
+	@:optional var body:BodyInit;
+	@:optional var referrer:String;
+	@:optional var referrerPolicy:String;
+	@:optional var mode:String;
+	@:optional var credentials:String;
+	@:optional var cache:String;
+	@:optional var redirect:String;
+	@:optional var integrity:String;
+	@:optional var keepalive:Bool;
+	@:optional var signal:AbortSignal;
+	@:optional var duplex:String;
+
+	/**
+		Undici-specific: custom dispatcher for the request.
+	**/
+	@:optional var dispatcher:Dynamic;
+}
+
+/**
+	Values accepted as request/response bodies.
+**/
+typedef BodyInit = EitherType<Blob,
+	EitherType<FormData, EitherType<URLSearchParams, EitherType<ArrayBuffer, EitherType<ArrayBufferView, EitherType<String, Dynamic>>>>>>;

--- a/src/js/node/web/Response.hx
+++ b/src/js/node/web/Response.hx
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.web;
+
+import haxe.DynamicAccess;
+import haxe.extern.EitherType;
+import js.node.web.Request.BodyInit;
+#if haxe4
+import js.lib.ArrayBuffer;
+import js.lib.Promise;
+import js.lib.Uint8Array;
+#else
+import js.html.ArrayBuffer;
+import js.Promise;
+import js.html.Uint8Array;
+#end
+
+/**
+	The Fetch API `Response` interface (undici).
+
+	@see https://nodejs.org/api/globals.html#class-response
+**/
+@:native("Response")
+extern class Response {
+	/**
+		Returns a new `Response` object associated with a network error.
+	**/
+	static function error():Response;
+
+	/**
+		Creates a new response with a different URL.
+	**/
+	static function redirect(url:String, ?status:Int):Response;
+
+	/**
+		Creates a new response with a JSON body.
+	**/
+	static function json(data:Dynamic, ?init:ResponseInit):Response;
+
+	var type(default, null):String;
+	var url(default, null):String;
+	var redirected(default, null):Bool;
+	var status(default, null):Int;
+	var ok(default, null):Bool;
+	var statusText(default, null):String;
+	var headers(default, null):Headers;
+
+	/**
+		A `ReadableStream` of the body contents, or `null`.
+		Typed as `Dynamic` until web streams externs are added.
+	**/
+	var body(default, null):Dynamic;
+
+	var bodyUsed(default, null):Bool;
+
+	function new(?body:BodyInit, ?init:ResponseInit):Void;
+
+	function clone():Response;
+	function arrayBuffer():Promise<ArrayBuffer>;
+	function blob():Promise<Blob>;
+	function bytes():Promise<Uint8Array>;
+	function formData():Promise<FormData>;
+	function json():Promise<Dynamic>;
+	function text():Promise<String>;
+}
+
+/**
+	Init options for `Response`.
+**/
+typedef ResponseInit = {
+	@:optional var status:Int;
+	@:optional var statusText:String;
+	@:optional var headers:EitherType<Headers, EitherType<Array<Array<String>>, DynamicAccess<String>>>;
+}


### PR DESCRIPTION
## Summary
- Add undici-based Node.js v24 fetch globals under `js.node.web`: `Fetch.fetch`, `Request`, `Response`, `Headers`, `FormData`, `Blob`, `File`
- `RequestInit.signal` uses `js.node.web.AbortSignal`
- Includes shared `AbortSignal` / `Event` / `EventTarget` path types so the branch compiles independently; intended to compose with the abort/events PRs
- `body` / `stream()` typed as `Dynamic` until web streams externs land
- No `Node.hx` changes

## Test plan
- [ ] `haxe build.hxml` with Haxe 4.3.x
- [ ] Spot-check `Fetch.fetch` + `Request`/`Response`/`Headers`/`FormData`/`Blob`/`File` against Node 24 / undici docs


Made with [Cursor](https://cursor.com)