### PR TITLE
Add fs/promises and FileHandle externs

### DIFF
--- a/src/js/node/FsPromises.hx
+++ b/src/js/node/FsPromises.hx
@@ -281,7 +281,7 @@ typedef FsPromisesWatchOptions = {
 	/**
 		Allows aborting an in-progress watch with an AbortSignal.
 	**/
-	@:optional var signal:js.html.AbortSignal;
+	@:optional var signal:js.node.web.AbortSignal;
 }
 
 /**

--- a/src/js/node/FsPromises.hx
+++ b/src/js/node/FsPromises.hx
@@ -1,0 +1,300 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node;
+
+import haxe.extern.EitherType;
+import js.node.Fs;
+import js.node.fs.Dir;
+import js.node.fs.Dirent;
+import js.node.fs.FileHandle;
+import js.node.fs.Stats;
+import js.node.fs.StatsFs;
+#if haxe4
+import js.lib.Promise;
+#else
+import js.Promise;
+#end
+
+/**
+	Minimal async iterator surface used by `glob` / `watch` (for `for await...of`).
+**/
+typedef FsPromisesAsyncIterator<T> = {
+	function next():Promise<{done:Bool, ?value:T}>;
+}
+
+/**
+	The `fs/promises` API provides asynchronous file system methods that return promises.
+
+	The API is accessible via `require('fs/promises')` or `require('fs').promises`.
+
+	@see https://nodejs.org/api/fs.html#promises-api
+**/
+@:jsRequire("fs/promises")
+extern class FsPromises {
+	/**
+		An object containing commonly used constants for file system operations.
+		Same as `Fs.constants`.
+	**/
+	static var constants(default, null):FsConstants;
+
+	/**
+		Tests a user's permissions for the file or directory specified by `path`.
+	**/
+	@:overload(function(path:FsPath):Promise<Void> {})
+	static function access(path:FsPath, mode:Int):Promise<Void>;
+
+	/**
+		Asynchronously append data to a file, creating the file if it does not exist.
+	**/
+	@:overload(function(path:EitherType<FsPath, FileHandle>, data:EitherType<String, Buffer>):Promise<Void> {})
+	static function appendFile(path:EitherType<FsPath, FileHandle>, data:EitherType<String, Buffer>,
+		options:EitherType<String, FsWriteFileOptions>):Promise<Void>;
+
+	/**
+		Changes file permissions of `path`.
+	**/
+	static function chmod(path:FsPath, mode:FsMode):Promise<Void>;
+
+	/**
+		Changes file ownership of `path`.
+	**/
+	static function chown(path:FsPath, uid:Int, gid:Int):Promise<Void>;
+
+	/**
+		Asynchronously copies `src` to `dest`.
+	**/
+	@:overload(function(src:FsPath, dest:FsPath):Promise<Void> {})
+	static function copyFile(src:FsPath, dest:FsPath, mode:Int):Promise<Void>;
+
+	/**
+		Asynchronously copies the entire directory structure from `src` to `dest`,
+		including subdirectories and files.
+	**/
+	@:overload(function(src:FsPath, dest:FsPath):Promise<Void> {})
+	static function cp(src:FsPath, dest:FsPath, options:FsCpOptions):Promise<Void>;
+
+	/**
+		Retrieves the files matching the specified pattern as an async iterator.
+	**/
+	@:overload(function(pattern:EitherType<String, Array<String>>):FsPromisesAsyncIterator<String> {})
+	@:overload(function(pattern:EitherType<String, Array<String>>, options:FsGlobOptions):FsPromisesAsyncIterator<String> {})
+	static function glob(pattern:EitherType<String, Array<String>>, options:{
+		?cwd:String,
+		?exclude:EitherType<String->Bool, Array<String>>,
+		?followSymlinks:Bool,
+		withFileTypes:Bool
+	}):FsPromisesAsyncIterator<Dirent>;
+
+	/**
+		Changes the permissions on a symbolic link.
+		No-op on Windows.
+	**/
+	static function lchmod(path:FsPath, mode:FsMode):Promise<Void>;
+
+	/**
+		Changes the ownership on a symbolic link.
+	**/
+	static function lchown(path:FsPath, uid:Int, gid:Int):Promise<Void>;
+
+	/**
+		Changes the access and modification times of a file in the same way as `utimes`,
+		without following symlinks.
+	**/
+	static function lutimes(path:FsPath, atime:EitherType<Date, EitherType<Float, String>>,
+		mtime:EitherType<Date, EitherType<Float, String>>):Promise<Void>;
+
+	/**
+		Creates a new link from `existingPath` to `newPath`.
+	**/
+	static function link(existingPath:FsPath, newPath:FsPath):Promise<Void>;
+
+	/**
+		Retrieves the `fs.Stats` for the symbolic link referred to by `path`.
+	**/
+	@:overload(function(path:FsPath):Promise<Stats> {})
+	static function lstat(path:FsPath, options:{?bigint:Bool}):Promise<Stats>;
+
+	/**
+		Asynchronously creates a directory.
+		When `recursive` is true, fulfills with the first directory path created, if any.
+	**/
+	@:overload(function(path:FsPath):Promise<Null<String>> {})
+	@:overload(function(path:FsPath, mode:FsMode):Promise<Null<String>> {})
+	static function mkdir(path:FsPath, options:{?recursive:Bool, ?mode:FsMode}):Promise<Null<String>>;
+
+	/**
+		Creates a unique temporary directory.
+		Generates six random characters to be appended behind a required `prefix` to create a unique temporary directory.
+	**/
+	@:overload(function(prefix:String):Promise<String> {})
+	static function mkdtemp(prefix:String, options:EitherType<String, {?encoding:String}>):Promise<String>;
+
+	/**
+		Opens a `FileHandle`.
+	**/
+	@:overload(function(path:FsPath):Promise<FileHandle> {})
+	@:overload(function(path:FsPath, flags:FsOpenFlag):Promise<FileHandle> {})
+	static function open(path:FsPath, flags:FsOpenFlag, mode:FsMode):Promise<FileHandle>;
+
+	/**
+		Asynchronously open a directory for iterative scanning.
+	**/
+	@:overload(function(path:FsPath):Promise<Dir> {})
+	static function opendir(path:FsPath, options:FsOpendirOptions):Promise<Dir>;
+
+	/**
+		Reads the contents of a directory.
+	**/
+	@:overload(function(path:FsPath):Promise<Array<String>> {})
+	@:overload(function(path:FsPath, options:EitherType<String, {?encoding:String, ?withFileTypes:Bool, ?recursive:Bool}>):Promise<Array<String>> {})
+	static function readdir(path:FsPath, options:{?encoding:String, withFileTypes:Bool, ?recursive:Bool}):Promise<Array<Dirent>>;
+
+	/**
+		Asynchronously reads the entire contents of a file.
+		If no encoding is specified, the data is returned as a `Buffer`.
+	**/
+	@:overload(function(path:EitherType<FsPath, FileHandle>):Promise<Buffer> {})
+	@:overload(function(path:EitherType<FsPath, FileHandle>, options:EitherType<String, {encoding:String, ?flag:FsOpenFlag}>):Promise<String> {})
+	static function readFile(path:EitherType<FsPath, FileHandle>,
+		?options:{?encoding:String, ?flag:FsOpenFlag}):Promise<EitherType<String, Buffer>>;
+
+	/**
+		Reads the contents of the symbolic link referred to by `path`.
+	**/
+	@:overload(function(path:FsPath):Promise<String> {})
+	static function readlink(path:FsPath, options:EitherType<String, {?encoding:String}>):Promise<EitherType<String, Buffer>>;
+
+	/**
+		Determines the actual location of `path` using the same semantics as the `fs.realpath` algorithm.
+	**/
+	@:overload(function(path:FsPath):Promise<String> {})
+	static function realpath(path:FsPath, options:EitherType<String, {?encoding:String}>):Promise<EitherType<String, Buffer>>;
+
+	/**
+		Renames `oldPath` to `newPath`.
+	**/
+	static function rename(oldPath:FsPath, newPath:FsPath):Promise<Void>;
+
+	/**
+		Removes files and directories (modeled on the standard POSIX `rm` utility).
+	**/
+	@:overload(function(path:FsPath):Promise<Void> {})
+	static function rm(path:FsPath, options:FsRmOptions):Promise<Void>;
+
+	/**
+		Removes the directory identified by `path`.
+	**/
+	@:overload(function(path:FsPath):Promise<Void> {})
+	static function rmdir(path:FsPath, options:FsRmdirOptions):Promise<Void>;
+
+	/**
+		Retrieves the `fs.Stats` for the file referred to by `path`.
+	**/
+	@:overload(function(path:FsPath):Promise<Stats> {})
+	static function stat(path:FsPath, options:{?bigint:Bool}):Promise<Stats>;
+
+	/**
+		Retrieves information about the file system containing the given `path`.
+	**/
+	@:overload(function(path:FsPath):Promise<StatsFs> {})
+	static function statfs(path:FsPath, options:{?bigint:Bool}):Promise<StatsFs>;
+
+	/**
+		Creates a symbolic link.
+	**/
+	@:overload(function(target:FsPath, path:FsPath):Promise<Void> {})
+	static function symlink(target:FsPath, path:FsPath, type:SymlinkType):Promise<Void>;
+
+	/**
+		Truncates (shortens or extends the length) of the content at `path` to be `len` bytes long.
+	**/
+	@:overload(function(path:FsPath):Promise<Void> {})
+	static function truncate(path:FsPath, len:Int):Promise<Void>;
+
+	/**
+		Removes the link and deletes the file named by `path` if no other references exist.
+	**/
+	static function unlink(path:FsPath):Promise<Void>;
+
+	/**
+		Change the file system timestamps of the object referenced by `path`.
+	**/
+	static function utimes(path:FsPath, atime:EitherType<Date, EitherType<Float, String>>,
+		mtime:EitherType<Date, EitherType<Float, String>>):Promise<Void>;
+
+	/**
+		Returns an async iterator that watches for changes on `filename`.
+	**/
+	@:overload(function(filename:FsPath):FsPromisesAsyncIterator<FsPromisesWatchEvent> {})
+	static function watch(filename:FsPath, options:EitherType<String, FsPromisesWatchOptions>):FsPromisesAsyncIterator<FsPromisesWatchEvent>;
+
+	/**
+		Asynchronously writes data to a file, replacing the file if it already exists.
+	**/
+	@:overload(function(file:EitherType<FsPath, FileHandle>, data:EitherType<String, Buffer>):Promise<Void> {})
+	static function writeFile(file:EitherType<FsPath, FileHandle>, data:EitherType<String, Buffer>,
+		options:EitherType<String, FsWriteFileOptions>):Promise<Void>;
+}
+
+/**
+	Options for `FsPromises.watch`.
+**/
+typedef FsPromisesWatchOptions = {
+	/**
+		Specifies the character encoding to be used for the filename passed to the listener.
+		Default: `'utf8'`.
+	**/
+	@:optional var encoding:String;
+
+	/**
+		Indicates whether the process should continue to run as long as files are being watched.
+		Default: `true`.
+	**/
+	@:optional var persistent:Bool;
+
+	/**
+		Indicates whether all files should be watched, or only the current directory.
+		Default: `false`.
+	**/
+	@:optional var recursive:Bool;
+
+	/**
+		Allows aborting an in-progress watch with an AbortSignal.
+	**/
+	@:optional var signal:js.html.AbortSignal;
+}
+
+/**
+	Event yielded by `FsPromises.watch`.
+**/
+typedef FsPromisesWatchEvent = {
+	/**
+		The type of change: `'rename'` or `'change'`.
+	**/
+	var eventType:String;
+
+	/**
+		The name of the file that changed.
+	**/
+	var filename:Null<EitherType<String, Buffer>>;
+}

--- a/src/js/node/fs/FileHandle.hx
+++ b/src/js/node/fs/FileHandle.hx
@@ -38,10 +38,13 @@ import js.Promise;
 	A `FileHandle` object is a wrapper for a numeric file descriptor.
 
 	Instances are created by `FsPromises.open()`.
+	Not a public export of `fs/promises` (`require("fs/promises").FileHandle` is undefined),
+	so this is a plain extern like `Stats` / `ReadStream`.
+
+	`Symbol.asyncDispose` (await using) is intentionally deferred.
 
 	@see https://nodejs.org/api/fs.html#class-filehandle
 **/
-@:jsRequire("fs/promises", "FileHandle")
 extern class FileHandle extends EventEmitter<FileHandle> {
 	/**
 		The numeric file descriptor managed by this `FileHandle`.
@@ -107,6 +110,13 @@ extern class FileHandle extends EventEmitter<FileHandle> {
 	function readLines(?options:FsCreateReadStreamOptions):Interface;
 
 	/**
+		Returns a byte-oriented `ReadableStream` for the file contents.
+
+		Typed as `Dynamic` until web streams externs are added (same pattern as `Blob.stream`).
+	**/
+	function readableWebStream(?options:FileHandleReadableWebStreamOptions):Dynamic;
+
+	/**
 		Read from a file and write to an array of buffers.
 	**/
 	@:overload(function(buffers:Array<FsVectorBuffer>):Promise<FileHandleReadvResult> {})
@@ -165,6 +175,17 @@ enum abstract FileHandleEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T>
 		Emitted when the `FileHandle` has been closed and can no longer be used.
 	**/
 	var Close:FileHandleEvent<Void->Void> = "close";
+}
+
+/**
+	Options for `FileHandle.readableWebStream`.
+**/
+typedef FileHandleReadableWebStreamOptions = {
+	/**
+		When `true`, closes the `FileHandle` when the stream is closed.
+		Default: `false`.
+	**/
+	@:optional var autoClose:Bool;
 }
 
 /**

--- a/src/js/node/fs/FileHandle.hx
+++ b/src/js/node/fs/FileHandle.hx
@@ -1,0 +1,253 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.fs;
+
+import haxe.extern.EitherType;
+import js.node.Buffer;
+import js.node.Fs;
+import js.node.events.EventEmitter;
+import js.node.events.EventEmitter.Event;
+import js.node.readline.Interface;
+#if haxe4
+import js.lib.Promise;
+#else
+import js.Promise;
+#end
+
+/**
+	A `FileHandle` object is a wrapper for a numeric file descriptor.
+
+	Instances are created by `FsPromises.open()`.
+
+	@see https://nodejs.org/api/fs.html#class-filehandle
+**/
+@:jsRequire("fs/promises", "FileHandle")
+extern class FileHandle extends EventEmitter<FileHandle> {
+	/**
+		The numeric file descriptor managed by this `FileHandle`.
+	**/
+	var fd(default, null):Int;
+
+	/**
+		Alias of `writeFile()`.
+		Asynchronously append data to a file, creating the file if it does not exist.
+	**/
+	@:overload(function(data:EitherType<String, Buffer>):Promise<Void> {})
+	function appendFile(data:EitherType<String, Buffer>, options:EitherType<String, FsWriteFileOptions>):Promise<Void>;
+
+	/**
+		Modifies the permissions on the file. See chmod(2).
+	**/
+	function chmod(mode:FsMode):Promise<Void>;
+
+	/**
+		Changes the ownership of the file. See chown(2).
+	**/
+	function chown(uid:Int, gid:Int):Promise<Void>;
+
+	/**
+		Closes the file handle after waiting for any pending operation on the handle to complete.
+	**/
+	function close():Promise<Void>;
+
+	/**
+		Unlike `createReadStream` on the `fs` module, this reads sequentially from the current file position.
+	**/
+	function createReadStream(?options:FsCreateReadStreamOptions):ReadStream;
+
+	/**
+		Creates a write stream associated with this file handle.
+	**/
+	function createWriteStream(?options:FsCreateWriteStreamOptions):WriteStream;
+
+	/**
+		Forces all currently queued I/O operations associated with the file to the
+		operating system's synchronized I/O completion state. See fdatasync(2).
+	**/
+	function datasync():Promise<Void>;
+
+	/**
+		Reads data from the file and stores that in the given buffer.
+	**/
+	@:overload(function(?options:FileHandleReadOptions):Promise<FileHandleReadResult> {})
+	@:overload(function(buffer:Buffer, ?options:FileHandleReadOptions):Promise<FileHandleReadResult> {})
+	function read(buffer:Buffer, offset:Int, length:Int, position:Null<EitherType<Int, Float>>):Promise<FileHandleReadResult>;
+
+	/**
+		Asynchronously reads the entire contents of a file.
+		If no encoding is specified, the data is returned as a `Buffer`.
+	**/
+	@:overload(function():Promise<Buffer> {})
+	@:overload(function(options:EitherType<String, {encoding:String}>):Promise<String> {})
+	function readFile(?options:{?encoding:String}):Promise<EitherType<String, Buffer>>;
+
+	/**
+		Convenience method to create a `readline` interface and stream over the file.
+	**/
+	function readLines(?options:FsCreateReadStreamOptions):Interface;
+
+	/**
+		Read from a file and write to an array of buffers.
+	**/
+	@:overload(function(buffers:Array<FsVectorBuffer>):Promise<FileHandleReadvResult> {})
+	function readv(buffers:Array<FsVectorBuffer>, position:Null<Int>):Promise<FileHandleReadvResult>;
+
+	/**
+		Retrieves `fs.Stats` for the file.
+	**/
+	@:overload(function():Promise<Stats> {})
+	function stat(options:{?bigint:Bool}):Promise<Stats>;
+
+	/**
+		Request that all data for the open file descriptor is flushed to the storage device.
+		See fsync(2).
+	**/
+	function sync():Promise<Void>;
+
+	/**
+		Truncates the file.
+		If `len` is negative then `0` will be used.
+	**/
+	@:overload(function():Promise<Void> {})
+	function truncate(len:Int):Promise<Void>;
+
+	/**
+		Change the file system timestamps of the object referenced by this `FileHandle`.
+	**/
+	function utimes(atime:EitherType<Date, EitherType<Float, String>>,
+		mtime:EitherType<Date, EitherType<Float, String>>):Promise<Void>;
+
+	/**
+		Write `buffer` / `string` to the file.
+	**/
+	@:overload(function(buffer:Buffer, ?options:FileHandleWriteOptions):Promise<FileHandleWriteResult> {})
+	@:overload(function(string:String, ?position:Null<Int>, ?encoding:String):Promise<FileHandleWriteResult> {})
+	function write(buffer:Buffer, offset:Int, ?length:Int, ?position:Null<Int>):Promise<FileHandleWriteResult>;
+
+	/**
+		Asynchronously writes data to a file, replacing the file if it already exists.
+	**/
+	@:overload(function(data:EitherType<String, Buffer>):Promise<Void> {})
+	function writeFile(data:EitherType<String, Buffer>, options:EitherType<String, FsWriteFileOptions>):Promise<Void>;
+
+	/**
+		Write an array of buffers to the file.
+	**/
+	@:overload(function(buffers:Array<FsVectorBuffer>):Promise<FileHandleWritevResult> {})
+	function writev(buffers:Array<FsVectorBuffer>, position:Null<Int>):Promise<FileHandleWritevResult>;
+}
+
+/**
+	Events emitted by `FileHandle`.
+**/
+enum abstract FileHandleEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
+	/**
+		Emitted when the `FileHandle` has been closed and can no longer be used.
+	**/
+	var Close:FileHandleEvent<Void->Void> = "close";
+}
+
+/**
+	Options for `FileHandle.read`.
+**/
+typedef FileHandleReadOptions = {
+	/**
+		A buffer that will be filled with the file data read.
+		Default: `Buffer.alloc(16384)`.
+	**/
+	@:optional var buffer:Buffer;
+
+	/**
+		The location in the buffer at which to start filling.
+		Default: `0`.
+	**/
+	@:optional var offset:Int;
+
+	/**
+		The number of bytes to read.
+		Default: `buffer.byteLength - offset`.
+	**/
+	@:optional var length:Int;
+
+	/**
+		The location where to begin reading data from the file.
+		If `null` or `-1`, data will be read from the current file position.
+		Default: `null`.
+	**/
+	@:optional var position:Null<EitherType<Int, Float>>;
+}
+
+/**
+	Result of `FileHandle.read`.
+**/
+typedef FileHandleReadResult = {
+	var bytesRead:Int;
+	var buffer:Buffer;
+}
+
+/**
+	Result of `FileHandle.readv`.
+**/
+typedef FileHandleReadvResult = {
+	var bytesRead:Int;
+	var buffers:Array<FsVectorBuffer>;
+}
+
+/**
+	Options for `FileHandle.write` (buffer form).
+**/
+typedef FileHandleWriteOptions = {
+	/**
+		The start position from within `buffer` where the data to write begins.
+		Default: `0`.
+	**/
+	@:optional var offset:Int;
+
+	/**
+		The number of bytes from `buffer` to write.
+		Default: `buffer.byteLength - offset`.
+	**/
+	@:optional var length:Int;
+
+	/**
+		The offset from the beginning of the file where the data should be written.
+		Default: `null` (write at current position).
+	**/
+	@:optional var position:Null<Int>;
+}
+
+/**
+	Result of `FileHandle.write`.
+**/
+typedef FileHandleWriteResult = {
+	var bytesWritten:Int;
+	var buffer:EitherType<String, Buffer>;
+}
+
+/**
+	Result of `FileHandle.writev`.
+**/
+typedef FileHandleWritevResult = {
+	var bytesWritten:Int;
+	var buffers:Array<FsVectorBuffer>;
+}


### PR DESCRIPTION
## Summary
- Add `js.node.FsPromises` (`@:jsRequire("fs/promises")`) mirroring callback `Fs` APIs as `Promise`-returning statics
- Add `js.node.fs.FileHandle` for the handle returned by `FsPromises.open`
- Reuse existing `Fs` typedefs (`FsPath`, options, Stats, Dir, etc.); no reshuffling of existing modules

## Test plan
- [ ] `haxe build.hxml` succeeds
- [ ] Spot-check against [Node 24 fs/promises](https://nodejs.org/docs/latest-v24.x/api/fs.html#promises-api): `access`, `readFile`, `writeFile`, `open`/`FileHandle`, `glob`, `watch`
- [ ] Confirm skipped APIs are intentional: `mkdtempDisposable`, `FileHandle.readableWebStream`, `Symbol.asyncDispose`


Made with [Cursor](https://cursor.com)