### PR TITLE
Add diagnostics_channel module externs

### DIFF
--- a/src/js/node/DiagnosticsChannel.hx
+++ b/src/js/node/DiagnosticsChannel.hx
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node;
+
+import haxe.extern.EitherType;
+import js.node.diagnostics_channel.Channel;
+import js.node.diagnostics_channel.Channel.ChannelListener;
+import js.node.diagnostics_channel.Channel.ChannelName;
+import js.node.diagnostics_channel.TracingChannel;
+import js.node.diagnostics_channel.TracingChannel.TracingChannelChannels;
+
+/**
+	The `diagnostics_channel` module provides an API to create named channels
+	to report arbitrary message data for diagnostics purposes.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/diagnostics_channel.html
+**/
+@:jsRequire("diagnostics_channel")
+extern class DiagnosticsChannel {
+	/**
+		Check if there are active subscribers to the named channel.
+		This is helpful if the message you want to send might be expensive to prepare.
+
+		This API is optional but helpful when trying to publish messages from very
+		performance-sensitive code.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/diagnostics_channel.html#diagnostics_channelhassubscribersname
+	**/
+	static function hasSubscribers(name:ChannelName):Bool;
+
+	/**
+		This is the primary entry-point for anyone wanting to publish to a named channel.
+		It produces a channel object which is optimized to reduce overhead at publish time
+		as much as possible.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/diagnostics_channel.html#diagnostics_channelchannelname
+	**/
+	static function channel(name:ChannelName):Channel;
+
+	/**
+		Register a message handler to subscribe to this channel.
+		This message handler will be run synchronously whenever a message is published
+		to the channel. Any errors thrown in the message handler will trigger an
+		`'uncaughtException'`.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/diagnostics_channel.html#diagnostics_channelsubscribename-onmessage
+	**/
+	static function subscribe(name:ChannelName, onMessage:ChannelListener):Void;
+
+	/**
+		Remove a message handler previously registered to this channel with
+		`DiagnosticsChannel.subscribe(name, onMessage)`.
+
+		Returns `true` if the handler was found, `false` otherwise.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/diagnostics_channel.html#diagnostics_channelunsubscribename-onmessage
+	**/
+	static function unsubscribe(name:ChannelName, onMessage:ChannelListener):Bool;
+
+	/**
+		Creates a `TracingChannel` wrapper for the given TracingChannel Channels.
+		If a name is given, the corresponding tracing channels will be created in the
+		form of `tracing:${name}:${eventType}` where `eventType` corresponds to the
+		types of TracingChannel Channels.
+
+		Stability: 1 - Experimental
+
+		@see https://nodejs.org/docs/latest-v24.x/api/diagnostics_channel.html#diagnostics_channeltracingchannelnameorchannels
+	**/
+	static function tracingChannel(nameOrChannels:EitherType<String, TracingChannelChannels>):TracingChannel;
+}

--- a/src/js/node/diagnostics_channel/Channel.hx
+++ b/src/js/node/diagnostics_channel/Channel.hx
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.diagnostics_channel;
+
+import haxe.Constraints.Function;
+import haxe.extern.EitherType;
+import haxe.extern.Rest;
+#if haxe4
+import js.lib.Symbol;
+#end
+
+/**
+	Channel name: a string or symbol.
+**/
+#if haxe4
+typedef ChannelName = EitherType<String, Symbol>;
+#else
+typedef ChannelName = EitherType<String, Dynamic>;
+#end
+
+/**
+	Handler invoked when a message is published on a channel.
+
+	Arguments:
+		* `message` - The message data
+		* `name` - The name of the channel
+**/
+typedef ChannelListener = Dynamic->ChannelName->Void;
+
+/**
+	Transform function used by `Channel.bindStore` to convert published context
+	data into the value stored in an `AsyncLocalStorage` instance.
+**/
+typedef ChannelStoreTransform = Dynamic->Dynamic;
+
+/**
+	The class `Channel` represents an individual named channel within the data pipeline.
+	It is used to track subscribers and to publish messages when there are subscribers present.
+
+	Channels are created with `DiagnosticsChannel.channel(name)`; constructing a channel
+	directly with `new Channel(name)` is not supported.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/diagnostics_channel.html#class-channel
+**/
+@:jsRequire("diagnostics_channel", "Channel")
+extern class Channel {
+	private function new();
+
+	/**
+		The channel name.
+	**/
+	var name(default, never):ChannelName;
+
+	/**
+		Check if there are active subscribers to this channel.
+		This is helpful if the message you want to send might be expensive to prepare.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/diagnostics_channel.html#channelhassubscribers
+	**/
+	var hasSubscribers(default, never):Bool;
+
+	/**
+		Publish a message to any subscribers to the channel.
+		This will trigger message handlers synchronously so they will execute within
+		the same context.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/diagnostics_channel.html#channelpublishmessage
+	**/
+	function publish(message:Dynamic):Void;
+
+	/**
+		Register a message handler to subscribe to this channel.
+		This message handler will be run synchronously whenever a message is published
+		to the channel. Any errors thrown in the message handler will trigger an
+		`'uncaughtException'`.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/diagnostics_channel.html#channelsubscribeonmessage
+	**/
+	function subscribe(onMessage:ChannelListener):Void;
+
+	/**
+		Remove a message handler previously registered to this channel with
+		`channel.subscribe(onMessage)`.
+
+		Returns `true` if the handler was found, `false` otherwise.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/diagnostics_channel.html#channelunsubscribeonmessage
+	**/
+	function unsubscribe(onMessage:ChannelListener):Bool;
+
+	/**
+		When `channel.runStores(context, ...)` is called, the given context data will be
+		applied to any store bound to the channel. If the store has already been bound
+		the previous `transform` function will be replaced with the new one.
+		The `transform` function may be omitted to set the given context data as the
+		context directly.
+
+		`store` should be an `AsyncLocalStorage` instance from `node:async_hooks`.
+
+		Stability: 1 - Experimental
+
+		@see https://nodejs.org/docs/latest-v24.x/api/diagnostics_channel.html#channelbindstorestore-transform
+	**/
+	function bindStore(store:Dynamic, ?transform:ChannelStoreTransform):Void;
+
+	/**
+		Remove a store previously bound to this channel with `channel.bindStore(store)`.
+
+		`store` should be an `AsyncLocalStorage` instance from `node:async_hooks`.
+
+		Returns `true` if the store was found, `false` otherwise.
+
+		Stability: 1 - Experimental
+
+		@see https://nodejs.org/docs/latest-v24.x/api/diagnostics_channel.html#channelunbindstorestore
+	**/
+	function unbindStore(store:Dynamic):Bool;
+
+	/**
+		Applies the given data to any AsyncLocalStorage instances bound to the channel
+		for the duration of the given function, then publishes to the channel within
+		the scope of that data is applied to the stores.
+
+		If a transform function was given to `channel.bindStore(store)` it will be
+		applied to transform the message data before it becomes the context value for
+		the store. The prior storage context is accessible from within the transform
+		function in cases where context linking is required.
+
+		Stability: 1 - Experimental
+
+		@see https://nodejs.org/docs/latest-v24.x/api/diagnostics_channel.html#channelrunstorescontext-fn-thisarg-args
+	**/
+	function runStores(context:Dynamic, fn:Function, ?thisArg:Dynamic, args:Rest<Dynamic>):Dynamic;
+}

--- a/src/js/node/diagnostics_channel/TracingChannel.hx
+++ b/src/js/node/diagnostics_channel/TracingChannel.hx
@@ -91,34 +91,33 @@ typedef TracingChannelSubscribers = {
 
 	@see https://nodejs.org/docs/latest-v24.x/api/diagnostics_channel.html#class-tracingchannel
 **/
-@:jsRequire("diagnostics_channel", "TracingChannel")
 extern class TracingChannel {
 	private function new();
 
 	/**
 		Channel for the `start` event (`tracing:${name}:start`).
 	**/
-	var start:Channel;
+	var start(default, never):Channel;
 
 	/**
 		Channel for the `end` event (`tracing:${name}:end`).
 	**/
-	var end:Channel;
+	var end(default, never):Channel;
 
 	/**
 		Channel for the `asyncStart` event (`tracing:${name}:asyncStart`).
 	**/
-	var asyncStart:Channel;
+	var asyncStart(default, never):Channel;
 
 	/**
 		Channel for the `asyncEnd` event (`tracing:${name}:asyncEnd`).
 	**/
-	var asyncEnd:Channel;
+	var asyncEnd(default, never):Channel;
 
 	/**
 		Channel for the `error` event (`tracing:${name}:error`).
 	**/
-	var error:Channel;
+	var error(default, never):Channel;
 
 	/**
 		This is a helper to check if any of the TracingChannel Channels have subscribers.

--- a/src/js/node/diagnostics_channel/TracingChannel.hx
+++ b/src/js/node/diagnostics_channel/TracingChannel.hx
@@ -1,0 +1,191 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.diagnostics_channel;
+
+import haxe.Constraints.Function;
+import haxe.extern.Rest;
+#if haxe4
+import js.lib.Promise;
+#else
+import js.Promise;
+#end
+
+/**
+	Object containing all the TracingChannel Channels, passed to
+	`DiagnosticsChannel.tracingChannel`.
+**/
+typedef TracingChannelChannels = {
+	var start:Channel;
+	var end:Channel;
+	var asyncStart:Channel;
+	var asyncEnd:Channel;
+	var error:Channel;
+}
+
+/**
+	Handler for a tracing channel message.
+**/
+typedef TracingChannelMessageHandler = Dynamic->Void;
+
+/**
+	Set of TracingChannel Channels subscribers.
+	Each handler is optional; omit any that are not needed.
+**/
+typedef TracingChannelSubscribers = {
+	/**
+		The `start` event subscriber.
+	**/
+	@:optional var start:TracingChannelMessageHandler;
+
+	/**
+		The `end` event subscriber.
+	**/
+	@:optional var end:TracingChannelMessageHandler;
+
+	/**
+		The `asyncStart` event subscriber.
+	**/
+	@:optional var asyncStart:TracingChannelMessageHandler;
+
+	/**
+		The `asyncEnd` event subscriber.
+	**/
+	@:optional var asyncEnd:TracingChannelMessageHandler;
+
+	/**
+		The `error` event subscriber.
+	**/
+	@:optional var error:TracingChannelMessageHandler;
+}
+
+/**
+	The class `TracingChannel` is a collection of TracingChannel Channels which
+	together express a single traceable action. It is used to formalize and simplify
+	the process of producing events for tracing application flow.
+
+	`DiagnosticsChannel.tracingChannel()` is used to construct a `TracingChannel`.
+	As with `Channel` it is recommended to create and reuse a single `TracingChannel`
+	at the top-level of the file rather than creating them dynamically.
+
+	Stability: 1 - Experimental
+
+	@see https://nodejs.org/docs/latest-v24.x/api/diagnostics_channel.html#class-tracingchannel
+**/
+@:jsRequire("diagnostics_channel", "TracingChannel")
+extern class TracingChannel {
+	private function new();
+
+	/**
+		Channel for the `start` event (`tracing:${name}:start`).
+	**/
+	var start:Channel;
+
+	/**
+		Channel for the `end` event (`tracing:${name}:end`).
+	**/
+	var end:Channel;
+
+	/**
+		Channel for the `asyncStart` event (`tracing:${name}:asyncStart`).
+	**/
+	var asyncStart:Channel;
+
+	/**
+		Channel for the `asyncEnd` event (`tracing:${name}:asyncEnd`).
+	**/
+	var asyncEnd:Channel;
+
+	/**
+		Channel for the `error` event (`tracing:${name}:error`).
+	**/
+	var error:Channel;
+
+	/**
+		This is a helper to check if any of the TracingChannel Channels have subscribers.
+		Returns `true` if any of them have at least one subscriber, `false` otherwise.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/diagnostics_channel.html#tracingchannelhassubscribers
+	**/
+	var hasSubscribers(default, never):Bool;
+
+	/**
+		Helper to subscribe a collection of functions to the corresponding channels.
+		This is the same as calling `channel.subscribe(onMessage)` on each channel
+		individually.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/diagnostics_channel.html#tracingchannelsubscribesubscribers
+	**/
+	function subscribe(subscribers:TracingChannelSubscribers):Void;
+
+	/**
+		Helper to unsubscribe a collection of functions from the corresponding channels.
+		This is the same as calling `channel.unsubscribe(onMessage)` on each channel
+		individually.
+
+		Returns `true` if all handlers were successfully unsubscribed, and `false` otherwise.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/diagnostics_channel.html#tracingchannelunsubscribesubscribers
+	**/
+	function unsubscribe(subscribers:TracingChannelSubscribers):Bool;
+
+	/**
+		Trace a synchronous function call. This will always produce a `start` event and
+		`end` event around the execution and may produce an `error` event if the given
+		function throws an error.
+
+		This will run the given function using `channel.runStores(context, ...)` on the
+		`start` channel which ensures all events should have any bound stores set to
+		match this trace context.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/diagnostics_channel.html#tracingchanneltracesyncfn-context-thisarg-args
+	**/
+	function traceSync(fn:Function, ?context:{}, ?thisArg:Dynamic, args:Rest<Dynamic>):Dynamic;
+
+	/**
+		Trace a promise-returning function call. This will always produce a `start`
+		event and `end` event around the synchronous portion of the function execution,
+		and will produce an `asyncStart` event and `asyncEnd` event when a promise
+		continuation is reached. It may also produce an `error` event if the given
+		function throws an error or the returned promise rejects.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/diagnostics_channel.html#tracingchanneltracepromisefn-context-thisarg-args
+	**/
+	function tracePromise(fn:Function, ?context:{}, ?thisArg:Dynamic, args:Rest<Dynamic>):Promise<Dynamic>;
+
+	/**
+		Trace a callback-receiving function call. The callback is expected to follow
+		the error as first arg convention typically used.
+
+		This will always produce a `start` event and `end` event around the synchronous
+		portion of the function execution, and will produce a `asyncStart` event and
+		`asyncEnd` event around the callback execution. It may also produce an `error`
+		event if the given function throws or the first argument passed to the callback
+		is set.
+
+		`position` is the zero-indexed argument position of the expected callback
+		(defaults to last argument if `undefined` is passed).
+
+		@see https://nodejs.org/docs/latest-v24.x/api/diagnostics_channel.html#tracingchanneltracecallbackfn-position-context-thisarg-args
+	**/
+	function traceCallback(fn:Function, ?position:Int, ?context:{}, ?thisArg:Dynamic, args:Rest<Dynamic>):Dynamic;
+}


### PR DESCRIPTION
## Summary
- Add `js.node.DiagnosticsChannel` module externs (`channel`, `hasSubscribers`, `subscribe`, `unsubscribe`, `tracingChannel`) aligned with Node.js v24 LTS.
- Add `Channel` and `TracingChannel` classes under `js.node.diagnostics_channel`, including store-binding helpers and trace wrappers (`traceSync` / `tracePromise` / `traceCallback`).

## Test plan
- [x] `haxe build.hxml` (ImportAll) succeeds with the new modules
- [ ] Spot-check against https://nodejs.org/docs/latest-v24.x/api/diagnostics_channel.html


Made with [Cursor](https://cursor.com)