### PR TITLE
Add node:test runner externs

### DIFF
--- a/src/js/node/Test.hx
+++ b/src/js/node/Test.hx
@@ -1,0 +1,530 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node;
+
+import haxe.Constraints.Function;
+import haxe.DynamicAccess;
+import haxe.extern.EitherType;
+import js.html.AbortSignal;
+import js.node.test.MockTracker;
+import js.node.test.SuiteContext;
+import js.node.test.TestContext;
+import js.node.test.TestFunction;
+import js.node.test.TestsStream;
+#if haxe4
+import js.lib.Error;
+import js.lib.Promise;
+import js.lib.RegExp;
+#else
+import js.Error;
+import js.Promise;
+import js.RegExp;
+#end
+
+/**
+	The `node:test` module facilitates the creation of JavaScript tests.
+
+	This module is only available under the `node:` scheme.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/test.html
+**/
+@:jsRequire("node:test")
+extern class Test {
+	/**
+		The `test()` function creates a test whose lifecycle is managed by the test runner.
+
+		Each invocation results in reporting the test to the test runner.
+		Returns a `Promise` that fulfills once the test completes (or immediately if
+		called within a suite).
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#testname-options-fn
+	**/
+	@:selfCall
+	@:overload(function(fn:TestCallback):Promise<Void> {})
+	@:overload(function(name:String, fn:TestCallback):Promise<Void> {})
+	@:overload(function(options:TestOptions, fn:TestCallback):Promise<Void> {})
+	static function test(?name:String, ?options:TestOptions, ?fn:TestCallback):Promise<Void>;
+
+	/**
+		Shorthand for skipping a test: `test(name, { skip: true }[, fn])`.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#testskipname-options-fn
+	**/
+	@:overload(function(fn:TestCallback):Promise<Void> {})
+	@:overload(function(name:String, fn:TestCallback):Promise<Void> {})
+	@:overload(function(options:TestOptions, fn:TestCallback):Promise<Void> {})
+	static function skip(?name:String, ?options:TestOptions, ?fn:TestCallback):Promise<Void>;
+
+	/**
+		Shorthand for marking a test as `TODO`: `test(name, { todo: true }[, fn])`.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#testtodoname-options-fn
+	**/
+	@:overload(function(fn:TestCallback):Promise<Void> {})
+	@:overload(function(name:String, fn:TestCallback):Promise<Void> {})
+	@:overload(function(options:TestOptions, fn:TestCallback):Promise<Void> {})
+	static function todo(?name:String, ?options:TestOptions, ?fn:TestCallback):Promise<Void>;
+
+	/**
+		Shorthand for marking a test as `only`: `test(name, { only: true }[, fn])`.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#testonlyname-options-fn
+	**/
+	@:overload(function(fn:TestCallback):Promise<Void> {})
+	@:overload(function(name:String, fn:TestCallback):Promise<Void> {})
+	@:overload(function(options:TestOptions, fn:TestCallback):Promise<Void> {})
+	static function only(?name:String, ?options:TestOptions, ?fn:TestCallback):Promise<Void>;
+
+	/**
+		Alias for `suite()`. Suites group related tests.
+
+		Supports `.skip`, `.todo`, and `.only` shorthands.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#describename-options-fn
+	**/
+	static var describe(default, never):SuiteFunction;
+
+	/**
+		Creates a suite whose lifecycle is managed by the test runner.
+
+		Supports `.skip`, `.todo`, and `.only` shorthands.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#suitename-options-fn
+	**/
+	static var suite(default, never):SuiteFunction;
+
+	/**
+		Alias for `test()`.
+
+		Supports `.skip`, `.todo`, `.only`, and `.expectFailure` shorthands.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#itname-options-fn
+	**/
+	static var it(default, never):ItFunction;
+
+	/**
+		Creates a hook that runs before executing a suite.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#beforefn-options
+	**/
+	@:overload(function(fn:HookCallback):Void {})
+	static function before(?fn:HookCallback, ?options:HookOptions):Void;
+
+	/**
+		Creates a hook that runs after executing a suite.
+		Guaranteed to run even if tests within the suite fail.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#afterfn-options
+	**/
+	@:overload(function(fn:HookCallback):Void {})
+	static function after(?fn:HookCallback, ?options:HookOptions):Void;
+
+	/**
+		Creates a hook that runs before each test in the current suite.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#beforeeachfn-options
+	**/
+	@:overload(function(fn:HookCallback):Void {})
+	static function beforeEach(?fn:HookCallback, ?options:HookOptions):Void;
+
+	/**
+		Creates a hook that runs after each test in the current suite.
+		Runs even if the test fails.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#aftereachfn-options
+	**/
+	@:overload(function(fn:HookCallback):Void {})
+	static function afterEach(?fn:HookCallback, ?options:HookOptions):Void;
+
+	/**
+		Top-level `MockTracker` instance for the process.
+
+		Each test also provides its own tracker via `TestContext.mock`.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#class-mocktracker
+	**/
+	static var mock(default, never):MockTracker;
+
+	/**
+		Object whose methods configure default snapshot settings in the current process.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#snapshot
+	**/
+	static var snapshot(default, never):Snapshot;
+
+	/**
+		Object whose methods configure available assertions on `TestContext` objects
+		in the current process.
+
+		Methods from `node:assert` and snapshot testing functions are available on
+		`TestContext.assert` by default; see `js.node.Assert` for the assert API.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#assert
+	**/
+	static var assert(default, never):TestAssert;
+
+	/**
+		Programmatically run tests and return a stream of test reporter events.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#runoptions
+	**/
+	static function run(?options:RunOptions):TestsStream;
+}
+
+/**
+	Callback for a test created with `test()` / `it()` / `TestContext.test()`.
+
+	May be synchronous, return a `Promise`, or accept a Node-style `done` callback
+	as the second argument.
+**/
+typedef TestCallback = EitherType<TestContext->Dynamic, TestContext->(Null<Error>->Void)->Dynamic>;
+
+/**
+	Callback for a suite created with `suite()` / `describe()`.
+**/
+typedef SuiteCallback = EitherType<SuiteContext->Dynamic, SuiteContext->(Null<Error>->Void)->Dynamic>;
+
+/**
+	Callback for `before` / `after` / `beforeEach` / `afterEach` hooks.
+**/
+typedef HookCallback = Function;
+
+/**
+	Configuration options for a test or suite.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/test.html#testname-options-fn
+**/
+typedef TestOptions = {
+	/**
+		If a number is provided, that many tests run asynchronously.
+		If `true`, all scheduled asynchronous tests run concurrently.
+		If `false`, only one test runs at a time.
+		Default: `false` (subtests inherit from parent when unspecified).
+	**/
+	@:optional var concurrency:EitherType<Int, Bool>;
+
+	/**
+		If truthy, the test is expected to fail.
+		A string is shown as the reason; a `RegExp` / function / object / `Error`
+		is matched like `Assert.throws`. Use `{ label, match }` for both.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#expecting-tests-to-fail
+	**/
+	@:optional var expectFailure:EitherType<Bool, EitherType<String, EitherType<RegExp, EitherType<Function, EitherType<{}, ExpectFailureOptions>>>>>;
+
+	/**
+		If truthy, and the test context is configured to run `only` tests, this test runs.
+		Otherwise it is skipped. Default: `false`.
+	**/
+	@:optional var only:Bool;
+
+	/**
+		Allows aborting an in-progress test.
+	**/
+	@:optional var signal:AbortSignal;
+
+	/**
+		If truthy, the test is skipped. A string is shown as the skip reason. Default: `false`.
+	**/
+	@:optional var skip:EitherType<Bool, String>;
+
+	/**
+		If truthy, the test is marked `TODO`. A string is shown as the reason. Default: `false`.
+	**/
+	@:optional var todo:EitherType<Bool, String>;
+
+	/**
+		Milliseconds after which the test fails. Default: `Infinity`.
+	**/
+	@:optional var timeout:Float;
+
+	/**
+		Number of assertions and subtests expected to run. Default: `undefined`.
+	**/
+	@:optional var plan:Int;
+}
+
+/**
+	Object form of `expectFailure` providing both a label and a matcher.
+**/
+typedef ExpectFailureOptions = {
+	/**
+		Reason displayed in the test results.
+	**/
+	@:optional var label:String;
+
+	/**
+		Matcher for the thrown value (same forms as `Assert.throws`).
+	**/
+	@:optional var match:EitherType<RegExp, EitherType<Function, EitherType<{}, Error>>>;
+}
+
+/**
+	Configuration options for hooks.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/test.html#beforefn-options
+**/
+typedef HookOptions = {
+	/**
+		Allows aborting an in-progress hook.
+	**/
+	@:optional var signal:AbortSignal;
+
+	/**
+		Milliseconds after which the hook fails. Default: `Infinity`.
+	**/
+	@:optional var timeout:Float;
+}
+
+/**
+	Options for `TestContext.plan()`.
+**/
+typedef PlanOptions = {
+	/**
+		If `true`, wait indefinitely for planned assertions/subtests.
+		If `false`, check immediately when the test function completes.
+		If a number, maximum wait time in milliseconds. Default: `false`.
+	**/
+	@:optional var wait:EitherType<Bool, Float>;
+}
+
+/**
+	Options for `TestContext.waitFor()`.
+**/
+typedef WaitForOptions = {
+	/**
+		Milliseconds to wait after an unsuccessful `condition` before retrying. Default: `50`.
+	**/
+	@:optional var interval:Float;
+
+	/**
+		Poll timeout in milliseconds. Default: `1000`.
+	**/
+	@:optional var timeout:Float;
+}
+
+/**
+	Options for snapshot assertions on `TestContext.assert`.
+**/
+typedef SnapshotAssertionOptions = {
+	/**
+		Serializers applied in order; final result is coerced to a string.
+	**/
+	@:optional var serializers:Array<Dynamic->Dynamic>;
+}
+
+/**
+	Configuration options for `Test.run()`.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/test.html#runoptions
+**/
+typedef RunOptions = {
+	/**
+		Parallelism for test files. Number of processes, or `true`/`false`. Default: `false`.
+	**/
+	@:optional var concurrency:EitherType<Int, Bool>;
+
+	/**
+		Working directory used as the base path for resolving files. Default: `process.cwd()`.
+	**/
+	@:optional var cwd:String;
+
+	/**
+		List of files to run. Default: same as CLI.
+	**/
+	@:optional var files:Array<String>;
+
+	/**
+		Exit the process once all known tests finished even if the event loop remains active.
+		Default: `false`.
+	**/
+	@:optional var forceExit:Bool;
+
+	/**
+		Glob patterns to match test files. Cannot be used with `files`.
+	**/
+	@:optional var globPatterns:Array<String>;
+
+	/**
+		Inspector port for test child processes, or a function returning a port.
+	**/
+	@:optional var inspectPort:EitherType<Int, Void->Int>;
+
+	/**
+		Test isolation: `'process'` (default) or `'none'`.
+	**/
+	@:optional var isolation:String;
+
+	/**
+		If truthy, only run tests with the `only` option set.
+	**/
+	@:optional var only:Bool;
+
+	/**
+		Setup listeners on the returned `TestsStream` before tests run.
+	**/
+	@:optional var setup:TestsStream->Any;
+
+	/**
+		CLI flags passed to the `node` executable when spawning subprocesses.
+	**/
+	@:optional var execArgv:Array<String>;
+
+	/**
+		CLI flags passed to each test file when spawning subprocesses.
+	**/
+	@:optional var argv:Array<String>;
+
+	/**
+		Allows aborting an in-progress test execution.
+	**/
+	@:optional var signal:AbortSignal;
+
+	/**
+		Only run tests whose names match these pattern(s).
+	**/
+	@:optional var testNamePatterns:EitherType<String, EitherType<RegExp, Array<EitherType<String, RegExp>>>>;
+
+	/**
+		Skip tests whose names match these pattern(s).
+	**/
+	@:optional var testSkipPatterns:EitherType<String, EitherType<RegExp, Array<EitherType<String, RegExp>>>>;
+
+	/**
+		Fail the run after this many milliseconds. Default: `Infinity`.
+	**/
+	@:optional var timeout:Float;
+
+	/**
+		Whether to run in watch mode. Default: `false`.
+	**/
+	@:optional var watch:Bool;
+
+	/**
+		Shard configuration for horizontal parallelization.
+	**/
+	@:optional var shard:RunShardOptions;
+
+	/**
+		Randomize execution order for test files and queued tests. Default: `false`.
+	**/
+	@:optional var randomize:Bool;
+
+	/**
+		Seed for deterministic randomization (`0`..`4294967295`). Enables randomization.
+	**/
+	@:optional var randomSeed:Int;
+
+	/**
+		File path where the runner stores state for `--test-rerun-failures`.
+	**/
+	@:optional var rerunFailuresFilePath:String;
+
+	/**
+		Enable code coverage collection. Default: `false`.
+	**/
+	@:optional var coverage:Bool;
+
+	/**
+		Exclude files from coverage via glob(s).
+	**/
+	@:optional var coverageExcludeGlobs:EitherType<String, Array<String>>;
+
+	/**
+		Include files in coverage via glob(s).
+	**/
+	@:optional var coverageIncludeGlobs:EitherType<String, Array<String>>;
+
+	/**
+		Require a minimum percent of covered lines. Default: `0`.
+	**/
+	@:optional var lineCoverage:Float;
+
+	/**
+		Require a minimum percent of covered branches. Default: `0`.
+	**/
+	@:optional var branchCoverage:Float;
+
+	/**
+		Require a minimum percent of covered functions. Default: `0`.
+	**/
+	@:optional var functionCoverage:Float;
+
+	/**
+		Environment variables for test processes (not merged with `process.env`).
+		Incompatible with `isolation: 'none'`.
+	**/
+	@:optional var env:DynamicAccess<String>;
+}
+
+/**
+	Shard selection for `RunOptions.shard`.
+**/
+typedef RunShardOptions = {
+	/**
+		Shard index between `1` and `total` (required).
+	**/
+	var index:Int;
+
+	/**
+		Total number of shards (required).
+	**/
+	var total:Int;
+}
+
+/**
+	Module-level snapshot configuration (`Test.snapshot`).
+**/
+typedef Snapshot = {
+	/**
+		Customize the default serializers used by snapshot tests.
+		Default serialization is `JSON.stringify(value, null, 2)`.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#snapshotsetdefaultsnapshotserializersserializers
+	**/
+	function setDefaultSnapshotSerializers(serializers:Array<Dynamic->Dynamic>):Void;
+
+	/**
+		Customize where snapshot files are written.
+		`fn` receives the test file path (or `undefined` in the REPL) and must return a path string.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#snapshotsetresolvesnapshotpathfn
+	**/
+	function setResolveSnapshotPath(fn:Null<String>->String):Void;
+}
+
+/**
+	Module-level assert configuration (`Test.assert`).
+
+	Does not re-export `node:assert`; see `js.node.Assert` for assertions.
+	`TestContext.assert` exposes assert methods bound to the test context for planning.
+**/
+typedef TestAssert = {
+	/**
+		Defines a new assertion function available on `TestContext.assert`.
+		Overwrites an existing assertion with the same name.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#assertregistername-fn
+	**/
+	function register(name:String, fn:Function):Void;
+}

--- a/src/js/node/Test.hx
+++ b/src/js/node/Test.hx
@@ -26,10 +26,11 @@ import haxe.Constraints.Function;
 import haxe.DynamicAccess;
 import haxe.extern.EitherType;
 import js.html.AbortSignal;
+import js.node.test.ItFunction;
 import js.node.test.MockTracker;
 import js.node.test.SuiteContext;
+import js.node.test.SuiteFunction;
 import js.node.test.TestContext;
-import js.node.test.TestFunction;
 import js.node.test.TestsStream;
 #if haxe4
 import js.lib.Error;

--- a/src/js/node/Test.hx
+++ b/src/js/node/Test.hx
@@ -47,6 +47,10 @@ import js.RegExp;
 
 	This module is only available under the `node:` scheme.
 
+	These externs target **Node.js 24+ Active LTS**. Dual-LTS APIs such as
+	`expectFailure`, `run({ randomize })`, and `TestContext.workerId` are typed
+	without version gates; older LTS releases may not provide them at runtime.
+
 	@see https://nodejs.org/docs/latest-v24.x/api/test.html
 **/
 @:jsRequire("node:test")
@@ -97,9 +101,21 @@ extern class Test {
 	static function only(?name:String, ?options:TestOptions, ?fn:TestCallback):Promise<Void>;
 
 	/**
+		Shorthand for expecting a test to fail: `test(name, { expectFailure: true }[, fn])`.
+
+		Added in: v24.14.0
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#expecting-tests-to-fail
+	**/
+	@:overload(function(fn:TestCallback):Promise<Void> {})
+	@:overload(function(name:String, fn:TestCallback):Promise<Void> {})
+	@:overload(function(options:TestOptions, fn:TestCallback):Promise<Void> {})
+	static function expectFailure(?name:String, ?options:TestOptions, ?fn:TestCallback):Promise<Void>;
+
+	/**
 		Alias for `suite()`. Suites group related tests.
 
-		Supports `.skip`, `.todo`, and `.only` shorthands.
+		Supports `.skip`, `.todo`, `.only`, and `.expectFailure` shorthands.
 
 		@see https://nodejs.org/docs/latest-v24.x/api/test.html#describename-options-fn
 	**/
@@ -108,7 +124,7 @@ extern class Test {
 	/**
 		Creates a suite whose lifecycle is managed by the test runner.
 
-		Supports `.skip`, `.todo`, and `.only` shorthands.
+		Supports `.skip`, `.todo`, `.only`, and `.expectFailure` shorthands.
 
 		@see https://nodejs.org/docs/latest-v24.x/api/test.html#suitename-options-fn
 	**/

--- a/src/js/node/test/ItFunction.hx
+++ b/src/js/node/test/ItFunction.hx
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.test;
+
+import js.node.Test.TestCallback;
+import js.node.Test.TestOptions;
+#if haxe4
+import js.lib.Promise;
+#else
+import js.Promise;
+#end
+
+/**
+	Callable test entry used by `it`, with suite-style shorthands plus `expectFailure`.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/test.html#itname-options-fn
+**/
+extern class ItFunction {
+	/**
+		Create a test (alias of `test()`).
+	**/
+	@:selfCall
+	@:overload(function(fn:TestCallback):Promise<Void> {})
+	@:overload(function(name:String, fn:TestCallback):Promise<Void> {})
+	@:overload(function(options:TestOptions, fn:TestCallback):Promise<Void> {})
+	function call(?name:String, ?options:TestOptions, ?fn:TestCallback):Promise<Void>;
+
+	/**
+		Shorthand for skipping a test.
+	**/
+	@:overload(function(fn:TestCallback):Promise<Void> {})
+	@:overload(function(name:String, fn:TestCallback):Promise<Void> {})
+	@:overload(function(options:TestOptions, fn:TestCallback):Promise<Void> {})
+	function skip(?name:String, ?options:TestOptions, ?fn:TestCallback):Promise<Void>;
+
+	/**
+		Shorthand for marking a test as `TODO`.
+	**/
+	@:overload(function(fn:TestCallback):Promise<Void> {})
+	@:overload(function(name:String, fn:TestCallback):Promise<Void> {})
+	@:overload(function(options:TestOptions, fn:TestCallback):Promise<Void> {})
+	function todo(?name:String, ?options:TestOptions, ?fn:TestCallback):Promise<Void>;
+
+	/**
+		Shorthand for marking a test as `only`.
+	**/
+	@:overload(function(fn:TestCallback):Promise<Void> {})
+	@:overload(function(name:String, fn:TestCallback):Promise<Void> {})
+	@:overload(function(options:TestOptions, fn:TestCallback):Promise<Void> {})
+	function only(?name:String, ?options:TestOptions, ?fn:TestCallback):Promise<Void>;
+
+	/**
+		Shorthand for expecting a test to fail (`expectFailure: true`).
+
+		Added in: v24.14.0
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#expecting-tests-to-fail
+	**/
+	@:overload(function(fn:TestCallback):Promise<Void> {})
+	@:overload(function(name:String, fn:TestCallback):Promise<Void> {})
+	@:overload(function(options:TestOptions, fn:TestCallback):Promise<Void> {})
+	function expectFailure(?name:String, ?options:TestOptions, ?fn:TestCallback):Promise<Void>;
+}

--- a/src/js/node/test/MockTimers.hx
+++ b/src/js/node/test/MockTimers.hx
@@ -23,11 +23,6 @@
 package js.node.test;
 
 import haxe.extern.EitherType;
-#if haxe4
-import js.lib.Date as JsDate;
-#else
-import js.Date as JsDate;
-#end
 
 /**
 	Timer / Date APIs that can be mocked via `MockTimers.enable()`.
@@ -51,8 +46,8 @@ typedef MockTimersEnableOptions = {
 	/**
 		Initial time (ms) or `Date` used as the value for `Date.now()`. Default: `0`.
 	**/
-	@:optional var now:EitherType<Float, JsDate>;
-};
+	@:optional var now:EitherType<Float, Dynamic>;
+}
 
 /**
 	Mocking timers simulates and controls `setInterval` / `setTimeout` / `setImmediate`
@@ -63,26 +58,36 @@ typedef MockTimersEnableOptions = {
 extern class MockTimers {
 	/**
 		Enable timer mocking for the specified timers.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#timersenableenableoptions
 	**/
 	function enable(?enableOptions:MockTimersEnableOptions):Void;
 
 	/**
 		Restore default behavior of all mocks created by this instance.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#timersreset
 	**/
 	function reset():Void;
 
 	/**
 		Advance time for all mocked timers by `milliseconds` (default: `1`).
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#timerstickmilliseconds
 	**/
 	function tick(?milliseconds:Float):Void;
 
 	/**
 		Trigger all pending mocked timers immediately.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#timersrunall
 	**/
 	function runAll():Void;
 
 	/**
 		Set the current Unix timestamp used as reference for mocked `Date` objects.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#timerssettimemilliseconds
 	**/
 	function setTime(milliseconds:Float):Void;
 }

--- a/src/js/node/test/MockTimers.hx
+++ b/src/js/node/test/MockTimers.hx
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.test;
+
+import haxe.extern.EitherType;
+#if haxe4
+import js.lib.Date as JsDate;
+#else
+import js.Date as JsDate;
+#end
+
+/**
+	Timer / Date APIs that can be mocked via `MockTimers.enable()`.
+**/
+enum abstract MockTimerApi(String) from String to String {
+	var SetInterval = "setInterval";
+	var SetTimeout = "setTimeout";
+	var SetImmediate = "setImmediate";
+	var Date = "Date";
+}
+
+/**
+	Options for `MockTimers.enable()`.
+**/
+typedef MockTimersEnableOptions = {
+	/**
+		Timers to mock. Default mocks all time-related APIs including `Date`.
+	**/
+	@:optional var apis:Array<MockTimerApi>;
+
+	/**
+		Initial time (ms) or `Date` used as the value for `Date.now()`. Default: `0`.
+	**/
+	@:optional var now:EitherType<Float, JsDate>;
+};
+
+/**
+	Mocking timers simulates and controls `setInterval` / `setTimeout` / `setImmediate`
+	and optionally the `Date` object without waiting for real time.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/test.html#class-mocktimers
+**/
+extern class MockTimers {
+	/**
+		Enable timer mocking for the specified timers.
+	**/
+	function enable(?enableOptions:MockTimersEnableOptions):Void;
+
+	/**
+		Restore default behavior of all mocks created by this instance.
+	**/
+	function reset():Void;
+
+	/**
+		Advance time for all mocked timers by `milliseconds` (default: `1`).
+	**/
+	function tick(?milliseconds:Float):Void;
+
+	/**
+		Trigger all pending mocked timers immediately.
+	**/
+	function runAll():Void;
+
+	/**
+		Set the current Unix timestamp used as reference for mocked `Date` objects.
+	**/
+	function setTime(milliseconds:Float):Void;
+}

--- a/src/js/node/test/MockTimers.hx
+++ b/src/js/node/test/MockTimers.hx
@@ -23,6 +23,11 @@
 package js.node.test;
 
 import haxe.extern.EitherType;
+#if haxe4
+import js.lib.Date as JsDate;
+#else
+import js.Date as JsDate;
+#end
 
 /**
 	Timer / Date APIs that can be mocked via `MockTimers.enable()`.
@@ -44,9 +49,11 @@ typedef MockTimersEnableOptions = {
 	@:optional var apis:Array<MockTimerApi>;
 
 	/**
-		Initial time (ms) or `Date` used as the value for `Date.now()`. Default: `0`.
+		Initial epoch as a Unix timestamp (ms) or a JS `Date`. Default: `0`.
+
+		Matches Node's `number | Date`.
 	**/
-	@:optional var now:EitherType<Float, Dynamic>;
+	@:optional var now:EitherType<Float, JsDate>;
 }
 
 /**

--- a/src/js/node/test/MockTracker.hx
+++ b/src/js/node/test/MockTracker.hx
@@ -24,142 +24,209 @@ package js.node.test;
 
 import haxe.Constraints.Function;
 import haxe.extern.EitherType;
-import haxe.extern.Rest;
 #if haxe4
 import js.lib.Error;
+import js.lib.Symbol;
 #else
 import js.Error;
 #end
 
 /**
-	A single recorded call to a mocked function.
+	Manages mocking functionality.
+
+	Obtained from `Test.mock` or `TestContext.mock`.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/test.html#class-mocktracker
 **/
-typedef MockFunctionCall = {
+extern class MockTracker {
 	/**
-		Arguments passed to the mock function.
+		Create a mock function.
+
+		The returned function has a `mock` property of type `MockFunctionContext`.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#mockfnoriginal-implementation-options
 	**/
-	var arguments:Array<Dynamic>;
+	@:overload(function(?original:Function, ?options:MockFunctionOptions):MockedFunction {})
+	function fn(?original:Function, ?implementation:Function, ?options:MockFunctionOptions):MockedFunction;
 
 	/**
-		If the mocked function threw, this property contains the thrown value.
+		Syntax sugar for `method` with `options.getter` set to `true`.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#mockgetterobject-methodname-implementation-options
 	**/
-	@:optional var error:Dynamic;
+	#if haxe4
+	@:overload(function(object:{}, methodName:EitherType<String, Symbol>, ?options:MockMethodOptions):MockedFunction {})
+	function getter(object:{}, methodName:EitherType<String, Symbol>, ?implementation:Function, ?options:MockMethodOptions):MockedFunction;
+	#else
+	@:overload(function(object:{}, methodName:String, ?options:MockMethodOptions):MockedFunction {})
+	function getter(object:{}, methodName:String, ?implementation:Function, ?options:MockMethodOptions):MockedFunction;
+	#end
 
 	/**
-		Value returned by the mocked function.
+		Create a mock on an existing object method.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#mockmethodobject-methodname-implementation-options
 	**/
-	@:optional var result:Dynamic;
+	#if haxe4
+	@:overload(function(object:{}, methodName:EitherType<String, Symbol>, ?options:MockMethodOptions):MockedFunction {})
+	function method(object:{}, methodName:EitherType<String, Symbol>, ?implementation:Function, ?options:MockMethodOptions):MockedFunction;
+	#else
+	@:overload(function(object:{}, methodName:String, ?options:MockMethodOptions):MockedFunction {})
+	function method(object:{}, methodName:String, ?implementation:Function, ?options:MockMethodOptions):MockedFunction;
+	#end
 
 	/**
-		Error whose stack can be used to determine the callsite.
+		Mock exports of an ESM, CommonJS, JSON, or builtin module.
+
+		Requires `--experimental-test-module-mocks`. Stability: 1.0.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#mockmodulespecifier-options
 	**/
-	var stack:Error;
+	function module(specifier:String, ?options:MockModuleOptions):MockModuleContext;
 
 	/**
-		If the mocked function is a constructor, the class being constructed.
+		Mock a property value on an object.
+
+		Added in: v24.3.0
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#mockpropertyobject-propertyname-value
 	**/
-	@:optional var target:Dynamic;
+	#if haxe4
+	function property(object:{}, propertyName:EitherType<String, Symbol>, ?value:Dynamic):MockedProperty;
+	#else
+	function property(object:{}, propertyName:String, ?value:Dynamic):MockedProperty;
+	#end
 
 	/**
-		The mocked function's `this` value.
+		Restore default behavior of all mocks created by this tracker and
+		disassociate them from the tracker.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#mockreset
 	**/
-	@:native("this")
-	var thisValue:Dynamic;
-};
+	function reset():Void;
+
+	/**
+		Restore default behavior of all mocks without disassociating them.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#mockrestoreall
+	**/
+	function restoreAll():Void;
+
+	/**
+		Syntax sugar for `method` with `options.setter` set to `true`.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#mocksetterobject-methodname-implementation-options
+	**/
+	#if haxe4
+	@:overload(function(object:{}, methodName:EitherType<String, Symbol>, ?options:MockMethodOptions):MockedFunction {})
+	function setter(object:{}, methodName:EitherType<String, Symbol>, ?implementation:Function, ?options:MockMethodOptions):MockedFunction;
+	#else
+	@:overload(function(object:{}, methodName:String, ?options:MockMethodOptions):MockedFunction {})
+	function setter(object:{}, methodName:String, ?implementation:Function, ?options:MockMethodOptions):MockedFunction;
+	#end
+
+	/**
+		Mock timers APIs (`setTimeout`, `setInterval`, `setImmediate`, `Date`, …).
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#class-mocktimers
+	**/
+	var timers(default, null):MockTimers;
+}
 
 /**
-	Options for `MockTracker.fn` / `MockTracker.method`.
+	Options for `MockTracker.fn`.
 **/
 typedef MockFunctionOptions = {
 	/**
-		Number of times the mock uses `implementation` before restoring `original`.
-		Default: `Infinity`.
+		How many times `implementation` is used before restoring `original`.
+		Must be an integer greater than zero. Default: `Infinity`.
 	**/
-	@:optional var times:Float;
-};
+	@:optional var times:Int;
+}
 
 /**
-	Options for `MockTracker.method` when mocking getters/setters.
+	Options for `MockTracker.method` / `getter` / `setter`.
 **/
 typedef MockMethodOptions = {
+	> MockFunctionOptions,
+
 	/**
-		If `true`, `object[methodName]` is treated as a getter.
+		Treat the member as a getter. Cannot be combined with `setter`. Default: `false`.
 	**/
 	@:optional var getter:Bool;
 
 	/**
-		If `true`, `object[methodName]` is treated as a setter.
+		Treat the member as a setter. Cannot be combined with `getter`. Default: `false`.
 	**/
 	@:optional var setter:Bool;
-
-	/**
-		Number of times the mock uses `implementation` before restoring the original.
-		Default: `Infinity`.
-	**/
-	@:optional var times:Float;
-};
+}
 
 /**
 	Options for `MockTracker.module`.
 **/
 typedef MockModuleOptions = {
 	/**
-		If `false`, each `require`/`import` generates a new mock module.
-		If `true`, subsequent calls return the same mock. Default: `false`.
+		If `false`, each import/require gets a new mock. If `true`, the mock is cached. Default: `false`.
 	**/
 	@:optional var cache:Bool;
 
 	/**
-		Mocked exports. `default` is used as the mocked module's default export;
-		other own enumerable properties are named exports.
+		Mocked exports object. Prefer this over deprecated `defaultExport` / `namedExports`.
 	**/
 	@:optional var exports:Dynamic;
 
 	/**
-		@deprecated Prefer `exports.default`.
+		Deprecated. Prefer `exports.default`.
 	**/
+	@:deprecated("Prefer options.exports.default")
 	@:optional var defaultExport:Dynamic;
 
 	/**
-		@deprecated Prefer `exports`.
+		Deprecated. Prefer `options.exports`.
 	**/
+	@:deprecated("Prefer options.exports")
 	@:optional var namedExports:Dynamic;
-};
-
-/**
-	Mocked function returned by `MockTracker.fn` / `MockTracker.method`.
-**/
-extern class MockedFunction {
-	@:selfCall
-	function call(args:Rest<Dynamic>):Dynamic;
-
-	/**
-		Context used to inspect or manipulate the mock.
-	**/
-	var mock(default, never):MockFunctionContext;
 }
 
 /**
-	Proxy returned by `MockTracker.property`.
+	A mocked function returned by `fn` / `method` / `getter` / `setter`.
+	Callable; inspect or reconfigure via `mock`.
 **/
-typedef MockedProperty = {
+@:callable
+abstract MockedFunction(Dynamic) from Dynamic to Dynamic {
 	/**
-		Context used to inspect or manipulate the mocked property.
+		`MockFunctionContext` for inspecting and changing mock behavior.
 	**/
-	var mock:MockPropertyContext;
-};
+	public var mock(get, never):MockFunctionContext;
+
+	inline function get_mock():MockFunctionContext
+		return this.mock;
+}
 
 /**
-	The `MockFunctionContext` class is used to inspect or manipulate the behavior
-	of mocks created via the `MockTracker` APIs.
+	A mocked property proxy returned by `MockTracker.property`.
+**/
+@:forward
+abstract MockedProperty(Dynamic) from Dynamic to Dynamic {
+	/**
+		`MockPropertyContext` for inspecting and changing mock behavior.
+	**/
+	public var mock(get, never):MockPropertyContext;
+
+	inline function get_mock():MockPropertyContext
+		return this.mock;
+}
+
+/**
+	Inspect or manipulate mocks created via `MockTracker` function APIs.
 
 	@see https://nodejs.org/docs/latest-v24.x/api/test.html#class-mockfunctioncontext
 **/
 extern class MockFunctionContext {
 	/**
-		Copy of the internal array used to track calls to the mock.
+		Copy of the internal call-tracking array.
 	**/
-	var calls(default, never):Array<MockFunctionCall>;
+	var calls(default, null):Array<MockFunctionCall>;
 
 	/**
 		Number of times this mock has been invoked.
@@ -167,12 +234,12 @@ extern class MockFunctionContext {
 	function callCount():Int;
 
 	/**
-		Change the behavior of an existing mock.
+		Change the mock's implementation.
 	**/
 	function mockImplementation(implementation:Function):Void;
 
 	/**
-		Change the behavior of an existing mock for a single invocation.
+		Change the mock's implementation for a single invocation.
 	**/
 	function mockImplementationOnce(implementation:Function, ?onCall:Int):Void;
 
@@ -182,58 +249,71 @@ extern class MockFunctionContext {
 	function resetCalls():Void;
 
 	/**
-		Reset the implementation of the mock function to its original behavior.
+		Reset the mock implementation to its original behavior.
 	**/
 	function restore():Void;
 }
 
 /**
-	The `MockModuleContext` class is used to manipulate module mocks.
+	One recorded invocation of a mocked function.
+**/
+typedef MockFunctionCall = {
+	/**
+		Arguments passed to the mock.
+	**/
+	var arguments:Array<Dynamic>;
 
-	Stability: 1.0 - Early development
+	/**
+		Thrown value, if any.
+	**/
+	@:optional var error:Dynamic;
+
+	/**
+		Return value of the mock.
+	**/
+	var result:Dynamic;
+
+	/**
+		Error whose stack identifies the callsite.
+	**/
+	var stack:Error;
+
+	/**
+		Constructed class when the mock was used as a constructor.
+	**/
+	@:optional var target:Function;
+
+	/**
+		`this` value for the invocation.
+	**/
+	@:native("this") var this_:Dynamic;
+}
+
+/**
+	Manipulate module mocks created via `MockTracker.module`.
 
 	@see https://nodejs.org/docs/latest-v24.x/api/test.html#class-mockmodulecontext
 **/
 extern class MockModuleContext {
 	/**
-		Reset the implementation of the mock module.
+		Reset the mock module implementation.
 	**/
 	function restore():Void;
 }
 
 /**
-	A single recorded access to a mocked property.
-**/
-typedef MockPropertyAccess = {
-	/**
-		Either `"get"` or `"set"`.
-	**/
-	var type:String;
-
-	/**
-		Value that was read or written.
-	**/
-	var value:Dynamic;
-
-	/**
-		Error whose stack can be used to determine the callsite.
-	**/
-	var stack:Error;
-};
-
-/**
-	The `MockPropertyContext` class is used to inspect or manipulate property mocks.
+	Inspect or manipulate property mocks created via `MockTracker.property`.
 
 	@see https://nodejs.org/docs/latest-v24.x/api/test.html#class-mockpropertycontext
 **/
 extern class MockPropertyContext {
 	/**
-		Copy of the internal array used to track accesses to the mocked property.
+		Copy of the internal access-tracking array.
 	**/
-	var accesses(default, never):Array<MockPropertyAccess>;
+	var accesses(default, null):Array<MockPropertyAccess>;
 
 	/**
-		Number of times the property was accessed (read or written).
+		Number of times the property was accessed (get or set).
 	**/
 	function accessCount():Int;
 
@@ -243,7 +323,7 @@ extern class MockPropertyContext {
 	function mockImplementation(value:Dynamic):Void;
 
 	/**
-		Change the mocked property value for a single access.
+		Change the mocked value for a single access.
 	**/
 	function mockImplementationOnce(value:Dynamic, ?onAccess:Int):Void;
 
@@ -253,68 +333,27 @@ extern class MockPropertyContext {
 	function resetAccesses():Void;
 
 	/**
-		Reset the implementation of the mock property to its original behavior.
+		Reset the mock property to its original behavior.
 	**/
 	function restore():Void;
 }
 
 /**
-	The `MockTracker` class manages mocking functionality.
-
-	The test runner module provides a top-level `mock` export which is a `MockTracker`
-	instance. Each test also provides its own instance via `TestContext.mock`.
-
-	@see https://nodejs.org/docs/latest-v24.x/api/test.html#class-mocktracker
+	One recorded get/set of a mocked property.
 **/
-extern class MockTracker {
+typedef MockPropertyAccess = {
 	/**
-		Create a mock function.
+		Either `'get'` or `'set'`.
 	**/
-	@:overload(function(?original:Function, ?options:MockFunctionOptions):MockedFunction {})
-	function fn(?original:Function, ?implementation:Function, ?options:MockFunctionOptions):MockedFunction;
+	var type:String;
 
 	/**
-		Syntax sugar for `method` with `options.getter` set to `true`.
+		Value that was read or written.
 	**/
-	@:overload(function(object:Dynamic, methodName:EitherType<String, Dynamic>, ?options:MockFunctionOptions):MockedFunction {})
-	function getter(object:Dynamic, methodName:EitherType<String, Dynamic>, ?implementation:Function, ?options:MockFunctionOptions):MockedFunction;
+	var value:Dynamic;
 
 	/**
-		Create a mock on an existing object method.
+		Error whose stack identifies the callsite.
 	**/
-	@:overload(function(object:Dynamic, methodName:EitherType<String, Dynamic>, ?options:MockMethodOptions):MockedFunction {})
-	function method(object:Dynamic, methodName:EitherType<String, Dynamic>, ?implementation:Function, ?options:MockMethodOptions):MockedFunction;
-
-	/**
-		Mock the exports of a module.
-
-		Requires `--experimental-test-module-mocks`.
-	**/
-	function module(specifier:EitherType<String, Dynamic>, ?options:MockModuleOptions):MockModuleContext;
-
-	/**
-		Create a mock for a property value on an object.
-	**/
-	function property(object:Dynamic, propertyName:EitherType<String, Dynamic>, ?value:Dynamic):MockedProperty;
-
-	/**
-		Restore default behavior of all mocks created by this tracker and disassociate them.
-	**/
-	function reset():Void;
-
-	/**
-		Restore default behavior of all mocks without disassociating them from this tracker.
-	**/
-	function restoreAll():Void;
-
-	/**
-		Syntax sugar for `method` with `options.setter` set to `true`.
-	**/
-	@:overload(function(object:Dynamic, methodName:EitherType<String, Dynamic>, ?options:MockFunctionOptions):MockedFunction {})
-	function setter(object:Dynamic, methodName:EitherType<String, Dynamic>, ?implementation:Function, ?options:MockFunctionOptions):MockedFunction;
-
-	/**
-		`MockTimers` instance associated with this tracker.
-	**/
-	var timers(default, never):MockTimers;
+	var stack:Error;
 }

--- a/src/js/node/test/MockTracker.hx
+++ b/src/js/node/test/MockTracker.hx
@@ -1,0 +1,320 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.test;
+
+import haxe.Constraints.Function;
+import haxe.extern.EitherType;
+import haxe.extern.Rest;
+#if haxe4
+import js.lib.Error;
+#else
+import js.Error;
+#end
+
+/**
+	A single recorded call to a mocked function.
+**/
+typedef MockFunctionCall = {
+	/**
+		Arguments passed to the mock function.
+	**/
+	var arguments:Array<Dynamic>;
+
+	/**
+		If the mocked function threw, this property contains the thrown value.
+	**/
+	@:optional var error:Dynamic;
+
+	/**
+		Value returned by the mocked function.
+	**/
+	@:optional var result:Dynamic;
+
+	/**
+		Error whose stack can be used to determine the callsite.
+	**/
+	var stack:Error;
+
+	/**
+		If the mocked function is a constructor, the class being constructed.
+	**/
+	@:optional var target:Dynamic;
+
+	/**
+		The mocked function's `this` value.
+	**/
+	@:native("this")
+	var thisValue:Dynamic;
+};
+
+/**
+	Options for `MockTracker.fn` / `MockTracker.method`.
+**/
+typedef MockFunctionOptions = {
+	/**
+		Number of times the mock uses `implementation` before restoring `original`.
+		Default: `Infinity`.
+	**/
+	@:optional var times:Float;
+};
+
+/**
+	Options for `MockTracker.method` when mocking getters/setters.
+**/
+typedef MockMethodOptions = {
+	/**
+		If `true`, `object[methodName]` is treated as a getter.
+	**/
+	@:optional var getter:Bool;
+
+	/**
+		If `true`, `object[methodName]` is treated as a setter.
+	**/
+	@:optional var setter:Bool;
+
+	/**
+		Number of times the mock uses `implementation` before restoring the original.
+		Default: `Infinity`.
+	**/
+	@:optional var times:Float;
+};
+
+/**
+	Options for `MockTracker.module`.
+**/
+typedef MockModuleOptions = {
+	/**
+		If `false`, each `require`/`import` generates a new mock module.
+		If `true`, subsequent calls return the same mock. Default: `false`.
+	**/
+	@:optional var cache:Bool;
+
+	/**
+		Mocked exports. `default` is used as the mocked module's default export;
+		other own enumerable properties are named exports.
+	**/
+	@:optional var exports:Dynamic;
+
+	/**
+		@deprecated Prefer `exports.default`.
+	**/
+	@:optional var defaultExport:Dynamic;
+
+	/**
+		@deprecated Prefer `exports`.
+	**/
+	@:optional var namedExports:Dynamic;
+};
+
+/**
+	Mocked function returned by `MockTracker.fn` / `MockTracker.method`.
+**/
+extern class MockedFunction {
+	@:selfCall
+	function call(args:Rest<Dynamic>):Dynamic;
+
+	/**
+		Context used to inspect or manipulate the mock.
+	**/
+	var mock(default, never):MockFunctionContext;
+}
+
+/**
+	Proxy returned by `MockTracker.property`.
+**/
+typedef MockedProperty = {
+	/**
+		Context used to inspect or manipulate the mocked property.
+	**/
+	var mock:MockPropertyContext;
+};
+
+/**
+	The `MockFunctionContext` class is used to inspect or manipulate the behavior
+	of mocks created via the `MockTracker` APIs.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/test.html#class-mockfunctioncontext
+**/
+extern class MockFunctionContext {
+	/**
+		Copy of the internal array used to track calls to the mock.
+	**/
+	var calls(default, never):Array<MockFunctionCall>;
+
+	/**
+		Number of times this mock has been invoked.
+	**/
+	function callCount():Int;
+
+	/**
+		Change the behavior of an existing mock.
+	**/
+	function mockImplementation(implementation:Function):Void;
+
+	/**
+		Change the behavior of an existing mock for a single invocation.
+	**/
+	function mockImplementationOnce(implementation:Function, ?onCall:Int):Void;
+
+	/**
+		Reset the call history of the mock function.
+	**/
+	function resetCalls():Void;
+
+	/**
+		Reset the implementation of the mock function to its original behavior.
+	**/
+	function restore():Void;
+}
+
+/**
+	The `MockModuleContext` class is used to manipulate module mocks.
+
+	Stability: 1.0 - Early development
+
+	@see https://nodejs.org/docs/latest-v24.x/api/test.html#class-mockmodulecontext
+**/
+extern class MockModuleContext {
+	/**
+		Reset the implementation of the mock module.
+	**/
+	function restore():Void;
+}
+
+/**
+	A single recorded access to a mocked property.
+**/
+typedef MockPropertyAccess = {
+	/**
+		Either `"get"` or `"set"`.
+	**/
+	var type:String;
+
+	/**
+		Value that was read or written.
+	**/
+	var value:Dynamic;
+
+	/**
+		Error whose stack can be used to determine the callsite.
+	**/
+	var stack:Error;
+};
+
+/**
+	The `MockPropertyContext` class is used to inspect or manipulate property mocks.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/test.html#class-mockpropertycontext
+**/
+extern class MockPropertyContext {
+	/**
+		Copy of the internal array used to track accesses to the mocked property.
+	**/
+	var accesses(default, never):Array<MockPropertyAccess>;
+
+	/**
+		Number of times the property was accessed (read or written).
+	**/
+	function accessCount():Int;
+
+	/**
+		Change the value returned by the mocked property getter.
+	**/
+	function mockImplementation(value:Dynamic):Void;
+
+	/**
+		Change the mocked property value for a single access.
+	**/
+	function mockImplementationOnce(value:Dynamic, ?onAccess:Int):Void;
+
+	/**
+		Reset the access history of the mocked property.
+	**/
+	function resetAccesses():Void;
+
+	/**
+		Reset the implementation of the mock property to its original behavior.
+	**/
+	function restore():Void;
+}
+
+/**
+	The `MockTracker` class manages mocking functionality.
+
+	The test runner module provides a top-level `mock` export which is a `MockTracker`
+	instance. Each test also provides its own instance via `TestContext.mock`.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/test.html#class-mocktracker
+**/
+extern class MockTracker {
+	/**
+		Create a mock function.
+	**/
+	@:overload(function(?original:Function, ?options:MockFunctionOptions):MockedFunction {})
+	function fn(?original:Function, ?implementation:Function, ?options:MockFunctionOptions):MockedFunction;
+
+	/**
+		Syntax sugar for `method` with `options.getter` set to `true`.
+	**/
+	@:overload(function(object:Dynamic, methodName:EitherType<String, Dynamic>, ?options:MockFunctionOptions):MockedFunction {})
+	function getter(object:Dynamic, methodName:EitherType<String, Dynamic>, ?implementation:Function, ?options:MockFunctionOptions):MockedFunction;
+
+	/**
+		Create a mock on an existing object method.
+	**/
+	@:overload(function(object:Dynamic, methodName:EitherType<String, Dynamic>, ?options:MockMethodOptions):MockedFunction {})
+	function method(object:Dynamic, methodName:EitherType<String, Dynamic>, ?implementation:Function, ?options:MockMethodOptions):MockedFunction;
+
+	/**
+		Mock the exports of a module.
+
+		Requires `--experimental-test-module-mocks`.
+	**/
+	function module(specifier:EitherType<String, Dynamic>, ?options:MockModuleOptions):MockModuleContext;
+
+	/**
+		Create a mock for a property value on an object.
+	**/
+	function property(object:Dynamic, propertyName:EitherType<String, Dynamic>, ?value:Dynamic):MockedProperty;
+
+	/**
+		Restore default behavior of all mocks created by this tracker and disassociate them.
+	**/
+	function reset():Void;
+
+	/**
+		Restore default behavior of all mocks without disassociating them from this tracker.
+	**/
+	function restoreAll():Void;
+
+	/**
+		Syntax sugar for `method` with `options.setter` set to `true`.
+	**/
+	@:overload(function(object:Dynamic, methodName:EitherType<String, Dynamic>, ?options:MockFunctionOptions):MockedFunction {})
+	function setter(object:Dynamic, methodName:EitherType<String, Dynamic>, ?implementation:Function, ?options:MockFunctionOptions):MockedFunction;
+
+	/**
+		`MockTimers` instance associated with this tracker.
+	**/
+	var timers(default, never):MockTimers;
+}

--- a/src/js/node/test/SuiteContext.hx
+++ b/src/js/node/test/SuiteContext.hx
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.test;
+
+/**
+	An instance of `SuiteContext` is passed to each suite function in order to
+	interact with the test runner. The constructor is not exposed as part of the API.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/test.html#class-suitecontext
+**/
+extern class SuiteContext {
+	/**
+		Absolute path of the test file that created the current suite.
+	**/
+	var filePath(default, never):Null<String>;
+
+	/**
+		Name of the suite and each of its ancestors, separated by `>`.
+	**/
+	var fullName(default, never):String;
+
+	/**
+		Name of the suite.
+	**/
+	var name(default, never):String;
+
+	/**
+		AbortSignal that can be used to abort test subtasks when the suite is aborted.
+	**/
+	var signal(default, never):Dynamic;
+
+	/**
+		Whether the suite and all of its subtests have passed.
+	**/
+	var passed(default, never):Bool;
+
+	/**
+		Zero-based attempt number of the suite (useful with `--test-rerun-failures`).
+	**/
+	var attempt(default, never):Int;
+
+	/**
+		Output a diagnostic message about the current suite or its tests.
+	**/
+	function diagnostic(message:String):Void;
+}

--- a/src/js/node/test/SuiteContext.hx
+++ b/src/js/node/test/SuiteContext.hx
@@ -22,45 +22,62 @@
 
 package js.node.test;
 
+import js.html.AbortSignal;
+
 /**
-	An instance of `SuiteContext` is passed to each suite function in order to
-	interact with the test runner. The constructor is not exposed as part of the API.
+	Passed to each suite function to interact with the test runner.
+
+	The `SuiteContext` constructor is not part of the public API.
 
 	@see https://nodejs.org/docs/latest-v24.x/api/test.html#class-suitecontext
 **/
 extern class SuiteContext {
 	/**
 		Absolute path of the test file that created the current suite.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#contextfilepath-1
 	**/
-	var filePath(default, never):Null<String>;
+	var filePath(default, null):Null<String>;
 
 	/**
 		Name of the suite and each of its ancestors, separated by `>`.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#contextfullname-1
 	**/
-	var fullName(default, never):String;
+	var fullName(default, null):String;
 
 	/**
 		Name of the suite.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#contextname-1
 	**/
-	var name(default, never):String;
+	var name(default, null):String;
 
 	/**
-		AbortSignal that can be used to abort test subtasks when the suite is aborted.
+		Abort signal for cancelling suite subtasks when the suite is aborted.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#contextsignal-1
 	**/
-	var signal(default, never):Dynamic;
+	var signal(default, null):AbortSignal;
 
 	/**
 		Whether the suite and all of its subtests have passed.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#contextpassed-1
 	**/
-	var passed(default, never):Bool;
+	var passed(default, null):Bool;
 
 	/**
-		Zero-based attempt number of the suite (useful with `--test-rerun-failures`).
+		Zero-based attempt number when using `--test-rerun-failures`.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#contextattempt-1
 	**/
-	var attempt(default, never):Int;
+	var attempt(default, null):Int;
 
 	/**
-		Output a diagnostic message about the current suite or its tests.
+		Output a diagnostic message for the suite.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#contextdiagnosticmessage-1
 	**/
 	function diagnostic(message:String):Void;
 }

--- a/src/js/node/test/SuiteFunction.hx
+++ b/src/js/node/test/SuiteFunction.hx
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.test;
+
+import js.node.Test.SuiteCallback;
+import js.node.Test.TestOptions;
+#if haxe4
+import js.lib.Promise;
+#else
+import js.Promise;
+#end
+
+/**
+	Callable suite entry (`describe` / `suite`) with `.skip`, `.todo`, and `.only` shorthands.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/test.html#suitename-options-fn
+**/
+extern class SuiteFunction {
+	/**
+		Create a suite.
+	**/
+	@:selfCall
+	@:overload(function(fn:SuiteCallback):Promise<Void> {})
+	@:overload(function(name:String, fn:SuiteCallback):Promise<Void> {})
+	@:overload(function(options:TestOptions, fn:SuiteCallback):Promise<Void> {})
+	function call(?name:String, ?options:TestOptions, ?fn:SuiteCallback):Promise<Void>;
+
+	/**
+		Shorthand for skipping a suite.
+	**/
+	@:overload(function(fn:SuiteCallback):Promise<Void> {})
+	@:overload(function(name:String, fn:SuiteCallback):Promise<Void> {})
+	@:overload(function(options:TestOptions, fn:SuiteCallback):Promise<Void> {})
+	function skip(?name:String, ?options:TestOptions, ?fn:SuiteCallback):Promise<Void>;
+
+	/**
+		Shorthand for marking a suite as `TODO`.
+	**/
+	@:overload(function(fn:SuiteCallback):Promise<Void> {})
+	@:overload(function(name:String, fn:SuiteCallback):Promise<Void> {})
+	@:overload(function(options:TestOptions, fn:SuiteCallback):Promise<Void> {})
+	function todo(?name:String, ?options:TestOptions, ?fn:SuiteCallback):Promise<Void>;
+
+	/**
+		Shorthand for marking a suite as `only`.
+	**/
+	@:overload(function(fn:SuiteCallback):Promise<Void> {})
+	@:overload(function(name:String, fn:SuiteCallback):Promise<Void> {})
+	@:overload(function(options:TestOptions, fn:SuiteCallback):Promise<Void> {})
+	function only(?name:String, ?options:TestOptions, ?fn:SuiteCallback):Promise<Void>;
+}

--- a/src/js/node/test/SuiteFunction.hx
+++ b/src/js/node/test/SuiteFunction.hx
@@ -31,7 +31,8 @@ import js.Promise;
 #end
 
 /**
-	Callable suite entry (`describe` / `suite`) with `.skip`, `.todo`, and `.only` shorthands.
+	Callable suite entry (`describe` / `suite`) with `.skip`, `.todo`, `.only`,
+	and `.expectFailure` shorthands.
 
 	@see https://nodejs.org/docs/latest-v24.x/api/test.html#suitename-options-fn
 **/
@@ -68,4 +69,16 @@ extern class SuiteFunction {
 	@:overload(function(name:String, fn:SuiteCallback):Promise<Void> {})
 	@:overload(function(options:TestOptions, fn:SuiteCallback):Promise<Void> {})
 	function only(?name:String, ?options:TestOptions, ?fn:SuiteCallback):Promise<Void>;
+
+	/**
+		Shorthand for expecting a suite to fail (`expectFailure: true`).
+
+		Added in: v24.14.0
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#expecting-tests-to-fail
+	**/
+	@:overload(function(fn:SuiteCallback):Promise<Void> {})
+	@:overload(function(name:String, fn:SuiteCallback):Promise<Void> {})
+	@:overload(function(options:TestOptions, fn:SuiteCallback):Promise<Void> {})
+	function expectFailure(?name:String, ?options:TestOptions, ?fn:SuiteCallback):Promise<Void>;
 }

--- a/src/js/node/test/TestContext.hx
+++ b/src/js/node/test/TestContext.hx
@@ -22,6 +22,7 @@
 
 package js.node.test;
 
+import haxe.extern.EitherType;
 import js.html.AbortSignal;
 import js.node.Test.HookCallback;
 import js.node.Test.HookOptions;
@@ -197,9 +198,12 @@ extern class TestContext {
 	/**
 		Poll `condition` until it succeeds or the timeout elapses.
 
+		`condition` may return a value or a `Promise` of that value; the returned
+		promise fulfills with the awaited successful result.
+
 		@see https://nodejs.org/docs/latest-v24.x/api/test.html#contextwaitforcondition-options
 	**/
-	function waitFor<T>(condition:Void->T, ?options:WaitForOptions):Promise<T>;
+	function waitFor<T>(condition:Void->EitherType<T, Promise<T>>, ?options:WaitForOptions):Promise<T>;
 
 	/**
 		`MockTracker` instance for this test.

--- a/src/js/node/test/TestContext.hx
+++ b/src/js/node/test/TestContext.hx
@@ -22,8 +22,14 @@
 
 package js.node.test;
 
-import haxe.extern.EitherType;
-import js.node.Test;
+import js.html.AbortSignal;
+import js.node.Test.HookCallback;
+import js.node.Test.HookOptions;
+import js.node.Test.PlanOptions;
+import js.node.Test.SnapshotAssertionOptions;
+import js.node.Test.TestCallback;
+import js.node.Test.TestOptions;
+import js.node.Test.WaitForOptions;
 #if haxe4
 import js.lib.Error;
 import js.lib.Promise;
@@ -33,186 +39,197 @@ import js.Promise;
 #end
 
 /**
-	Options for `TestContext.plan()`.
-**/
-typedef PlanOptions = {
-	/**
-		Wait behavior for the plan:
-		- `true`: wait indefinitely
-		- `false`: check immediately after the test function completes
-		- number: maximum wait time in milliseconds
-		Default: `false`.
-	**/
-	@:optional var wait:EitherType<Bool, Float>;
-};
+	Passed to each test function to interact with the test runner.
 
-/**
-	Options for `TestContext.waitFor()`.
-**/
-typedef WaitForOptions = {
-	/**
-		Milliseconds to wait after an unsuccessful invocation before trying again.
-		Default: `50`.
-	**/
-	@:optional var interval:Float;
-
-	/**
-		Poll timeout in milliseconds. Default: `1000`.
-	**/
-	@:optional var timeout:Float;
-};
-
-/**
-	Runner-specific assertion helpers on `TestContext`, plus commonly used
-	`node:assert` methods bound to the context for test plans.
-
-	For the full assert API, see `js.node.Assert`.
-
-	@see https://nodejs.org/docs/latest-v24.x/api/test.html#contextassert
-**/
-typedef TestContextAssert = {
-	/**
-		Serialize `value` and compare/write it against the snapshot file for this test.
-	**/
-	function snapshot(value:Dynamic, ?options:SnapshotAssertionOptions):Void;
-
-	/**
-		Serialize `value` and compare/write it to an explicit snapshot file path.
-	**/
-	function fileSnapshot(value:Dynamic, path:String, ?options:SnapshotAssertionOptions):Void;
-
-	function ok(value:Dynamic, ?message:EitherType<String, Error>):Void;
-	function equal<T>(actual:T, expected:T, ?message:EitherType<String, Error>):Void;
-	function notEqual<T>(actual:T, expected:T, ?message:EitherType<String, Error>):Void;
-	function strictEqual<T>(actual:T, expected:T, ?message:EitherType<String, Error>):Void;
-	function notStrictEqual<T>(actual:T, expected:T, ?message:EitherType<String, Error>):Void;
-	function deepEqual<T>(actual:T, expected:T, ?message:EitherType<String, Error>):Void;
-	function notDeepEqual<T>(actual:T, expected:T, ?message:EitherType<String, Error>):Void;
-	function deepStrictEqual<T>(actual:T, expected:T, ?message:EitherType<String, Error>):Void;
-	function notDeepStrictEqual<T>(actual:T, expected:T, ?message:EitherType<String, Error>):Void;
-	function match(string:String, regexp:Dynamic, ?message:EitherType<String, Error>):Void;
-	function doesNotMatch(string:String, regexp:Dynamic, ?message:EitherType<String, Error>):Void;
-	function throws(block:haxe.Constraints.Function, ?error:Dynamic, ?message:String):Void;
-	function doesNotThrow(block:haxe.Constraints.Function, ?error:Dynamic, ?message:String):Void;
-	function ifError(value:Dynamic):Void;
-	function fail(?message:EitherType<String, Error>):Void;
-	function rejects(asyncFn:Dynamic, ?error:Dynamic, ?message:String):Promise<Void>;
-	function doesNotReject(asyncFn:Dynamic, ?error:Dynamic, ?message:String):Promise<Void>;
-};
-
-/**
-	An instance of `TestContext` is passed to each test function in order to
-	interact with the test runner. The constructor is not exposed as part of the API.
+	The `TestContext` constructor is not part of the public API.
 
 	@see https://nodejs.org/docs/latest-v24.x/api/test.html#class-testcontext
 **/
 extern class TestContext {
 	/**
-		Creates a hook running before subtests of the current test.
+		Create a hook that runs before subtests of the current test.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#contextbeforefn-options
 	**/
-	function before(?fn:HookFn, ?options:HookOptions):Void;
+	@:overload(function(fn:HookCallback):Void {})
+	function before(?fn:HookCallback, ?options:HookOptions):Void;
 
 	/**
-		Creates a hook running before each subtest of the current test.
+		Create a hook that runs before each subtest of the current test.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#contextbeforeeachfn-options
 	**/
-	function beforeEach(?fn:HookFn, ?options:HookOptions):Void;
+	@:overload(function(fn:HookCallback):Void {})
+	function beforeEach(?fn:HookCallback, ?options:HookOptions):Void;
 
 	/**
-		Creates a hook that runs after the current test finishes.
+		Create a hook that runs after the current test finishes.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#contextafterfn-options
 	**/
-	function after(?fn:HookFn, ?options:HookOptions):Void;
+	@:overload(function(fn:HookCallback):Void {})
+	function after(?fn:HookCallback, ?options:HookOptions):Void;
 
 	/**
-		Creates a hook running after each subtest of the current test.
+		Create a hook that runs after each subtest of the current test.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#contextaftereachfn-options
 	**/
-	function afterEach(?fn:HookFn, ?options:HookOptions):Void;
+	@:overload(function(fn:HookCallback):Void {})
+	function afterEach(?fn:HookCallback, ?options:HookOptions):Void;
 
 	/**
-		Assertion methods bound to this context (for plans and snapshots).
+		Assertion methods bound to this context, used for test plans.
+
+		Includes the usual `node:assert` methods (see `js.node.Assert`) plus
+		runner-specific snapshot helpers.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#contextassert
 	**/
-	var assert(default, never):TestContextAssert;
+	var assert(default, null):TestContextAssert;
 
 	/**
 		Write a diagnostic message included at the end of the test's results.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#contextdiagnosticmessage
 	**/
 	function diagnostic(message:String):Void;
 
 	/**
 		Absolute path of the test file that created the current test.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#contextfilepath
 	**/
-	var filePath(default, never):Null<String>;
+	var filePath(default, null):Null<String>;
 
 	/**
 		Name of the test and each of its ancestors, separated by `>`.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#contextfullname
 	**/
-	var fullName(default, never):String;
+	var fullName(default, null):String;
 
 	/**
 		Name of the test.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#contextname
 	**/
-	var name(default, never):String;
+	var name(default, null):String;
 
 	/**
-		Whether the test succeeded (`false` before the test is executed).
+		Whether the test succeeded. `false` before the test has executed
+		(e.g. in a `beforeEach` hook).
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#contextpassed
 	**/
-	var passed(default, never):Bool;
+	var passed(default, null):Bool;
 
 	/**
-		Failure reason for the test; wrapped and available via `error.cause`.
+		Failure reason for the test when it did not pass; wrapped with `cause`.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#contexterror
 	**/
-	var error(default, never):Null<Error>;
+	var error(default, null):Null<Error>;
 
 	/**
-		Zero-based attempt number of the test (useful with `--test-rerun-failures`).
+		Zero-based attempt number when using `--test-rerun-failures`.
+
+		Added in: v25.0.0 (documented on the Node 24 test page for newer runtimes).
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#contextattempt
 	**/
-	var attempt(default, never):Int;
+	var attempt(default, null):Int;
 
 	/**
-		Unique identifier of the worker running the current test file, or `undefined`
-		when not running in a test context.
+		Unique worker id for the current test file process, or `undefined`
+		outside a test context.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#contextworkerid
 	**/
-	var workerId(default, never):Null<Int>;
+	var workerId(default, null):Null<Int>;
 
 	/**
-		Set the number of assertions and subtests expected to run within the test.
+		Set the number of assertions and subtests expected to run.
+		Use `t.assert` (not bare `assert`) so assertions are tracked.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#contextplancountoptions
 	**/
 	function plan(count:Int, ?options:PlanOptions):Void;
 
 	/**
-		If truthy, only run subtests that have the `only` option set.
+		When `true`, only subtests with the `only` option set are run.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#contextrunonlyshouldrunonlytests
 	**/
 	function runOnly(shouldRunOnlyTests:Bool):Void;
 
 	/**
-		AbortSignal that can be used to abort test subtasks when the test is aborted.
+		Abort signal for cancelling test subtasks when the test is aborted.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#contextsignal
 	**/
-	var signal(default, never):Dynamic;
+	var signal(default, null):AbortSignal;
 
 	/**
-		Cause the test's output to indicate the test as skipped.
+		Mark the test as skipped. Does not terminate the test function.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#contextskipmessage
 	**/
 	function skip(?message:String):Void;
 
 	/**
-		Add a `TODO` directive to the test's output.
+		Mark the test as `TODO`. Does not terminate the test function.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#contexttodomessage
 	**/
 	function todo(?message:String):Void;
 
 	/**
 		Create a subtest under the current test.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#contexttestname-options-fn
 	**/
-	@:overload(function(?name:String, ?fn:TestFn):Promise<Void> {})
-	@:overload(function(?options:TestOptions, ?fn:TestFn):Promise<Void> {})
-	@:overload(function(?fn:TestFn):Promise<Void> {})
-	function test(?name:String, ?options:TestOptions, ?fn:TestFn):Promise<Void>;
+	@:overload(function(fn:TestCallback):Promise<Void> {})
+	@:overload(function(name:String, fn:TestCallback):Promise<Void> {})
+	@:overload(function(options:TestOptions, fn:TestCallback):Promise<Void> {})
+	function test(?name:String, ?options:TestOptions, ?fn:TestCallback):Promise<Void>;
 
 	/**
-		Poll `condition` until it succeeds or the operation times out.
+		Poll `condition` until it succeeds or the timeout elapses.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#contextwaitforcondition-options
 	**/
 	function waitFor<T>(condition:Void->T, ?options:WaitForOptions):Promise<T>;
 
 	/**
-		`MockTracker` instance for this test. Restored automatically when the test finishes.
+		`MockTracker` instance for this test.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#class-mocktracker
 	**/
-	var mock(default, never):MockTracker;
+	var mock(default, null):MockTracker;
+}
+
+/**
+	Assertion helpers on `TestContext.assert`.
+
+	Runner-specific snapshot APIs are typed here. The object also exposes the
+	usual `node:assert` methods bound to this context (see `js.node.Assert`);
+	those are intentionally not fully re-declared.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/test.html#contextassert
+**/
+extern class TestContextAssert implements Dynamic {
+	/**
+		Serialize `value` and write/compare against the snapshot file at `path`.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#contextassertfilesnapshotvalue-path-options
+	**/
+	function fileSnapshot(value:Dynamic, path:String, ?options:SnapshotAssertionOptions):Void;
+
+	/**
+		Assert against (or update) a snapshot entry for this test.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#contextassertsnapshotvalue-options
+	**/
+	function snapshot(value:Dynamic, ?options:SnapshotAssertionOptions):Void;
 }

--- a/src/js/node/test/TestContext.hx
+++ b/src/js/node/test/TestContext.hx
@@ -1,0 +1,218 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.test;
+
+import haxe.extern.EitherType;
+import js.node.Test;
+#if haxe4
+import js.lib.Error;
+import js.lib.Promise;
+#else
+import js.Error;
+import js.Promise;
+#end
+
+/**
+	Options for `TestContext.plan()`.
+**/
+typedef PlanOptions = {
+	/**
+		Wait behavior for the plan:
+		- `true`: wait indefinitely
+		- `false`: check immediately after the test function completes
+		- number: maximum wait time in milliseconds
+		Default: `false`.
+	**/
+	@:optional var wait:EitherType<Bool, Float>;
+};
+
+/**
+	Options for `TestContext.waitFor()`.
+**/
+typedef WaitForOptions = {
+	/**
+		Milliseconds to wait after an unsuccessful invocation before trying again.
+		Default: `50`.
+	**/
+	@:optional var interval:Float;
+
+	/**
+		Poll timeout in milliseconds. Default: `1000`.
+	**/
+	@:optional var timeout:Float;
+};
+
+/**
+	Runner-specific assertion helpers on `TestContext`, plus commonly used
+	`node:assert` methods bound to the context for test plans.
+
+	For the full assert API, see `js.node.Assert`.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/test.html#contextassert
+**/
+typedef TestContextAssert = {
+	/**
+		Serialize `value` and compare/write it against the snapshot file for this test.
+	**/
+	function snapshot(value:Dynamic, ?options:SnapshotAssertionOptions):Void;
+
+	/**
+		Serialize `value` and compare/write it to an explicit snapshot file path.
+	**/
+	function fileSnapshot(value:Dynamic, path:String, ?options:SnapshotAssertionOptions):Void;
+
+	function ok(value:Dynamic, ?message:EitherType<String, Error>):Void;
+	function equal<T>(actual:T, expected:T, ?message:EitherType<String, Error>):Void;
+	function notEqual<T>(actual:T, expected:T, ?message:EitherType<String, Error>):Void;
+	function strictEqual<T>(actual:T, expected:T, ?message:EitherType<String, Error>):Void;
+	function notStrictEqual<T>(actual:T, expected:T, ?message:EitherType<String, Error>):Void;
+	function deepEqual<T>(actual:T, expected:T, ?message:EitherType<String, Error>):Void;
+	function notDeepEqual<T>(actual:T, expected:T, ?message:EitherType<String, Error>):Void;
+	function deepStrictEqual<T>(actual:T, expected:T, ?message:EitherType<String, Error>):Void;
+	function notDeepStrictEqual<T>(actual:T, expected:T, ?message:EitherType<String, Error>):Void;
+	function match(string:String, regexp:Dynamic, ?message:EitherType<String, Error>):Void;
+	function doesNotMatch(string:String, regexp:Dynamic, ?message:EitherType<String, Error>):Void;
+	function throws(block:haxe.Constraints.Function, ?error:Dynamic, ?message:String):Void;
+	function doesNotThrow(block:haxe.Constraints.Function, ?error:Dynamic, ?message:String):Void;
+	function ifError(value:Dynamic):Void;
+	function fail(?message:EitherType<String, Error>):Void;
+	function rejects(asyncFn:Dynamic, ?error:Dynamic, ?message:String):Promise<Void>;
+	function doesNotReject(asyncFn:Dynamic, ?error:Dynamic, ?message:String):Promise<Void>;
+};
+
+/**
+	An instance of `TestContext` is passed to each test function in order to
+	interact with the test runner. The constructor is not exposed as part of the API.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/test.html#class-testcontext
+**/
+extern class TestContext {
+	/**
+		Creates a hook running before subtests of the current test.
+	**/
+	function before(?fn:HookFn, ?options:HookOptions):Void;
+
+	/**
+		Creates a hook running before each subtest of the current test.
+	**/
+	function beforeEach(?fn:HookFn, ?options:HookOptions):Void;
+
+	/**
+		Creates a hook that runs after the current test finishes.
+	**/
+	function after(?fn:HookFn, ?options:HookOptions):Void;
+
+	/**
+		Creates a hook running after each subtest of the current test.
+	**/
+	function afterEach(?fn:HookFn, ?options:HookOptions):Void;
+
+	/**
+		Assertion methods bound to this context (for plans and snapshots).
+	**/
+	var assert(default, never):TestContextAssert;
+
+	/**
+		Write a diagnostic message included at the end of the test's results.
+	**/
+	function diagnostic(message:String):Void;
+
+	/**
+		Absolute path of the test file that created the current test.
+	**/
+	var filePath(default, never):Null<String>;
+
+	/**
+		Name of the test and each of its ancestors, separated by `>`.
+	**/
+	var fullName(default, never):String;
+
+	/**
+		Name of the test.
+	**/
+	var name(default, never):String;
+
+	/**
+		Whether the test succeeded (`false` before the test is executed).
+	**/
+	var passed(default, never):Bool;
+
+	/**
+		Failure reason for the test; wrapped and available via `error.cause`.
+	**/
+	var error(default, never):Null<Error>;
+
+	/**
+		Zero-based attempt number of the test (useful with `--test-rerun-failures`).
+	**/
+	var attempt(default, never):Int;
+
+	/**
+		Unique identifier of the worker running the current test file, or `undefined`
+		when not running in a test context.
+	**/
+	var workerId(default, never):Null<Int>;
+
+	/**
+		Set the number of assertions and subtests expected to run within the test.
+	**/
+	function plan(count:Int, ?options:PlanOptions):Void;
+
+	/**
+		If truthy, only run subtests that have the `only` option set.
+	**/
+	function runOnly(shouldRunOnlyTests:Bool):Void;
+
+	/**
+		AbortSignal that can be used to abort test subtasks when the test is aborted.
+	**/
+	var signal(default, never):Dynamic;
+
+	/**
+		Cause the test's output to indicate the test as skipped.
+	**/
+	function skip(?message:String):Void;
+
+	/**
+		Add a `TODO` directive to the test's output.
+	**/
+	function todo(?message:String):Void;
+
+	/**
+		Create a subtest under the current test.
+	**/
+	@:overload(function(?name:String, ?fn:TestFn):Promise<Void> {})
+	@:overload(function(?options:TestOptions, ?fn:TestFn):Promise<Void> {})
+	@:overload(function(?fn:TestFn):Promise<Void> {})
+	function test(?name:String, ?options:TestOptions, ?fn:TestFn):Promise<Void>;
+
+	/**
+		Poll `condition` until it succeeds or the operation times out.
+	**/
+	function waitFor<T>(condition:Void->T, ?options:WaitForOptions):Promise<T>;
+
+	/**
+		`MockTracker` instance for this test. Restored automatically when the test finishes.
+	**/
+	var mock(default, never):MockTracker;
+}

--- a/src/js/node/test/TestsStream.hx
+++ b/src/js/node/test/TestsStream.hx
@@ -22,6 +22,8 @@
 
 package js.node.test;
 
+import haxe.Constraints.Function;
+import haxe.extern.EitherType;
 import js.node.events.EventEmitter.Event;
 import js.node.stream.Readable;
 #if haxe4
@@ -35,156 +37,197 @@ import js.Error;
 
 	@see https://nodejs.org/docs/latest-v24.x/api/test.html#class-testsstream
 **/
-enum abstract TestsStreamEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
-	var TestCoverage:TestsStreamEvent<TestCoverageEvent->Void> = "test:coverage";
-	var TestComplete:TestsStreamEvent<TestCompleteEvent->Void> = "test:complete";
-	var TestDequeue:TestsStreamEvent<TestDequeueEvent->Void> = "test:dequeue";
-	var TestDiagnostic:TestsStreamEvent<TestDiagnosticEvent->Void> = "test:diagnostic";
-	var TestEnqueue:TestsStreamEvent<TestEnqueueEvent->Void> = "test:enqueue";
-	var TestFail:TestsStreamEvent<TestFailEvent->Void> = "test:fail";
-	var TestInterrupted:TestsStreamEvent<TestInterruptedEvent->Void> = "test:interrupted";
-	var TestPass:TestsStreamEvent<TestPassEvent->Void> = "test:pass";
-	var TestPlan:TestsStreamEvent<TestPlanEvent->Void> = "test:plan";
-	var TestStart:TestsStreamEvent<TestStartEvent->Void> = "test:start";
-	var TestStderr:TestsStreamEvent<TestStdioEvent->Void> = "test:stderr";
-	var TestStdout:TestsStreamEvent<TestStdioEvent->Void> = "test:stdout";
-	var TestSummary:TestsStreamEvent<TestSummaryEvent->Void> = "test:summary";
+enum abstract TestsStreamEvent<T:Function>(Event<T>) to Event<T> {
+	/**
+		Emitted when code coverage is enabled and all tests have completed.
+	**/
+	var TestCoverage:TestsStreamEvent<TestsStreamCoverageEvent->Void> = "test:coverage";
+
+	/**
+		Emitted when a test completes (execution order; see also `test:pass` / `test:fail`).
+	**/
+	var TestComplete:TestsStreamEvent<TestsStreamTestEvent->Void> = "test:complete";
+
+	/**
+		Emitted when a test is dequeued, right before it is executed.
+	**/
+	var TestDequeue:TestsStreamEvent<TestsStreamTestEvent->Void> = "test:dequeue";
+
+	/**
+		Emitted when `context.diagnostic` is called (declaration order).
+	**/
+	var TestDiagnostic:TestsStreamEvent<TestsStreamDiagnosticEvent->Void> = "test:diagnostic";
+
+	/**
+		Emitted when a test is enqueued for execution.
+	**/
+	var TestEnqueue:TestsStreamEvent<TestsStreamTestEvent->Void> = "test:enqueue";
+
+	/**
+		Emitted when a test fails (declaration order).
+	**/
+	var TestFail:TestsStreamEvent<TestsStreamTestEvent->Void> = "test:fail";
+
+	/**
+		Emitted when the runner is interrupted by `SIGINT`.
+	**/
+	var TestInterrupted:TestsStreamEvent<TestsStreamInterruptedEvent->Void> = "test:interrupted";
+
+	/**
+		Emitted when a test passes (declaration order).
+	**/
+	var TestPass:TestsStreamEvent<TestsStreamTestEvent->Void> = "test:pass";
+
+	/**
+		Emitted when all subtests have completed for a given test.
+	**/
+	var TestPlan:TestsStreamEvent<TestsStreamPlanEvent->Void> = "test:plan";
+
+	/**
+		Emitted when a test starts reporting status (declaration order).
+	**/
+	var TestStart:TestsStreamEvent<TestsStreamTestEvent->Void> = "test:start";
+
+	/**
+		Emitted when a running test writes to `stderr` (only with `--test`).
+	**/
+	var TestStderr:TestsStreamEvent<TestsStreamStdioEvent->Void> = "test:stderr";
+
+	/**
+		Emitted when a running test writes to `stdout` (only with `--test`).
+	**/
+	var TestStdout:TestsStreamEvent<TestsStreamStdioEvent->Void> = "test:stdout";
+
+	/**
+		Emitted when a test run completes, with aggregate counts.
+	**/
+	var TestSummary:TestsStreamEvent<TestsStreamSummaryEvent->Void> = "test:summary";
+
+	/**
+		Emitted when no more tests are queued in watch mode.
+	**/
 	var TestWatchDrained:TestsStreamEvent<Void->Void> = "test:watch:drained";
+
+	/**
+		Emitted when tests are restarted due to a file change in watch mode.
+	**/
 	var TestWatchRestarted:TestsStreamEvent<Void->Void> = "test:watch:restarted";
 }
 
 /**
-	Location fields shared by several test stream events.
-**/
-typedef TestLocationInfo = {
-	@:optional var column:Int;
-	@:optional var file:String;
-	@:optional var line:Int;
-};
-
-typedef EitherBoolOrString = haxe.extern.EitherType<Bool, String>;
-
-typedef TestCoverageEvent = {
-	var summary:Dynamic;
-	var nesting:Int;
-};
-
-typedef TestCompleteEvent = {
-	> TestLocationInfo,
-	var details:{
-		var passed:Bool;
-		var duration_ms:Float;
-		@:optional var error:Error;
-		@:optional var type:String;
-	};
-	var name:String;
-	var nesting:Int;
-	var testId:Float;
-	var testNumber:Int;
-	@:optional var todo:EitherBoolOrString;
-	@:optional var skip:EitherBoolOrString;
-};
-typedef TestDequeueEvent = {
-	> TestLocationInfo,
-	var name:String;
-	var nesting:Int;
-	var testId:Float;
-	var type:String;
-};
-
-typedef TestDiagnosticEvent = {
-	> TestLocationInfo,
-	var message:String;
-	var nesting:Int;
-	var level:String;
-};
-
-typedef TestEnqueueEvent = {
-	> TestLocationInfo,
-	var name:String;
-	var nesting:Int;
-	var testId:Float;
-	var type:String;
-};
-
-typedef TestFailEvent = {
-	> TestLocationInfo,
-	var details:{
-		var duration_ms:Float;
-		var error:Error;
-		@:optional var type:String;
-	};
-	@:optional var attempt:Int;
-	var name:String;
-	var nesting:Int;
-	var testId:Float;
-	var testNumber:Int;
-	@:optional var todo:EitherBoolOrString;
-	@:optional var skip:EitherBoolOrString;
-};
-
-typedef TestInterruptedEvent = {
-	var tests:Array<{
-		> TestLocationInfo,
-		var name:String;
-		var nesting:Int;
-	}>;
-};
-
-typedef TestPassEvent = {
-	> TestLocationInfo,
-	var details:{
-		var duration_ms:Float;
-		@:optional var type:String;
-	};
-	@:optional var attempt:Int;
-	@:optional var passed_on_attempt:Int;
-	var name:String;
-	var nesting:Int;
-	var testId:Float;
-	var testNumber:Int;
-	@:optional var todo:EitherBoolOrString;
-	@:optional var skip:EitherBoolOrString;
-};
-
-typedef TestPlanEvent = {
-	> TestLocationInfo,
-	var nesting:Int;
-	var count:Int;
-};
-
-typedef TestStartEvent = {
-	> TestLocationInfo,
-	var name:String;
-	var nesting:Int;
-	var testId:Float;
-};
-
-typedef TestStdioEvent = {
-	var file:String;
-	var message:String;
-};
-
-typedef TestSummaryEvent = {
-	var counts:{
-		var cancelled:Int;
-		var failed:Int;
-		var passed:Int;
-		var skipped:Int;
-		var suites:Int;
-		var tests:Int;
-		var todo:Int;
-		var topLevel:Int;
-	};
-	var duration_ms:Float;
-	@:optional var file:String;
-	var success:Bool;
-};
-
-/**
-	A successful call to `Test.run()` returns a `TestsStream`, streaming events
-	representing the execution of the tests.
+	Readable stream of test reporter events returned by `Test.run()`.
 
 	@see https://nodejs.org/docs/latest-v24.x/api/test.html#class-testsstream
 **/
 extern class TestsStream extends Readable<TestsStream> {}
+
+/**
+	Payload for most test lifecycle events (`data` field shape varies slightly by event).
+**/
+typedef TestsStreamTestEvent = {
+	var data:TestsStreamTestData;
+}
+
+typedef TestsStreamTestData = {
+	@:optional var column:Null<Int>;
+	@:optional var details:TestsStreamTestDetails;
+	@:optional var file:Null<String>;
+	@:optional var line:Null<Int>;
+	var name:String;
+	var nesting:Int;
+	@:optional var testId:Int;
+	@:optional var testNumber:Int;
+	@:optional var type:String;
+	@:optional var todo:EitherType<Bool, String>;
+	@:optional var skip:EitherType<Bool, String>;
+	@:optional var attempt:Int;
+	@:optional var passed_on_attempt:Int;
+}
+
+typedef TestsStreamTestDetails = {
+	@:optional var passed:Bool;
+	@:optional var duration_ms:Float;
+	@:optional var error:Error;
+	@:optional var type:String;
+}
+
+typedef TestsStreamDiagnosticEvent = {
+	var data:TestsStreamDiagnosticData;
+}
+
+typedef TestsStreamDiagnosticData = {
+	@:optional var column:Null<Int>;
+	@:optional var file:Null<String>;
+	@:optional var line:Null<Int>;
+	var message:String;
+	var nesting:Int;
+	var level:String;
+}
+
+typedef TestsStreamPlanEvent = {
+	var data:TestsStreamPlanData;
+}
+
+typedef TestsStreamPlanData = {
+	@:optional var column:Null<Int>;
+	@:optional var file:Null<String>;
+	@:optional var line:Null<Int>;
+	var nesting:Int;
+	var count:Int;
+}
+
+typedef TestsStreamStdioEvent = {
+	var data:TestsStreamStdioData;
+}
+
+typedef TestsStreamStdioData = {
+	var file:String;
+	var message:String;
+}
+
+typedef TestsStreamInterruptedEvent = {
+	var data:TestsStreamInterruptedData;
+}
+
+typedef TestsStreamInterruptedData = {
+	var tests:Array<TestsStreamInterruptedTest>;
+}
+
+typedef TestsStreamInterruptedTest = {
+	@:optional var column:Null<Int>;
+	@:optional var file:Null<String>;
+	@:optional var line:Null<Int>;
+	var name:String;
+	var nesting:Int;
+}
+
+typedef TestsStreamSummaryEvent = {
+	var data:TestsStreamSummaryData;
+}
+
+typedef TestsStreamSummaryData = {
+	var counts:TestsStreamSummaryCounts;
+	var duration_ms:Float;
+	@:optional var file:Null<String>;
+	var success:Bool;
+}
+
+typedef TestsStreamSummaryCounts = {
+	var cancelled:Int;
+	var failed:Int;
+	var passed:Int;
+	var skipped:Int;
+	var suites:Int;
+	var tests:Int;
+	var todo:Int;
+	var topLevel:Int;
+}
+
+typedef TestsStreamCoverageEvent = {
+	var data:TestsStreamCoverageData;
+}
+
+typedef TestsStreamCoverageData = {
+	var summary:Dynamic;
+	var nesting:Int;
+}

--- a/src/js/node/test/TestsStream.hx
+++ b/src/js/node/test/TestsStream.hx
@@ -1,0 +1,190 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.test;
+
+import js.node.events.EventEmitter.Event;
+import js.node.stream.Readable;
+#if haxe4
+import js.lib.Error;
+#else
+import js.Error;
+#end
+
+/**
+	Events emitted by `TestsStream`.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/test.html#class-testsstream
+**/
+enum abstract TestsStreamEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
+	var TestCoverage:TestsStreamEvent<TestCoverageEvent->Void> = "test:coverage";
+	var TestComplete:TestsStreamEvent<TestCompleteEvent->Void> = "test:complete";
+	var TestDequeue:TestsStreamEvent<TestDequeueEvent->Void> = "test:dequeue";
+	var TestDiagnostic:TestsStreamEvent<TestDiagnosticEvent->Void> = "test:diagnostic";
+	var TestEnqueue:TestsStreamEvent<TestEnqueueEvent->Void> = "test:enqueue";
+	var TestFail:TestsStreamEvent<TestFailEvent->Void> = "test:fail";
+	var TestInterrupted:TestsStreamEvent<TestInterruptedEvent->Void> = "test:interrupted";
+	var TestPass:TestsStreamEvent<TestPassEvent->Void> = "test:pass";
+	var TestPlan:TestsStreamEvent<TestPlanEvent->Void> = "test:plan";
+	var TestStart:TestsStreamEvent<TestStartEvent->Void> = "test:start";
+	var TestStderr:TestsStreamEvent<TestStdioEvent->Void> = "test:stderr";
+	var TestStdout:TestsStreamEvent<TestStdioEvent->Void> = "test:stdout";
+	var TestSummary:TestsStreamEvent<TestSummaryEvent->Void> = "test:summary";
+	var TestWatchDrained:TestsStreamEvent<Void->Void> = "test:watch:drained";
+	var TestWatchRestarted:TestsStreamEvent<Void->Void> = "test:watch:restarted";
+}
+
+/**
+	Location fields shared by several test stream events.
+**/
+typedef TestLocationInfo = {
+	@:optional var column:Int;
+	@:optional var file:String;
+	@:optional var line:Int;
+};
+
+typedef EitherBoolOrString = haxe.extern.EitherType<Bool, String>;
+
+typedef TestCoverageEvent = {
+	var summary:Dynamic;
+	var nesting:Int;
+};
+
+typedef TestCompleteEvent = {
+	> TestLocationInfo,
+	var details:{
+		var passed:Bool;
+		var duration_ms:Float;
+		@:optional var error:Error;
+		@:optional var type:String;
+	};
+	var name:String;
+	var nesting:Int;
+	var testId:Float;
+	var testNumber:Int;
+	@:optional var todo:EitherBoolOrString;
+	@:optional var skip:EitherBoolOrString;
+};
+typedef TestDequeueEvent = {
+	> TestLocationInfo,
+	var name:String;
+	var nesting:Int;
+	var testId:Float;
+	var type:String;
+};
+
+typedef TestDiagnosticEvent = {
+	> TestLocationInfo,
+	var message:String;
+	var nesting:Int;
+	var level:String;
+};
+
+typedef TestEnqueueEvent = {
+	> TestLocationInfo,
+	var name:String;
+	var nesting:Int;
+	var testId:Float;
+	var type:String;
+};
+
+typedef TestFailEvent = {
+	> TestLocationInfo,
+	var details:{
+		var duration_ms:Float;
+		var error:Error;
+		@:optional var type:String;
+	};
+	@:optional var attempt:Int;
+	var name:String;
+	var nesting:Int;
+	var testId:Float;
+	var testNumber:Int;
+	@:optional var todo:EitherBoolOrString;
+	@:optional var skip:EitherBoolOrString;
+};
+
+typedef TestInterruptedEvent = {
+	var tests:Array<{
+		> TestLocationInfo,
+		var name:String;
+		var nesting:Int;
+	}>;
+};
+
+typedef TestPassEvent = {
+	> TestLocationInfo,
+	var details:{
+		var duration_ms:Float;
+		@:optional var type:String;
+	};
+	@:optional var attempt:Int;
+	@:optional var passed_on_attempt:Int;
+	var name:String;
+	var nesting:Int;
+	var testId:Float;
+	var testNumber:Int;
+	@:optional var todo:EitherBoolOrString;
+	@:optional var skip:EitherBoolOrString;
+};
+
+typedef TestPlanEvent = {
+	> TestLocationInfo,
+	var nesting:Int;
+	var count:Int;
+};
+
+typedef TestStartEvent = {
+	> TestLocationInfo,
+	var name:String;
+	var nesting:Int;
+	var testId:Float;
+};
+
+typedef TestStdioEvent = {
+	var file:String;
+	var message:String;
+};
+
+typedef TestSummaryEvent = {
+	var counts:{
+		var cancelled:Int;
+		var failed:Int;
+		var passed:Int;
+		var skipped:Int;
+		var suites:Int;
+		var tests:Int;
+		var todo:Int;
+		var topLevel:Int;
+	};
+	var duration_ms:Float;
+	@:optional var file:String;
+	var success:Bool;
+};
+
+/**
+	A successful call to `Test.run()` returns a `TestsStream`, streaming events
+	representing the execution of the tests.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/test.html#class-testsstream
+**/
+extern class TestsStream extends Readable<TestsStream> {}


### PR DESCRIPTION
## Summary
- Add `js.node.Test` externs for the Node.js built-in test runner (`node:test`), covering `test` / `describe` / `it` / `suite`, hooks, `mock`, `snapshot`, `assert.register`, and `run`
- Add supporting types under `js.node.test` (`TestContext`, `SuiteContext`, `MockTracker` / mock helpers, `MockTimers`, `TestsStream` events)
- Runner-specific assert surface on `TestContext.assert` (snapshots + common assert methods); full `node:assert` remains in `js.node.Assert`

## Test plan
- [x] `haxe completion.hxml` succeeds with the new modules included
- [ ] Spot-check that `@:jsRequire("node:test")` matches Node 24 docs
- [ ] Optional: small Haxe example using `Test.test` / `Test.describe` / `t.mock.fn`


Made with [Cursor](https://cursor.com)