### PR TITLE
Add Node.js inspector (+ inspector/promises) externs

### DIFF
--- a/src/js/node/Inspector.hx
+++ b/src/js/node/Inspector.hx
@@ -40,7 +40,8 @@ extern class Inspector {
 		If `wait` is `true`, will block until a client has connected to the inspect port
 		and flow control has been passed to the debugger client.
 
-		Returns a Disposable that calls `inspector.close()` (via `Symbol.dispose`).
+		Returns a Disposable (`{ [Symbol.dispose](): void }`) that calls `inspector.close()`.
+		Typed as `Dynamic` because hxnodejs does not yet model the Web IDL `Disposable` interface.
 	**/
 	static function open(?port:Int, ?host:String, ?wait:Bool):Dynamic;
 

--- a/src/js/node/Inspector.hx
+++ b/src/js/node/Inspector.hx
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node;
+
+import js.node.inspector.InspectorConsole;
+
+/**
+	The `inspector` module provides an API for interacting with the V8 inspector.
+
+	Related types live under `js.node.inspector` (`Session`, `Network`, `NetworkResources`, `DomStorage`).
+
+	@see https://nodejs.org/api/inspector.html
+**/
+@:jsRequire("inspector")
+extern class Inspector {
+	/**
+		Activate inspector on host and port. Equivalent to `node --inspect=[[host:]port]`,
+		but can be done programmatically after node has started.
+
+		If `wait` is `true`, will block until a client has connected to the inspect port
+		and flow control has been passed to the debugger client.
+
+		Returns a Disposable that calls `inspector.close()` (via `Symbol.dispose`).
+	**/
+	static function open(?port:Int, ?host:String, ?wait:Bool):Dynamic;
+
+	/**
+		Attempts to close all remaining connections, blocking the event loop until all are closed.
+		Once all connections are closed, deactivates the inspector.
+	**/
+	static function close():Void;
+
+	/**
+		Return the URL of the active inspector, or `undefined` if there is none.
+	**/
+	static function url():Null<String>;
+
+	/**
+		Blocks until a client (existing or connected later) has sent
+		`Runtime.runIfWaitingForDebugger` command.
+
+		An exception will be thrown if there is no active inspector.
+	**/
+	static function waitForDebugger():Void;
+
+	/**
+		An object to send messages to the remote inspector console.
+
+		The inspector console does not have API parity with Node.js console.
+	**/
+	static var console(default, null):InspectorConsole;
+}

--- a/src/js/node/InspectorPromises.hx
+++ b/src/js/node/InspectorPromises.hx
@@ -39,7 +39,9 @@ import js.node.inspector.promises.Session;
 extern class InspectorPromises {
 	/**
 		Activate inspector on host and port.
-		Returns a Disposable that calls `close()`.
+
+		Returns a Disposable (`{ [Symbol.dispose](): void }`) that calls `close()`.
+		Typed as `Dynamic` because hxnodejs does not yet model the Web IDL `Disposable` interface.
 	**/
 	static function open(?port:Int, ?host:String, ?wait:Bool):Dynamic;
 

--- a/src/js/node/InspectorPromises.hx
+++ b/src/js/node/InspectorPromises.hx
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node;
+
+import js.node.inspector.InspectorConsole;
+import js.node.inspector.promises.Session;
+
+/**
+	Promise-based `inspector` API (`inspector/promises`).
+
+	Stability: 1 - Experimental.
+
+	Module-level helpers match `Inspector`; use `js.node.inspector.promises.Session`
+	for a `Session` whose `post` returns a `Promise`.
+
+	@see https://nodejs.org/api/inspector.html#promises-api
+**/
+@:jsRequire("inspector/promises")
+extern class InspectorPromises {
+	/**
+		Activate inspector on host and port.
+		Returns a Disposable that calls `close()`.
+	**/
+	static function open(?port:Int, ?host:String, ?wait:Bool):Dynamic;
+
+	/**
+		Attempts to close all remaining connections, blocking the event loop until all are closed.
+	**/
+	static function close():Void;
+
+	/**
+		Return the URL of the active inspector, or `undefined` if there is none.
+	**/
+	static function url():Null<String>;
+
+	/**
+		Blocks until a client has sent `Runtime.runIfWaitingForDebugger`.
+	**/
+	static function waitForDebugger():Void;
+
+	/**
+		An object to send messages to the remote inspector console.
+	**/
+	static var console(default, null):InspectorConsole;
+}

--- a/src/js/node/inspector/DomStorage.hx
+++ b/src/js/node/inspector/DomStorage.hx
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.inspector;
+
+/**
+	Helpers that broadcast Chrome DevTools Protocol `DOMStorage` events to connected frontends.
+
+	Only available with the `--experimental-storage-inspection` flag enabled.
+
+	Haxe type is `DomStorage` (acronyms are not uppercased); the Node.js export name is `DOMStorage`.
+
+	@see https://nodejs.org/api/inspector.html#inspectordomstoragedomstorageitemadded
+**/
+@:jsRequire("inspector", "DOMStorage")
+extern class DomStorage {
+	/**
+		Broadcasts the `DOMStorage.domStorageItemAdded` event to connected frontends.
+	**/
+	static function domStorageItemAdded(params:DomStorageItemAddedParams):Void;
+
+	/**
+		Broadcasts the `DOMStorage.domStorageItemRemoved` event to connected frontends.
+	**/
+	static function domStorageItemRemoved(params:DomStorageItemRemovedParams):Void;
+
+	/**
+		Broadcasts the `DOMStorage.domStorageItemUpdated` event to connected frontends.
+	**/
+	static function domStorageItemUpdated(params:DomStorageItemUpdatedParams):Void;
+
+	/**
+		Broadcasts the `DOMStorage.domStorageItemsCleared` event to connected frontends.
+	**/
+	static function domStorageItemsCleared(params:DomStorageItemsClearedParams):Void;
+
+	/**
+		Registers storage for inspection.
+	**/
+	static function registerStorage(params:Dynamic):Void;
+}
+
+typedef DomStorageId = {
+	@:optional var securityOrigin:String;
+	@:optional var storageKey:String;
+	var isLocalStorage:Bool;
+}
+
+typedef DomStorageItemAddedParams = {
+	var storageId:DomStorageId;
+	var key:String;
+	var newValue:String;
+}
+
+typedef DomStorageItemRemovedParams = {
+	var storageId:DomStorageId;
+	var key:String;
+}
+
+typedef DomStorageItemUpdatedParams = {
+	var storageId:DomStorageId;
+	var key:String;
+	var oldValue:String;
+	var newValue:String;
+}
+
+typedef DomStorageItemsClearedParams = {
+	var storageId:DomStorageId;
+}

--- a/src/js/node/inspector/DomStorage.hx
+++ b/src/js/node/inspector/DomStorage.hx
@@ -25,6 +25,7 @@ package js.node.inspector;
 /**
 	Helpers that broadcast Chrome DevTools Protocol `DOMStorage` events to connected frontends.
 
+	Added in: v24.16.0 (Active LTS). Not available on Maintenance LTS 22.x.
 	Only available with the `--experimental-storage-inspection` flag enabled.
 
 	Haxe type is `DomStorage` (acronyms are not uppercased); the Node.js export name is `DOMStorage`.

--- a/src/js/node/inspector/InspectorConsole.hx
+++ b/src/js/node/inspector/InspectorConsole.hx
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.inspector;
+
+import haxe.extern.Rest;
+
+/**
+	Object used to send messages to the remote inspector console.
+
+	The inspector console does not have API parity with Node.js console.
+
+	@see https://nodejs.org/api/inspector.html#inspectorconsole
+**/
+extern class InspectorConsole {
+	function debug(data:Rest<Dynamic>):Void;
+	function error(data:Rest<Dynamic>):Void;
+	function info(data:Rest<Dynamic>):Void;
+	function log(data:Rest<Dynamic>):Void;
+	function warn(data:Rest<Dynamic>):Void;
+	function dir(data:Rest<Dynamic>):Void;
+	function dirxml(data:Rest<Dynamic>):Void;
+	function table(data:Rest<Dynamic>):Void;
+	function trace(data:Rest<Dynamic>):Void;
+	function group(data:Rest<Dynamic>):Void;
+	function groupCollapsed(data:Rest<Dynamic>):Void;
+	function groupEnd(data:Rest<Dynamic>):Void;
+	function clear(data:Rest<Dynamic>):Void;
+	function count(?label:Dynamic):Void;
+	function countReset(?label:Dynamic):Void;
+	function assert(?value:Dynamic, data:Rest<Dynamic>):Void;
+	function profile(?label:Dynamic):Void;
+	function profileEnd(?label:Dynamic):Void;
+	function time(?label:Dynamic):Void;
+	function timeLog(?label:Dynamic):Void;
+	function timeStamp(?label:Dynamic):Void;
+}

--- a/src/js/node/inspector/Network.hx
+++ b/src/js/node/inspector/Network.hx
@@ -73,18 +73,24 @@ extern class Network {
 	/**
 		Broadcasts the `Network.webSocketCreated` event to connected frontends.
 		This event indicates that a WebSocket connection has been initiated.
+
+		Added in: v24.7.0. Not available on Maintenance LTS 22.x.
 	**/
 	static function webSocketCreated(?params:NetworkWebSocketCreatedParams):Void;
 
 	/**
 		Broadcasts the `Network.webSocketHandshakeResponseReceived` event to connected frontends.
 		This event indicates that the WebSocket handshake response has been received.
+
+		Added in: v24.7.0. Not available on Maintenance LTS 22.x.
 	**/
 	static function webSocketHandshakeResponseReceived(?params:NetworkWebSocketHandshakeResponseReceivedParams):Void;
 
 	/**
 		Broadcasts the `Network.webSocketClosed` event to connected frontends.
 		This event indicates that a WebSocket connection has been closed.
+
+		Added in: v24.7.0. Not available on Maintenance LTS 22.x.
 	**/
 	static function webSocketClosed(?params:NetworkWebSocketClosedParams):Void;
 }

--- a/src/js/node/inspector/Network.hx
+++ b/src/js/node/inspector/Network.hx
@@ -1,0 +1,215 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.inspector;
+
+/**
+	Broadcast helpers for Chrome DevTools Protocol `Network.*` events.
+
+	These APIs require the `--experimental-network-inspection` flag.
+
+	Usage: `Network.requestWillBeSent({ ... })` (maps to `inspector.Network` in Node.js).
+
+	@see https://nodejs.org/api/inspector.html#integration-with-devtools
+**/
+@:jsRequire("inspector", "Network")
+extern class Network {
+	/**
+		Broadcasts the `Network.dataReceived` event to connected frontends, or buffers the data if
+		`Network.streamResourceContent` command was not invoked for the given request yet.
+
+		Also enables `Network.getResponseBody` command to retrieve the response data.
+	**/
+	static function dataReceived(?params:NetworkDataReceivedParams):Void;
+
+	/**
+		Enables `Network.getRequestPostData` command to retrieve the request data.
+	**/
+	static function dataSent(?params:Dynamic):Void;
+
+	/**
+		Broadcasts the `Network.requestWillBeSent` event to connected frontends.
+		This event indicates that the application is about to send an HTTP request.
+	**/
+	static function requestWillBeSent(?params:NetworkRequestWillBeSentParams):Void;
+
+	/**
+		Broadcasts the `Network.responseReceived` event to connected frontends.
+		This event indicates that HTTP response is available.
+	**/
+	static function responseReceived(?params:NetworkResponseReceivedParams):Void;
+
+	/**
+		Broadcasts the `Network.loadingFinished` event to connected frontends.
+		This event indicates that HTTP request has finished loading.
+	**/
+	static function loadingFinished(?params:NetworkLoadingFinishedParams):Void;
+
+	/**
+		Broadcasts the `Network.loadingFailed` event to connected frontends.
+		This event indicates that HTTP request has failed to load.
+	**/
+	static function loadingFailed(?params:NetworkLoadingFailedParams):Void;
+
+	/**
+		Broadcasts the `Network.webSocketCreated` event to connected frontends.
+		This event indicates that a WebSocket connection has been initiated.
+	**/
+	static function webSocketCreated(?params:NetworkWebSocketCreatedParams):Void;
+
+	/**
+		Broadcasts the `Network.webSocketHandshakeResponseReceived` event to connected frontends.
+		This event indicates that the WebSocket handshake response has been received.
+	**/
+	static function webSocketHandshakeResponseReceived(?params:NetworkWebSocketHandshakeResponseReceivedParams):Void;
+
+	/**
+		Broadcasts the `Network.webSocketClosed` event to connected frontends.
+		This event indicates that a WebSocket connection has been closed.
+	**/
+	static function webSocketClosed(?params:NetworkWebSocketClosedParams):Void;
+}
+
+/**
+	Pragmatic subset of CDP `Network.Request`.
+**/
+typedef NetworkRequest = {
+	var url:String;
+	var method:String;
+	@:optional var headers:Dynamic;
+	@:optional var postData:String;
+	@:optional var hasPostData:Bool;
+}
+
+/**
+	Pragmatic subset of CDP `Network.Response`.
+**/
+typedef NetworkResponse = {
+	@:optional var url:String;
+	@:optional var status:Int;
+	@:optional var statusText:String;
+	@:optional var headers:Dynamic;
+	@:optional var mimeType:String;
+	@:optional var charset:String;
+}
+
+/**
+	Pragmatic subset of CDP request initiator.
+**/
+typedef NetworkInitiator = {
+	var type:String;
+	@:optional var url:String;
+	@:optional var lineNumber:Float;
+	@:optional var columnNumber:Float;
+	@:optional var stack:Dynamic;
+}
+
+/**
+	Parameters for `Network.requestWillBeSent`.
+**/
+typedef NetworkRequestWillBeSentParams = {
+	var requestId:String;
+	var timestamp:Float;
+	var wallTime:Float;
+	var request:NetworkRequest;
+	@:optional var initiator:NetworkInitiator;
+	@:optional var type:String;
+	@:optional var frameId:String;
+	@:optional var hasUserGesture:Bool;
+}
+
+/**
+	Parameters for `Network.responseReceived`.
+**/
+typedef NetworkResponseReceivedParams = {
+	var requestId:String;
+	var timestamp:Float;
+	var type:String;
+	var response:NetworkResponse;
+	@:optional var frameId:String;
+}
+
+/**
+	Parameters for `Network.loadingFinished`.
+**/
+typedef NetworkLoadingFinishedParams = {
+	var requestId:String;
+	var timestamp:Float;
+	@:optional var encodedDataLength:Float;
+}
+
+/**
+	Parameters for `Network.loadingFailed`.
+**/
+typedef NetworkLoadingFailedParams = {
+	var requestId:String;
+	var timestamp:Float;
+	var type:String;
+	var errorText:String;
+	@:optional var canceled:Bool;
+}
+
+/**
+	Parameters for `Network.dataReceived`.
+**/
+typedef NetworkDataReceivedParams = {
+	var requestId:String;
+	var timestamp:Float;
+	var dataLength:Int;
+	var encodedDataLength:Int;
+	@:optional var data:String;
+}
+
+/**
+	Parameters for `Network.webSocketCreated`.
+**/
+typedef NetworkWebSocketCreatedParams = {
+	var requestId:String;
+	var url:String;
+	@:optional var initiator:NetworkInitiator;
+}
+
+/**
+	Parameters for `Network.webSocketHandshakeResponseReceived`.
+**/
+typedef NetworkWebSocketHandshakeResponseReceivedParams = {
+	var requestId:String;
+	var timestamp:Float;
+	var response:NetworkWebSocketResponse;
+}
+
+/**
+	Pragmatic subset of CDP WebSocket handshake response.
+**/
+typedef NetworkWebSocketResponse = {
+	var status:Int;
+	var statusText:String;
+	@:optional var headers:Dynamic;
+}
+
+/**
+	Parameters for `Network.webSocketClosed`.
+**/
+typedef NetworkWebSocketClosedParams = {
+	var requestId:String;
+	var timestamp:Float;
+}

--- a/src/js/node/inspector/NetworkResources.hx
+++ b/src/js/node/inspector/NetworkResources.hx
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.inspector;
+
+/**
+	Provides responses for `Network.loadNetworkResource` CDP requests
+	(e.g. source maps requested by a DevTools frontend).
+
+	Requires the `--experimental-inspector-network-resource` flag.
+
+	Usage: `NetworkResources.put(url, data)` (maps to `inspector.NetworkResources` in Node.js).
+
+	@see https://nodejs.org/api/inspector.html#inspectornetworkresourcesput
+**/
+@:jsRequire("inspector", "NetworkResources")
+extern class NetworkResources {
+	/**
+		Register resource content to be served in response to a `loadNetworkResource` request.
+	**/
+	static function put(url:String, data:String):Void;
+}

--- a/src/js/node/inspector/Session.hx
+++ b/src/js/node/inspector/Session.hx
@@ -49,7 +49,7 @@ enum abstract SessionEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 	/**
 		Emitted when an inspector notification is received with method `Debugger.resumed`.
 	**/
-	var DebuggerResumed:SessionEvent<Void->Void> = "Debugger.resumed";
+	var DebuggerResumed:SessionEvent<InspectorNotificationMessage->Void> = "Debugger.resumed";
 
 	/**
 		Emitted when an inspector notification is received with method `HeapProfiler.addHeapSnapshotChunk`.

--- a/src/js/node/inspector/Session.hx
+++ b/src/js/node/inspector/Session.hx
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.inspector;
+
+import js.node.events.EventEmitter;
+#if haxe4
+import js.lib.Error;
+#else
+import js.Error;
+#end
+
+/**
+	Enumeration of events emitted by `inspector.Session`.
+
+	Arbitrary Chrome DevTools Protocol notification method names can also be used
+	as event names (e.g. `'Runtime.consoleAPICalled'`).
+**/
+enum abstract SessionEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
+	/**
+		Emitted when any notification from the V8 Inspector is received.
+	**/
+	var InspectorNotification:SessionEvent<InspectorNotificationMessage->Void> = "inspectorNotification";
+
+	/**
+		Emitted when an inspector notification is received with method `Debugger.paused`.
+	**/
+	var DebuggerPaused:SessionEvent<InspectorNotificationMessage->Void> = "Debugger.paused";
+
+	/**
+		Emitted when an inspector notification is received with method `Debugger.resumed`.
+	**/
+	var DebuggerResumed:SessionEvent<Void->Void> = "Debugger.resumed";
+
+	/**
+		Emitted when an inspector notification is received with method `HeapProfiler.addHeapSnapshotChunk`.
+	**/
+	var HeapProfilerAddHeapSnapshotChunk:SessionEvent<InspectorNotificationMessage->Void> = "HeapProfiler.addHeapSnapshotChunk";
+}
+
+/**
+	A notification message object received from the V8 inspector.
+
+	`params` shape depends on the Chrome DevTools Protocol method; kept pragmatic here.
+**/
+typedef InspectorNotificationMessage = {
+	var method:String;
+	@:optional var params:Dynamic;
+}
+
+/**
+	The `inspector.Session` is used for dispatching messages to the V8 inspector
+	back-end and receiving message responses and notifications.
+
+	@see https://nodejs.org/api/inspector.html#class-inspectorsession
+**/
+@:jsRequire("inspector", "Session")
+extern class Session extends EventEmitter<Session> {
+	/**
+		Create a new instance of the `inspector.Session` class.
+		The inspector session needs to be connected through `session.connect()`
+		before the messages can be dispatched to the inspector backend.
+	**/
+	function new();
+
+	/**
+		Connects a session to the inspector back-end.
+	**/
+	function connect():Void;
+
+	/**
+		Connects a session to the main thread inspector back-end.
+		An exception will be thrown if this API was not called on a Worker thread.
+	**/
+	function connectToMainThread():Void;
+
+	/**
+		Immediately close the session. All pending message callbacks will be called with an error.
+		`session.connect()` will need to be called to be able to send messages again.
+		Reconnected session will lose all inspector state, such as enabled agents or configured breakpoints.
+	**/
+	function disconnect():Void;
+
+	/**
+		Posts a message to the inspector back-end.
+
+		`callback` will be notified when a response is received.
+		`callback` is a function that accepts two optional arguments: error and message-specific result.
+
+		Protocol method names and parameter/result shapes follow the Chrome DevTools Protocol;
+		they are typed as `String` / `Dynamic` rather than enumerating the full CDP schema.
+	**/
+	@:overload(function(method:String, ?callback:Null<Error>->Dynamic->Void):Void {})
+	function post(method:String, ?params:Dynamic, ?callback:Null<Error>->Dynamic->Void):Void;
+}

--- a/src/js/node/inspector/promises/Session.hx
+++ b/src/js/node/inspector/promises/Session.hx
@@ -34,6 +34,9 @@ import js.Promise;
 
 	Stability: 1 - Experimental.
 
+	Emits the same notification events as callback `inspector.Session`;
+	use `js.node.inspector.SessionEvent` with `on` / `once` / `off`.
+
 	@see https://nodejs.org/api/inspector.html#promises-api
 **/
 @:jsRequire("inspector/promises", "Session")

--- a/src/js/node/inspector/promises/Session.hx
+++ b/src/js/node/inspector/promises/Session.hx
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.inspector.promises;
+
+import js.node.events.EventEmitter;
+#if haxe4
+import js.lib.Promise;
+#else
+import js.Promise;
+#end
+
+/**
+	Promise-based `inspector.Session` from `inspector/promises`.
+
+	Stability: 1 - Experimental.
+
+	@see https://nodejs.org/api/inspector.html#promises-api
+**/
+@:jsRequire("inspector/promises", "Session")
+extern class Session extends EventEmitter<Session> {
+	/**
+		Create a new instance of the `inspector.Session` class.
+		The inspector session needs to be connected through `session.connect()`
+		before the messages can be dispatched to the inspector backend.
+	**/
+	function new();
+
+	/**
+		Connects a session to the inspector back-end.
+	**/
+	function connect():Void;
+
+	/**
+		Connects a session to the main thread inspector back-end.
+		An exception will be thrown if this API was not called on a Worker thread.
+	**/
+	function connectToMainThread():Void;
+
+	/**
+		Immediately close the session. All pending message callbacks will be called with an error.
+		`session.connect()` will need to be called to be able to send messages again.
+		Reconnected session will lose all inspector state, such as enabled agents or configured breakpoints.
+	**/
+	function disconnect():Void;
+
+	/**
+		Posts a message to the inspector back-end and returns a Promise that resolves
+		with the message-specific result object.
+	**/
+	function post(method:String, ?params:Dynamic):Promise<Dynamic>;
+}


### PR DESCRIPTION
## Summary
- Add `js.node.Inspector` for the stable `inspector` module: `open` / `close` / `url` / `waitForDebugger` / `console`
- Add `js.node.inspector.Session` (EventEmitter subclass) with typed session events where practical and callback-based `post`
- Add pragmatic DevTools helpers: `Network`, `NetworkResources`, `DomStorage` (experimental Node flags), without exhaustive CDP schema typings
- Add thin `js.node.InspectorPromises` + `js.node.inspector.promises.Session` for Promise-returning `post`

## Test plan
- [x] `haxe build.hxml` (Haxe 5.0.0-preview.1) — passes (pre-existing Url/Domain warnings only)
- [ ] Spot-check `Session.connect` / `post` against Node 24 inspector callback API
- [ ] Spot-check `inspector/promises` Session `post` returns a Promise
- [ ] Spot-check `Network.requestWillBeSent` param typedefs against Node docs examples


Made with [Cursor](https://cursor.com)