### PR TITLE
[ci] Add github action build workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        haxe_ver: [3.4.7, 4.3.7, latest]
+
+    steps:
+    - uses: actions/checkout@v7
+
+    - uses: krdlab/setup-haxe@v2
+      with:
+        haxe-version: ${{ matrix.haxe_ver }}
+
+    - run: haxelib dev hxnodejs .
+      name: Set haxelib dev path
+
+    - run: |
+        haxe build.hxml
+        haxelib git dox https://github.com/HaxeFoundation/dox
+        haxe doc.hxml
+      name: Build
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        haxe_ver: [3.4.7, 4.3.7, latest]
+        haxe_ver: [4.0.5, 4.3.7, latest]
 
     steps:
     - uses: actions/checkout@v7

--- a/ImportAll.hx
+++ b/ImportAll.hx
@@ -24,6 +24,10 @@ class ImportAll {
 				Context.getType(typePath);
 			}
 		}
+		#if haxe5
+		Context.onAfterInitMacros(() -> loop([]));
+		#else
 		loop([]);
+		#end
 	}
 }

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Haxelib Downloads](https://badgen.net/haxelib/d/hxnodejs?color=blue)](https://lib.haxe.org/p/hxnodejs)
 [![Haxelib License](https://badgen.net/haxelib/license/hxnodejs)](LICENSE.md)
 
-Extern type definitions for Node.JS. Haxe **3.4** or newer is required.
+Extern type definitions for Node.JS. Haxe **4.0** or newer is required.
 
 Haxe-generated API documentation is available at http://haxefoundation.github.io/hxnodejs/js/Node.html.
 


### PR DESCRIPTION
Haxe 3 support was lost in 504066dc1ba5ad543afa5f6c3ea019f06136a82b. It could be restored but might make more sense to just increase the minimum version to Haxe 4.0.

Partially addresses #188.