### PR TITLE
Add perf_hooks module externs and global performance

### DIFF
--- a/src/js/Node.hx
+++ b/src/js/Node.hx
@@ -29,6 +29,7 @@ import js.node.Process;
 import js.node.Timers.Immediate;
 import js.node.Timers.Timeout;
 import js.node.console.Console;
+import js.node.perf_hooks.Performance;
 #if haxe4
 import js.Syntax.code;
 #end
@@ -153,6 +154,23 @@ extern class Node {
 		return code("process");
 		#else
 		return untyped __js__("process");
+		#end
+	}
+
+	/**
+		An object that can be used to collect performance metrics from the current Node.js instance.
+		It is similar to `window.performance` in browsers.
+
+		@see https://nodejs.org/api/globals.html#performance
+		@see https://nodejs.org/api/perf_hooks.html#perf_hooksperformance
+	**/
+	static var performance(get, never):Performance;
+
+	private static inline function get_performance():Performance {
+		#if haxe4
+		return code("performance");
+		#else
+		return untyped __js__("performance");
 		#end
 	}
 

--- a/src/js/node/PerfHooks.hx
+++ b/src/js/node/PerfHooks.hx
@@ -26,7 +26,6 @@ import haxe.Constraints.Function;
 import haxe.extern.EitherType;
 import js.node.perf_hooks.IntervalHistogram;
 import js.node.perf_hooks.Performance;
-import js.node.perf_hooks.PerformanceObserver;
 import js.node.perf_hooks.RecordableHistogram;
 
 /**
@@ -87,13 +86,6 @@ extern class PerfHooks {
 		@see https://nodejs.org/api/perf_hooks.html#perf_hookstimerifyfn-options
 	**/
 	static function timerify<T:Function>(fn:T, ?options:TimerifyOptions):T;
-
-	/**
-		The `PerformanceObserver` class.
-
-		@see https://nodejs.org/api/perf_hooks.html#class-performanceobserver
-	**/
-	static var PerformanceObserver(default, never):Class<PerformanceObserver>;
 }
 
 /**

--- a/src/js/node/PerfHooks.hx
+++ b/src/js/node/PerfHooks.hx
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node;
+
+import haxe.Constraints.Function;
+import haxe.extern.EitherType;
+import js.node.perf_hooks.IntervalHistogram;
+import js.node.perf_hooks.Performance;
+import js.node.perf_hooks.PerformanceObserver;
+import js.node.perf_hooks.RecordableHistogram;
+
+/**
+	This module provides an implementation of a subset of the W3C Web Performance APIs
+	as well as additional APIs for Node.js-specific performance measurements.
+
+	@see https://nodejs.org/api/perf_hooks.html
+**/
+@:jsRequire("perf_hooks")
+extern class PerfHooks {
+	/**
+		An object that can be used to collect performance metrics from the current Node.js instance.
+		It is similar to `window.performance` in browsers.
+
+		@see https://nodejs.org/api/perf_hooks.html#perf_hooksperformance
+	**/
+	static var performance(default, never):Performance;
+
+	/**
+		Constants for garbage collection kinds and flags.
+
+		@see https://nodejs.org/api/perf_hooks.html#perf_hooksconstants
+	**/
+	static var constants(default, never):PerfHooksConstants;
+
+	/**
+		Returns a `RecordableHistogram`.
+
+		@see https://nodejs.org/api/perf_hooks.html#perf_hookscreatehistogramoptions
+	**/
+	static function createHistogram(?options:CreateHistogramOptions):RecordableHistogram;
+
+	/**
+		Creates an `IntervalHistogram` object that samples and reports the event loop delay over time.
+		The delays will be reported in nanoseconds.
+
+		This property is an extension by Node.js. It is not available in Web browsers.
+
+		@see https://nodejs.org/api/perf_hooks.html#perf_hooksmonitoreventloopdelayoptions
+	**/
+	static function monitorEventLoopDelay(?options:EventLoopMonitorOptions):IntervalHistogram;
+
+	/**
+		Returns an object that contains the cumulative duration of time the event loop has been
+		both idle and active as a high resolution milliseconds timer.
+
+		@see https://nodejs.org/api/perf_hooks.html#perf_hookseventlooputilizationutilization1-utilization2
+	**/
+	static function eventLoopUtilization(?utilization1:EventLoopUtilization, ?utilization2:EventLoopUtilization):EventLoopUtilization;
+
+	/**
+		Wraps a function within a new function that measures the running time of the wrapped function.
+		A `PerformanceObserver` must be subscribed to the `'function'` event type in order for the
+		timing details to be accessed.
+
+		This property is an extension by Node.js. It is not available in Web browsers.
+
+		@see https://nodejs.org/api/perf_hooks.html#perf_hookstimerifyfn-options
+	**/
+	static function timerify<T:Function>(fn:T, ?options:TimerifyOptions):T;
+
+	/**
+		The `PerformanceObserver` class.
+
+		@see https://nodejs.org/api/perf_hooks.html#class-performanceobserver
+	**/
+	static var PerformanceObserver(default, never):Class<PerformanceObserver>;
+}
+
+/**
+	Constants exported by `perf_hooks.constants`.
+**/
+typedef PerfHooksConstants = {
+	var NODE_PERFORMANCE_GC_MAJOR(default, never):Int;
+	var NODE_PERFORMANCE_GC_MINOR(default, never):Int;
+	var NODE_PERFORMANCE_GC_INCREMENTAL(default, never):Int;
+	var NODE_PERFORMANCE_GC_WEAKCB(default, never):Int;
+	var NODE_PERFORMANCE_GC_FLAGS_NO(default, never):Int;
+	var NODE_PERFORMANCE_GC_FLAGS_CONSTRUCT_RETAINED(default, never):Int;
+	var NODE_PERFORMANCE_GC_FLAGS_FORCED(default, never):Int;
+	var NODE_PERFORMANCE_GC_FLAGS_SYNCHRONOUS_PHANTOM_PROCESSING(default, never):Int;
+	var NODE_PERFORMANCE_GC_FLAGS_ALL_AVAILABLE_GARBAGE(default, never):Int;
+	var NODE_PERFORMANCE_GC_FLAGS_ALL_EXTERNAL_MEMORY(default, never):Int;
+	var NODE_PERFORMANCE_GC_FLAGS_SCHEDULE_IDLE(default, never):Int;
+}
+
+/**
+	Options for `PerfHooks.createHistogram`.
+**/
+typedef CreateHistogramOptions = {
+	/**
+		The lowest discernible value. Must be an integer value greater than 0.
+		Default: `1`.
+	**/
+	@:optional var lowest:EitherType<Float, Dynamic>;
+
+	/**
+		The highest recordable value. Must be an integer value that is equal to or greater than
+		two times `lowest`. Default: `Number.MAX_SAFE_INTEGER`.
+	**/
+	@:optional var highest:EitherType<Float, Dynamic>;
+
+	/**
+		The number of accuracy digits. Must be a number between `1` and `5`.
+		Default: `3`.
+	**/
+	@:optional var figures:Int;
+}
+
+/**
+	Options for `PerfHooks.monitorEventLoopDelay`.
+**/
+typedef EventLoopMonitorOptions = {
+	/**
+		The sampling rate in milliseconds. Must be greater than zero.
+		Default: `10`.
+	**/
+	@:optional var resolution:Float;
+}
+
+/**
+	Result of `PerfHooks.eventLoopUtilization` / `Performance.eventLoopUtilization`.
+**/
+typedef EventLoopUtilization = {
+	var idle:Float;
+	var active:Float;
+	var utilization:Float;
+}
+
+/**
+	Options for `PerfHooks.timerify` / `Performance.timerify`.
+**/
+typedef TimerifyOptions = {
+	/**
+		A histogram object created using `PerfHooks.createHistogram()` that will record
+		runtime durations in nanoseconds.
+	**/
+	@:optional var histogram:RecordableHistogram;
+}

--- a/src/js/node/PerfHooks.hx
+++ b/src/js/node/PerfHooks.hx
@@ -72,6 +72,10 @@ extern class PerfHooks {
 		Returns an object that contains the cumulative duration of time the event loop has been
 		both idle and active as a high resolution milliseconds timer.
 
+		Module-level alias of `performance.eventLoopUtilization()`.
+		Added in Node.js v24.12.0 (Active LTS). On earlier versions (including Node.js 22 LTS)
+		this is `undefined` at module level; use `PerfHooks.performance.eventLoopUtilization` instead.
+
 		@see https://nodejs.org/api/perf_hooks.html#perf_hookseventlooputilizationutilization1-utilization2
 	**/
 	static function eventLoopUtilization(?utilization1:EventLoopUtilization, ?utilization2:EventLoopUtilization):EventLoopUtilization;
@@ -82,6 +86,10 @@ extern class PerfHooks {
 		timing details to be accessed.
 
 		This property is an extension by Node.js. It is not available in Web browsers.
+
+		Module-level alias of `performance.timerify()`.
+		Added in Node.js v24.12.0 (Active LTS). On earlier versions (including Node.js 22 LTS)
+		this is `undefined` at module level; use `PerfHooks.performance.timerify` instead.
 
 		@see https://nodejs.org/api/perf_hooks.html#perf_hookstimerifyfn-options
 	**/

--- a/src/js/node/perf_hooks/Histogram.hx
+++ b/src/js/node/perf_hooks/Histogram.hx
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.perf_hooks;
+
+/**
+	Histogram for recording values (e.g. event loop delay samples).
+
+	The constructor of this class is not exposed to users.
+
+	@see https://nodejs.org/api/perf_hooks.html#class-histogram
+**/
+extern class Histogram {
+	/**
+		The number of samples recorded by the histogram.
+	**/
+	var count(default, null):Float;
+
+	/**
+		The number of samples recorded by the histogram (as a BigInt).
+	**/
+	var countBigInt(default, null):Dynamic;
+
+	/**
+		The number of times the event loop delay exceeded the maximum 1 hour event loop delay threshold.
+	**/
+	var exceeds(default, null):Float;
+
+	/**
+		The number of times the event loop delay exceeded the maximum 1 hour event loop delay threshold (as a BigInt).
+	**/
+	var exceedsBigInt(default, null):Dynamic;
+
+	/**
+		The maximum recorded event loop delay.
+	**/
+	var max(default, null):Float;
+
+	/**
+		The maximum recorded event loop delay (as a BigInt).
+	**/
+	var maxBigInt(default, null):Dynamic;
+
+	/**
+		The mean of the recorded event loop delays.
+	**/
+	var mean(default, null):Float;
+
+	/**
+		The minimum recorded event loop delay.
+	**/
+	var min(default, null):Float;
+
+	/**
+		The minimum recorded event loop delay (as a BigInt).
+	**/
+	var minBigInt(default, null):Dynamic;
+
+	/**
+		Returns the value at the given percentile.
+
+		@param percentile A percentile value in the range (0, 100].
+	**/
+	function percentile(percentile:Float):Float;
+
+	/**
+		Returns the value at the given percentile (as a BigInt).
+
+		@param percentile A percentile value in the range (0, 100].
+	**/
+	function percentileBigInt(percentile:Float):Dynamic;
+
+	/**
+		Returns a `Map` object detailing the accumulated percentile distribution.
+	**/
+	var percentiles(default, null):Dynamic;
+
+	/**
+		Returns a `Map` object detailing the accumulated percentile distribution (BigInt keys/values).
+	**/
+	var percentilesBigInt(default, null):Dynamic;
+
+	/**
+		Resets the collected histogram data.
+	**/
+	function reset():Void;
+
+	/**
+		The standard deviation of the recorded event loop delays.
+	**/
+	var stddev(default, null):Float;
+}

--- a/src/js/node/perf_hooks/IntervalHistogram.hx
+++ b/src/js/node/perf_hooks/IntervalHistogram.hx
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.perf_hooks;
+
+/**
+	A `Histogram` that is periodically updated on a given interval.
+
+	@see https://nodejs.org/api/perf_hooks.html#class-intervalhistogram-extends-histogram
+**/
+extern class IntervalHistogram extends Histogram {
+	/**
+		Disables the update interval timer. Returns `true` if the timer was stopped,
+		`false` if it was already stopped.
+	**/
+	function disable():Bool;
+
+	/**
+		Enables the update interval timer. Returns `true` if the timer was started,
+		`false` if it was already started.
+	**/
+	function enable():Bool;
+}

--- a/src/js/node/perf_hooks/Performance.hx
+++ b/src/js/node/perf_hooks/Performance.hx
@@ -29,6 +29,10 @@ import js.node.PerfHooks.TimerifyOptions;
 import js.node.web.Event;
 import js.node.web.EventTarget;
 
+// Bring secondary types (option typedefs) from sibling modules into scope.
+import js.node.perf_hooks.PerformanceMark;
+import js.node.perf_hooks.PerformanceMeasure;
+
 /**
 	Events emitted by `Performance` (via `EventTarget`).
 **/
@@ -116,8 +120,8 @@ extern class Performance extends EventTarget {
 	/**
 		Creates a new `PerformanceMeasure` entry in the Performance Timeline.
 	**/
-	@:overload(function(name:String, ?startMark:String, ?endMark:String):PerformanceMeasure {})
-	function measure(name:String, options:PerformanceMeasureOptions):PerformanceMeasure;
+	@:overload(function(name:String, options:PerformanceMeasureOptions):PerformanceMeasure {})
+	function measure(name:String, ?startMark:String, ?endMark:String):PerformanceMeasure;
 
 	/**
 		An instance of the `PerformanceNodeTiming` class that provides performance metrics for

--- a/src/js/node/perf_hooks/Performance.hx
+++ b/src/js/node/perf_hooks/Performance.hx
@@ -79,9 +79,13 @@ extern class Performance extends EventTarget {
 	function clearResourceTimings(?name:String):Void;
 
 	/**
-		This is an alias of `PerfHooks.eventLoopUtilization()`.
+		Returns an object that contains the cumulative duration of time the event loop has been
+		both idle and active as a high resolution milliseconds timer.
 
 		This property is an extension by Node.js. It is not available in Web browsers.
+
+		Prefer this over the module-level `PerfHooks.eventLoopUtilization` when targeting
+		Node.js 22 LTS as well as Node.js 24; the module-level alias was only added in v24.12.0.
 	**/
 	function eventLoopUtilization(?utilization1:EventLoopUtilization, ?utilization2:EventLoopUtilization):EventLoopUtilization;
 
@@ -152,9 +156,14 @@ extern class Performance extends EventTarget {
 	var timeOrigin(default, null):Float;
 
 	/**
-		This is an alias of `PerfHooks.timerify()`.
+		Wraps a function within a new function that measures the running time of the wrapped function.
+		A `PerformanceObserver` must be subscribed to the `'function'` event type in order for the
+		timing details to be accessed.
 
 		This property is an extension by Node.js. It is not available in Web browsers.
+
+		Prefer this over the module-level `PerfHooks.timerify` when targeting Node.js 22 LTS as well
+		as Node.js 24; the module-level alias was only added in v24.12.0.
 	**/
 	function timerify<T:Function>(fn:T, ?options:TimerifyOptions):T;
 

--- a/src/js/node/perf_hooks/Performance.hx
+++ b/src/js/node/perf_hooks/Performance.hx
@@ -1,0 +1,166 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.perf_hooks;
+
+import haxe.Constraints.Function;
+import haxe.extern.EitherType;
+import js.node.PerfHooks.EventLoopUtilization;
+import js.node.PerfHooks.TimerifyOptions;
+import js.node.web.Event;
+import js.node.web.EventTarget;
+
+/**
+	Events emitted by `Performance` (via `EventTarget`).
+**/
+enum abstract PerformanceEvent(String) from String to String {
+	/**
+		The `'resourcetimingbufferfull'` event is fired when the global performance resource
+		timing buffer is full. Adjust resource timing buffer size with
+		`performance.setResourceTimingBufferSize()` or clear the buffer with
+		`performance.clearResourceTimings()` in the event listener to allow more entries
+		to be added to the performance timeline buffer.
+
+		@see https://nodejs.org/api/perf_hooks.html#event-resourcetimingbufferfull
+	**/
+	var ResourceTimingBufferFull = "resourcetimingbufferfull";
+}
+
+/**
+	An object that can be used to collect performance metrics from the current Node.js instance.
+	It is similar to `window.performance` in browsers.
+
+	Extends `EventTarget` (not `EventEmitter`).
+
+	@see https://nodejs.org/api/perf_hooks.html#class-performance
+	@see https://nodejs.org/api/globals.html#performance
+**/
+@:jsRequire("perf_hooks", "Performance")
+extern class Performance extends EventTarget {
+	/**
+		If `name` is not provided, removes all `PerformanceMark` objects from the Performance Timeline.
+		If `name` is provided, removes only the named mark.
+	**/
+	function clearMarks(?name:String):Void;
+
+	/**
+		If `name` is not provided, removes all `PerformanceMeasure` objects from the Performance Timeline.
+		If `name` is provided, removes only the named measure.
+	**/
+	function clearMeasures(?name:String):Void;
+
+	/**
+		If `name` is not provided, removes all `PerformanceResourceTiming` objects from the Resource Timeline.
+		If `name` is provided, removes only the named resource.
+	**/
+	function clearResourceTimings(?name:String):Void;
+
+	/**
+		This is an alias of `PerfHooks.eventLoopUtilization()`.
+
+		This property is an extension by Node.js. It is not available in Web browsers.
+	**/
+	function eventLoopUtilization(?utilization1:EventLoopUtilization, ?utilization2:EventLoopUtilization):EventLoopUtilization;
+
+	/**
+		Returns a list of `PerformanceEntry` objects in chronological order with respect to
+		`performanceEntry.startTime`.
+	**/
+	function getEntries():Array<PerformanceEntry>;
+
+	/**
+		Returns a list of `PerformanceEntry` objects in chronological order with respect to
+		`performanceEntry.startTime` whose `performanceEntry.name` is equal to `name`, and optionally,
+		whose `performanceEntry.entryType` is equal to `type`.
+	**/
+	function getEntriesByName(name:String, ?type:PerformanceEntryType):Array<PerformanceEntry>;
+
+	/**
+		Returns a list of `PerformanceEntry` objects in chronological order with respect to
+		`performanceEntry.startTime` whose `performanceEntry.entryType` is equal to `type`.
+	**/
+	function getEntriesByType(type:PerformanceEntryType):Array<PerformanceEntry>;
+
+	/**
+		Creates a new `PerformanceMark` entry in the Performance Timeline.
+	**/
+	function mark(name:String, ?options:PerformanceMarkOptions):PerformanceMark;
+
+	/**
+		Creates a new `PerformanceResourceTiming` entry in the Resource Timeline.
+
+		This property is an extension by Node.js. It is not available in Web browsers.
+	**/
+	function markResourceTiming(timingInfo:Dynamic, requestedUrl:String, initiatorType:String, global:Dynamic, cacheMode:String, bodyInfo:Dynamic,
+		responseStatus:Int, ?deliveryType:String):PerformanceResourceTiming;
+
+	/**
+		Creates a new `PerformanceMeasure` entry in the Performance Timeline.
+	**/
+	@:overload(function(name:String, ?startMark:String, ?endMark:String):PerformanceMeasure {})
+	function measure(name:String, options:PerformanceMeasureOptions):PerformanceMeasure;
+
+	/**
+		An instance of the `PerformanceNodeTiming` class that provides performance metrics for
+		specific Node.js operational milestones.
+
+		This property is an extension by Node.js. It is not available in Web browsers.
+	**/
+	var nodeTiming(default, null):PerformanceNodeTiming;
+
+	/**
+		Returns the current high resolution millisecond timestamp, where 0 represents the start
+		of the current `node` process.
+	**/
+	function now():Float;
+
+	/**
+		Sets the global performance resource timing buffer size to the specified number of
+		"resource" type performance entry objects.
+
+		By default the max buffer size is set to 250.
+	**/
+	function setResourceTimingBufferSize(maxSize:Int):Void;
+
+	/**
+		The timeOrigin specifies the high resolution millisecond timestamp at which the current
+		`node` process began, measured in Unix time.
+	**/
+	var timeOrigin(default, null):Float;
+
+	/**
+		This is an alias of `PerfHooks.timerify()`.
+
+		This property is an extension by Node.js. It is not available in Web browsers.
+	**/
+	function timerify<T:Function>(fn:T, ?options:TimerifyOptions):T;
+
+	/**
+		An object which is JSON representation of the `performance` object.
+	**/
+	function toJSON():Dynamic;
+
+	/**
+		Event handler for the `'resourcetimingbufferfull'` event.
+	**/
+	var onresourcetimingbufferfull:EitherType<Event->Void, Function>;
+}

--- a/src/js/node/perf_hooks/PerformanceEntry.hx
+++ b/src/js/node/perf_hooks/PerformanceEntry.hx
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.perf_hooks;
+
+/**
+	The constructor of this class is not exposed to users directly.
+
+	@see https://nodejs.org/api/perf_hooks.html#class-performanceentry
+**/
+@:jsRequire("perf_hooks", "PerformanceEntry")
+extern class PerformanceEntry {
+	/**
+		The total number of milliseconds elapsed for this entry.
+		This value will not be meaningful for all Performance Entry types.
+	**/
+	var duration(default, null):Float;
+
+	/**
+		The type of the performance entry.
+	**/
+	var entryType(default, null):PerformanceEntryType;
+
+	/**
+		The name of the performance entry.
+	**/
+	var name(default, null):String;
+
+	/**
+		The high resolution millisecond timestamp marking the starting time of the Performance Entry.
+	**/
+	var startTime(default, null):Float;
+
+	/**
+		Returns a JSON representation of the `PerformanceEntry` object.
+	**/
+	function toJSON():Dynamic;
+}

--- a/src/js/node/perf_hooks/PerformanceEntryType.hx
+++ b/src/js/node/perf_hooks/PerformanceEntryType.hx
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.perf_hooks;
+
+/**
+	Type of a performance entry (`performanceEntry.entryType`).
+
+	@see https://nodejs.org/api/perf_hooks.html#performanceentryentrytype
+**/
+enum abstract PerformanceEntryType(String) from String to String {
+	/** Node.js only **/
+	var Dns = "dns";
+
+	/** Node.js only **/
+	var Function = "function";
+
+	/** Node.js only **/
+	var Gc = "gc";
+
+	/** Node.js only **/
+	var Http2 = "http2";
+
+	/** Node.js only **/
+	var Http = "http";
+
+	/** Available on the Web **/
+	var Mark = "mark";
+
+	/** Available on the Web **/
+	var Measure = "measure";
+
+	/** Node.js only **/
+	var Net = "net";
+
+	/** Node.js only **/
+	var Node = "node";
+
+	/** Available on the Web **/
+	var Resource = "resource";
+}

--- a/src/js/node/perf_hooks/PerformanceMark.hx
+++ b/src/js/node/perf_hooks/PerformanceMark.hx
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.perf_hooks;
+
+/**
+	Exposes marks created via the `Performance.mark()` method.
+
+	@see https://nodejs.org/api/perf_hooks.html#class-performancemark
+**/
+@:jsRequire("perf_hooks", "PerformanceMark")
+extern class PerformanceMark extends PerformanceEntry {
+	function new(markName:String, ?markOptions:PerformanceMarkOptions);
+
+	/**
+		Additional detail specified when creating with `Performance.mark()` method.
+	**/
+	var detail(default, null):Dynamic;
+}
+
+/**
+	Options for `Performance.mark`.
+**/
+typedef PerformanceMarkOptions = {
+	/**
+		Additional optional detail to include with the mark.
+	**/
+	@:optional var detail:Dynamic;
+
+	/**
+		An optional timestamp to be used as the mark time.
+		Default: `performance.now()`.
+	**/
+	@:optional var startTime:Float;
+}

--- a/src/js/node/perf_hooks/PerformanceMeasure.hx
+++ b/src/js/node/perf_hooks/PerformanceMeasure.hx
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.perf_hooks;
+
+import haxe.extern.EitherType;
+
+/**
+	Exposes measures created via the `Performance.measure()` method.
+
+	The constructor of this class is not exposed to users directly.
+
+	@see https://nodejs.org/api/perf_hooks.html#class-performancemeasure
+**/
+@:jsRequire("perf_hooks", "PerformanceMeasure")
+extern class PerformanceMeasure extends PerformanceEntry {
+	/**
+		Additional detail specified when creating with `Performance.measure()` method.
+	**/
+	var detail(default, null):Dynamic;
+}
+
+/**
+	Options for `Performance.measure` when using the options-object form.
+**/
+typedef PerformanceMeasureOptions = {
+	/**
+		Additional optional detail to include with the measure.
+	**/
+	@:optional var detail:Dynamic;
+
+	/**
+		Duration between start and end times.
+	**/
+	@:optional var duration:Float;
+
+	/**
+		Timestamp to be used as the end time, or a string identifying a previously recorded mark.
+	**/
+	@:optional var end:EitherType<String, Float>;
+
+	/**
+		Timestamp to be used as the start time, or a string identifying a previously recorded mark.
+	**/
+	@:optional var start:EitherType<String, Float>;
+}

--- a/src/js/node/perf_hooks/PerformanceNodeEntry.hx
+++ b/src/js/node/perf_hooks/PerformanceNodeEntry.hx
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.perf_hooks;
+
+/**
+	This class is an extension by Node.js. It is not available in Web browsers.
+
+	Provides detailed Node.js timing data.
+
+	The constructor of this class is not exposed to users directly.
+
+	@see https://nodejs.org/api/perf_hooks.html#class-performancenodeentry
+**/
+extern class PerformanceNodeEntry extends PerformanceEntry {
+	/**
+		Additional detail specific to the `entryType`.
+	**/
+	var detail(default, null):Dynamic;
+
+	/**
+		Stability: 0 - Deprecated: Use `detail` instead.
+
+		When `entryType` is equal to `'gc'`, contains additional information about
+		garbage collection operation.
+	**/
+	@:deprecated("Use detail instead")
+	var flags(default, null):Int;
+
+	/**
+		Stability: 0 - Deprecated: Use `detail` instead.
+
+		When `entryType` is equal to `'gc'`, identifies the type of garbage collection
+		operation that occurred.
+	**/
+	@:deprecated("Use detail instead")
+	var kind(default, null):Int;
+}

--- a/src/js/node/perf_hooks/PerformanceNodeTiming.hx
+++ b/src/js/node/perf_hooks/PerformanceNodeTiming.hx
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.perf_hooks;
+
+/**
+	This property is an extension by Node.js. It is not available in Web browsers.
+
+	Provides timing details for Node.js itself. The constructor of this class is
+	not exposed to users.
+
+	@see https://nodejs.org/api/perf_hooks.html#class-performancenodetiming
+**/
+extern class PerformanceNodeTiming extends PerformanceEntry {
+	/**
+		The high resolution millisecond timestamp at which the Node.js process completed bootstrapping.
+		If bootstrapping has not yet finished, the property has the value of -1.
+	**/
+	var bootstrapComplete(default, null):Float;
+
+	/**
+		The high resolution millisecond timestamp at which the Node.js environment was initialized.
+	**/
+	var environment(default, null):Float;
+
+	/**
+		The high resolution millisecond timestamp of the amount of time the event loop has been idle
+		within the event loop's event provider (e.g. `epoll_wait`). This does not take CPU usage into
+		consideration. If the event loop has not yet started, the property has the value of 0.
+	**/
+	var idleTime(default, null):Float;
+
+	/**
+		The high resolution millisecond timestamp at which the Node.js event loop exited.
+		If the event loop has not yet exited, the property has the value of -1.
+	**/
+	var loopExit(default, null):Float;
+
+	/**
+		The high resolution millisecond timestamp at which the Node.js event loop started.
+		If the event loop has not yet started, the property has the value of -1.
+	**/
+	var loopStart(default, null):Float;
+
+	/**
+		The high resolution millisecond timestamp at which the Node.js process was initialized.
+	**/
+	var nodeStart(default, null):Float;
+
+	/**
+		A wrapper to the `uv_metrics_info` function. Returns the current set of event loop metrics.
+
+		It is recommended to use this property inside a function whose execution was scheduled using
+		`setImmediate` to avoid collecting metrics before finishing all operations scheduled during
+		the current loop iteration.
+	**/
+	var uvMetricsInfo(default, null):UVMetrics;
+
+	/**
+		The high resolution millisecond timestamp at which the V8 platform was initialized.
+	**/
+	var v8Start(default, null):Float;
+}
+
+/**
+	Event loop metrics from `PerformanceNodeTiming.uvMetricsInfo`.
+**/
+typedef UVMetrics = {
+	/**
+		Number of event loop iterations.
+	**/
+	var loopCount:Float;
+
+	/**
+		Number of events that have been processed by the event handler.
+	**/
+	var events:Float;
+
+	/**
+		Number of events that were waiting to be processed when the event provider was called.
+	**/
+	var eventsWaiting:Float;
+}

--- a/src/js/node/perf_hooks/PerformanceObserver.hx
+++ b/src/js/node/perf_hooks/PerformanceObserver.hx
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.perf_hooks;
+
+/**
+	`PerformanceObserver` objects provide notifications when new `PerformanceEntry`
+	instances have been added to the Performance Timeline.
+
+	@see https://nodejs.org/api/perf_hooks.html#class-performanceobserver
+**/
+@:jsRequire("perf_hooks", "PerformanceObserver")
+extern class PerformanceObserver {
+	/**
+		Get supported entry types.
+	**/
+	static var supportedEntryTypes(default, never):Array<PerformanceEntryType>;
+
+	/**
+		Creates a new `PerformanceObserver`.
+
+		The `callback` is invoked when a `PerformanceObserver` is notified about new
+		`PerformanceEntry` instances.
+	**/
+	function new(callback:PerformanceObserverCallback);
+
+	/**
+		Disconnects the `PerformanceObserver` instance from all notifications.
+	**/
+	function disconnect():Void;
+
+	/**
+		Subscribes the instance to notifications of new instances identified either by
+		`options.entryTypes` or `options.type`.
+	**/
+	function observe(options:PerformanceObserverObserveOptions):Void;
+
+	/**
+		Returns the current list of entries stored in the performance observer, emptying it out.
+	**/
+	function takeRecords():Array<PerformanceEntry>;
+}
+
+/**
+	Callback invoked when a `PerformanceObserver` is notified about new entries.
+**/
+typedef PerformanceObserverCallback = PerformanceObserverEntryList->PerformanceObserver->Void;
+
+/**
+	Options for `PerformanceObserver.observe`.
+**/
+typedef PerformanceObserverObserveOptions = {
+	/**
+		A single entry type. Must not be given if `entryTypes` is already specified.
+	**/
+	@:optional var type:PerformanceEntryType;
+
+	/**
+		An array of strings identifying the types of instances the observer is interested in.
+		If not provided an error will be thrown.
+	**/
+	@:optional var entryTypes:Array<PerformanceEntryType>;
+
+	/**
+		If `true`, the observer callback is called with a list of global `PerformanceEntry`
+		buffered entries. If `false`, only `PerformanceEntry`s created after the time point
+		are sent to the observer callback. Default: `false`.
+	**/
+	@:optional var buffered:Bool;
+}

--- a/src/js/node/perf_hooks/PerformanceObserverEntryList.hx
+++ b/src/js/node/perf_hooks/PerformanceObserverEntryList.hx
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.perf_hooks;
+
+/**
+	Used to provide access to the `PerformanceEntry` instances passed to a `PerformanceObserver`.
+	The constructor of this class is not exposed to users.
+
+	@see https://nodejs.org/api/perf_hooks.html#class-performanceobserverentrylist
+**/
+@:jsRequire("perf_hooks", "PerformanceObserverEntryList")
+extern class PerformanceObserverEntryList {
+	/**
+		Returns a list of `PerformanceEntry` objects in chronological order with respect to
+		`performanceEntry.startTime`.
+	**/
+	function getEntries():Array<PerformanceEntry>;
+
+	/**
+		Returns a list of `PerformanceEntry` objects in chronological order with respect to
+		`performanceEntry.startTime` whose `performanceEntry.name` is equal to `name`, and optionally,
+		whose `performanceEntry.entryType` is equal to `type`.
+	**/
+	function getEntriesByName(name:String, ?type:PerformanceEntryType):Array<PerformanceEntry>;
+
+	/**
+		Returns a list of `PerformanceEntry` objects in chronological order with respect to
+		`performanceEntry.startTime` whose `performanceEntry.entryType` is equal to `type`.
+	**/
+	function getEntriesByType(type:PerformanceEntryType):Array<PerformanceEntry>;
+}

--- a/src/js/node/perf_hooks/PerformanceResourceTiming.hx
+++ b/src/js/node/perf_hooks/PerformanceResourceTiming.hx
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.perf_hooks;
+
+/**
+	Provides detailed network timing data regarding the loading of an application's resources.
+
+	The constructor of this class is not exposed to users directly.
+
+	@see https://nodejs.org/api/perf_hooks.html#class-performanceresourcetiming
+**/
+@:jsRequire("perf_hooks", "PerformanceResourceTiming")
+extern class PerformanceResourceTiming extends PerformanceEntry {
+	/**
+		The high resolution millisecond timestamp at immediately before dispatching the `fetch` request.
+		If the resource is not intercepted by a worker the property will always return 0.
+	**/
+	var workerStart(default, null):Float;
+
+	/**
+		The high resolution millisecond timestamp that represents the start time of the fetch which
+		initiates the redirect.
+	**/
+	var redirectStart(default, null):Float;
+
+	/**
+		The high resolution millisecond timestamp that will be created immediately after receiving the
+		last byte of the response of the last redirect.
+	**/
+	var redirectEnd(default, null):Float;
+
+	/**
+		The high resolution millisecond timestamp immediately before the Node.js starts to fetch the resource.
+	**/
+	var fetchStart(default, null):Float;
+
+	/**
+		The high resolution millisecond timestamp immediately before the Node.js starts the domain name
+		lookup for the resource.
+	**/
+	var domainLookupStart(default, null):Float;
+
+	/**
+		The high resolution millisecond timestamp representing the time immediately after the Node.js
+		finished the domain name lookup for the resource.
+	**/
+	var domainLookupEnd(default, null):Float;
+
+	/**
+		The high resolution millisecond timestamp representing the time immediately before Node.js starts
+		to establish the connection to the server to retrieve the resource.
+	**/
+	var connectStart(default, null):Float;
+
+	/**
+		The high resolution millisecond timestamp representing the time immediately after Node.js finishes
+		establishing the connection to the server to retrieve the resource.
+	**/
+	var connectEnd(default, null):Float;
+
+	/**
+		The high resolution millisecond timestamp representing the time immediately before Node.js starts
+		the handshake process to secure the current connection.
+	**/
+	var secureConnectionStart(default, null):Float;
+
+	/**
+		The high resolution millisecond timestamp representing the time immediately before Node.js receives
+		the first byte of the response from the server.
+	**/
+	var requestStart(default, null):Float;
+
+	/**
+		The high resolution millisecond timestamp representing the time immediately after Node.js receives
+		the last byte of the resource or immediately before the transport connection is closed, whichever
+		comes first.
+	**/
+	var responseEnd(default, null):Float;
+
+	/**
+		A number representing the size (in octets) of the fetched resource. The size includes the response
+		header fields plus the response payload body.
+	**/
+	var transferSize(default, null):Float;
+
+	/**
+		A number representing the size (in octets) received from the fetch (HTTP or cache), of the payload
+		body, before removing any applied content-codings.
+	**/
+	var encodedBodySize(default, null):Float;
+
+	/**
+		A number representing the size (in octets) received from the fetch (HTTP or cache), of the message
+		body, after removing any applied content-codings.
+	**/
+	var decodedBodySize(default, null):Float;
+
+	/**
+		Returns an object that is the JSON representation of the `PerformanceResourceTiming` object.
+	**/
+	override function toJSON():Dynamic;
+}

--- a/src/js/node/perf_hooks/RecordableHistogram.hx
+++ b/src/js/node/perf_hooks/RecordableHistogram.hx
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.perf_hooks;
+
+import haxe.extern.EitherType;
+
+/**
+	A `Histogram` that can record values.
+
+	@see https://nodejs.org/api/perf_hooks.html#class-recordablehistogram-extends-histogram
+**/
+extern class RecordableHistogram extends Histogram {
+	/**
+		Adds the values from `other` to this histogram.
+	**/
+	function add(other:RecordableHistogram):Void;
+
+	/**
+		Records `val` in the histogram.
+	**/
+	function record(val:EitherType<Float, Dynamic>):Void;
+
+	/**
+		Calculates the amount of time (in nanoseconds) that has passed since the previous call
+		to `recordDelta()` and records that amount in the histogram.
+	**/
+	function recordDelta():Void;
+}


### PR DESCRIPTION
## Summary
- Add `js.node.PerfHooks` (`@:jsRequire("perf_hooks")`) with `performance`, `constants`, `createHistogram`, `monitorEventLoopDelay`, `eventLoopUtilization`, and `timerify`
- Add classes under `js.node.perf_hooks`: `Performance`, entry/observer/resource timing types, and `Histogram` / `IntervalHistogram` / `RecordableHistogram`
- Wire global `performance` on `js.Node` via `Syntax.code("performance")`, typed as `js.node.perf_hooks.Performance`

## Test plan
- [x] `haxe build.hxml` succeeds in the worktree
- [ ] Spot-check against [Node.js v24 perf_hooks docs](https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html) and globals `performance`

Made with [Cursor](https://cursor.com)