### PR TITLE
Add dns/promises externs

### DIFF
--- a/src/js/node/Dns.hx
+++ b/src/js/node/Dns.hx
@@ -467,7 +467,7 @@ typedef DnsLookupCallbackAllEntry = {address:String, family:DnsAddressFamily};
 	they do not use the configuration from /etc/hosts. These functions should be used by developers who do not want
 	to use the underlying operating system's facilities for name resolution, and instead want to always perform DNS queries.
 
-	@see https://nodejs.org/docs/latest-v22.x/api/dns.html
+	@see https://nodejs.org/docs/latest-v24.x/api/dns.html
 **/
 @:jsRequire("dns")
 extern class Dns {
@@ -671,7 +671,7 @@ extern class Dns {
 	/**
 		`Resolver` class constructor for an independent DNS resolver.
 
-		@see https://nodejs.org/docs/latest-v22.x/api/dns.html#class-dnsresolver
+		@see https://nodejs.org/docs/latest-v24.x/api/dns.html#class-dnsresolver
 	**/
 	static var Resolver:Class<ResolverObject>;
 }

--- a/src/js/node/Dns.hx
+++ b/src/js/node/Dns.hx
@@ -23,9 +23,12 @@
 package js.node;
 
 import haxe.extern.EitherType;
+import js.node.dns.Resolver as ResolverObject;
 #if haxe4
+import js.lib.ArrayBuffer;
 import js.lib.Error;
 #else
+import js.html.ArrayBuffer;
 import js.Error;
 #end
 
@@ -38,13 +41,25 @@ enum abstract DnsAddressFamily(Int) from Int to Int {
 }
 
 /**
+	Values for the `order` option of `Dns.lookup` / `DnsPromises.lookup`
+	and for `Dns.setDefaultResultOrder` / `Dns.getDefaultResultOrder`.
+**/
+enum abstract DnsResultOrder(String) from String to String {
+	var Ipv4First = "ipv4first";
+	var Ipv6First = "ipv6first";
+	var Verbatim = "verbatim";
+}
+
+/**
 	Type of the `options` argument for `Dns.lookup`.
 **/
 typedef DnsLookupOptions = {
 	/**
-		The record family. If not provided, both IP v4 and v6 addresses are accepted.
+		The record family. Must be `4`, `6`, or `0`.
+		For compatibility, `'IPv4'` and `'IPv6'` are also accepted.
+		The value `0` indicates that either an IPv4 or IPv6 address is returned.
 	**/
-	@:optional var family:DnsAddressFamily;
+	@:optional var family:EitherType<DnsAddressFamily, String>;
 
 	/**
 		If present, it should be one or more of the supported `getaddrinfo` flags.
@@ -58,6 +73,52 @@ typedef DnsLookupOptions = {
 		Defaults to false.
 	**/
 	@:optional var all:Bool;
+
+	/**
+		When `verbatim`, the resolved addresses are returned unsorted.
+		When `ipv4first` / `ipv6first`, addresses are sorted accordingly.
+		Default is configurable via `Dns.setDefaultResultOrder`.
+	**/
+	@:optional var order:DnsResultOrder;
+
+	/**
+		When `true`, the callback receives IPv4 and IPv6 addresses in the order the DNS resolver returned them.
+		When `false`, IPv4 addresses are placed before IPv6 addresses.
+
+		Deprecated in favor of `order`. When both are specified, `order` has higher precedence.
+	**/
+	@:optional var verbatim:Bool;
+}
+
+/**
+	Options for `Dns.resolve4` / `Dns.resolve6`.
+**/
+typedef DnsResolveOptions = {
+	/**
+		When `true`, each record includes its TTL (in seconds).
+	**/
+	@:optional var ttl:Bool;
+}
+
+/**
+	Options for constructing a `dns.Resolver`.
+**/
+typedef DnsResolverOptions = {
+	/**
+		Query timeout in milliseconds, or `-1` to use the default timeout.
+	**/
+	@:optional var timeout:Int;
+
+	/**
+		The number of tries the resolver will try contacting each name server before giving up.
+		Default: `4`.
+	**/
+	@:optional var tries:Int;
+
+	/**
+		The max retry timeout, in milliseconds. Default: `0` (disabled).
+	**/
+	@:optional var maxTimeout:Int;
 }
 
 /**
@@ -75,6 +136,16 @@ enum abstract DnsRrtype(String) from String to String {
 	var AAAA = "AAAA";
 
 	/**
+		any records
+	**/
+	var ANY = "ANY";
+
+	/**
+		CA authorization records
+	**/
+	var CAA = "CAA";
+
+	/**
 		mail exchange records
 	**/
 	var MX = "MX";
@@ -90,9 +161,19 @@ enum abstract DnsRrtype(String) from String to String {
 	var SRV = "SRV";
 
 	/**
+		certificate associations
+	**/
+	var TLSA = "TLSA";
+
+	/**
 		used for reverse IP lookups
 	**/
 	var PTR = "PTR";
+
+	/**
+		name authority pointer records
+	**/
+	var NAPTR = "NAPTR";
 
 	/**
 		name server records
@@ -117,7 +198,116 @@ typedef DnsResolvedAddressMX = {priority:Int, exchange:String};
 
 typedef DnsResolvedAddressSRV = {priority:Int, weight:Int, port:Int, name:String};
 typedef DnsResolvedAddressSOA = {nsname:String, hostmaster:String, serial:Int, refresh:Int, retry:Int, expire:Int, minttl:Int};
-typedef DnsResolvedAddress = EitherType<String, EitherType<DnsResolvedAddressMX, EitherType<DnsResolvedAddressSOA, DnsResolvedAddressSRV>>>;
+
+typedef DnsResolvedAddressCAA = {
+	var critical:Int;
+	@:optional var issue:String;
+	@:optional var issuewild:String;
+	@:optional var iodef:String;
+	@:optional var contactemail:String;
+	@:optional var contactphone:String;
+};
+
+typedef DnsResolvedAddressNAPTR = {
+	var flags:String;
+	var service:String;
+	var regexp:String;
+	var replacement:String;
+	var order:Int;
+	var preference:Int;
+};
+
+typedef DnsResolvedAddressTLSA = {
+	var certUsage:Int;
+	var selector:Int;
+	var match:Int;
+	var data:ArrayBuffer;
+};
+
+/**
+	Address record that includes TTL, returned by `resolve4`/`resolve6` when `ttl` is true.
+**/
+typedef DnsRecordWithTtl = {
+	var address:String;
+	var ttl:Int;
+};
+
+typedef DnsAnyARecord = {
+	> DnsRecordWithTtl,
+	var type:String;
+};
+
+typedef DnsAnyAaaaRecord = {
+	> DnsRecordWithTtl,
+	var type:String;
+};
+
+typedef DnsAnyCaaRecord = {
+	> DnsResolvedAddressCAA,
+	var type:String;
+};
+
+typedef DnsAnyMxRecord = {
+	> DnsResolvedAddressMX,
+	var type:String;
+};
+
+typedef DnsAnyNaptrRecord = {
+	> DnsResolvedAddressNAPTR,
+	var type:String;
+};
+
+typedef DnsAnySoaRecord = {
+	> DnsResolvedAddressSOA,
+	var type:String;
+};
+
+typedef DnsAnySrvRecord = {
+	> DnsResolvedAddressSRV,
+	var type:String;
+};
+
+typedef DnsAnyTlsaRecord = {
+	> DnsResolvedAddressTLSA,
+	var type:String;
+};
+
+typedef DnsAnyTxtRecord = {
+	var type:String;
+	var entries:Array<String>;
+};
+
+typedef DnsAnyNsRecord = {
+	var type:String;
+	var value:String;
+};
+
+typedef DnsAnyPtrRecord = {
+	var type:String;
+	var value:String;
+};
+
+typedef DnsAnyCnameRecord = {
+	var type:String;
+	var value:String;
+};
+
+typedef DnsAnyRecord = EitherType<DnsAnyARecord,
+	EitherType<DnsAnyAaaaRecord,
+		EitherType<DnsAnyCaaRecord,
+			EitherType<DnsAnyCnameRecord,
+				EitherType<DnsAnyMxRecord,
+					EitherType<DnsAnyNaptrRecord,
+						EitherType<DnsAnyNsRecord,
+							EitherType<DnsAnyPtrRecord,
+								EitherType<DnsAnySoaRecord,
+									EitherType<DnsAnySrvRecord, EitherType<DnsAnyTlsaRecord, DnsAnyTxtRecord>>>>>>>>>>>;
+
+typedef DnsResolvedAddress = EitherType<String,
+	EitherType<DnsResolvedAddressMX,
+		EitherType<DnsResolvedAddressSOA,
+			EitherType<DnsResolvedAddressSRV,
+				EitherType<DnsResolvedAddressCAA, EitherType<DnsResolvedAddressNAPTR, DnsResolvedAddressTLSA>>>>>>;
 
 /**
 	Error objects returned by dns lookups are of this type
@@ -276,6 +466,8 @@ typedef DnsLookupCallbackAllEntry = {address:String, family:DnsAddressFamily};
 	These functions do not use the same set of configuration files than what `lookup` uses. For instance,
 	they do not use the configuration from /etc/hosts. These functions should be used by developers who do not want
 	to use the underlying operating system's facilities for name resolution, and instead want to always perform DNS queries.
+
+	@see https://nodejs.org/docs/latest-v22.x/api/dns.html
 **/
 @:jsRequire("dns")
 extern class Dns {
@@ -322,6 +514,13 @@ extern class Dns {
 	static var V4MAPPED(default, null):Int;
 
 	/**
+		A flag passed in the `hints` argument of `lookup` method.
+
+		If `V4MAPPED` is specified, return resolved IPv6 addresses as well as IPv4 mapped IPv6 addresses.
+	**/
+	static var ALL(default, null):Int;
+
+	/**
 		Resolves the given `address` and `port` into a hostname and service using `getnameinfo`.
 
 		The `callback` has arguments (err, hostname, service).
@@ -346,13 +545,31 @@ extern class Dns {
 	/**
 		The same as `resolve`, but only for IPv4 queries (A records).
 		`addresses` is an array of IPv4 addresses (e.g. ['74.125.79.104', '74.125.79.105', '74.125.79.106']).
+
+		When `options.ttl` is `true`, each entry is `{ address, ttl }` instead of a string.
 	**/
+	@:overload(function(hostname:String, options:DnsResolveOptions,
+		callback:DnsError->EitherType<Array<String>, Array<DnsRecordWithTtl>>->Void):Void {})
 	static function resolve4(hostname:String, callback:DnsError->Array<String>->Void):Void;
 
 	/**
 		The same as `resolve4` except for IPv6 queries (an AAAA query).
+
+		When `options.ttl` is `true`, each entry is `{ address, ttl }` instead of a string.
 	**/
+	@:overload(function(hostname:String, options:DnsResolveOptions,
+		callback:DnsError->EitherType<Array<String>, Array<DnsRecordWithTtl>>->Void):Void {})
 	static function resolve6(hostname:String, callback:DnsError->Array<String>->Void):Void;
+
+	/**
+		Uses the DNS protocol to resolve all records (also known as `ANY` or `*` query).
+	**/
+	static function resolveAny(hostname:String, callback:DnsError->Array<DnsAnyRecord>->Void):Void;
+
+	/**
+		Uses the DNS protocol to resolve `CAA` records for the `hostname`.
+	**/
+	static function resolveCaa(hostname:String, callback:DnsError->Array<DnsResolvedAddressCAA>->Void):Void;
 
 	/**
 		The same as `resolve`, but only for mail exchange queries (MX records).
@@ -360,6 +577,11 @@ extern class Dns {
 		and an exchange attribute (e.g. [{'priority': 10, 'exchange': 'mx.example.com'},...]).
 	**/
 	static function resolveMx(hostname:String, callback:DnsError->Array<DnsResolvedAddressMX>->Void):Void;
+
+	/**
+		Uses the DNS protocol to resolve regular expression-based records (`NAPTR` records) for the `hostname`.
+	**/
+	static function resolveNaptr(hostname:String, callback:DnsError->Array<DnsResolvedAddressNAPTR>->Void):Void;
 
 	/**
 		The same as `resolve`, but only for text queries (TXT records).
@@ -376,6 +598,11 @@ extern class Dns {
 		(e.g., [{'priority': 10, 'weight': 5, 'port': 21223, 'name': 'service.example.com'}, ...]).
 	**/
 	static function resolveSrv(hostname:String, callback:DnsError->Array<DnsResolvedAddressSRV>->Void):Void;
+
+	/**
+		Uses the DNS protocol to resolve certificate associations (`TLSA` records) for the `hostname`.
+	**/
+	static function resolveTlsa(hostname:String, callback:DnsError->Array<DnsResolvedAddressTLSA>->Void):Void;
 
 	/**
 		Uses the DNS protocol to resolve pointer records (PTR records) for the `hostname`.
@@ -430,4 +657,21 @@ extern class Dns {
 		This will throw if you pass invalid input.
 	**/
 	static function setServers(servers:Array<String>):Void;
+
+	/**
+		Get the default value for `order` in `Dns.lookup` and `DnsPromises.lookup`.
+	**/
+	static function getDefaultResultOrder():DnsResultOrder;
+
+	/**
+		Set the default value of `order` in `Dns.lookup` and `DnsPromises.lookup`.
+	**/
+	static function setDefaultResultOrder(order:DnsResultOrder):Void;
+
+	/**
+		`Resolver` class constructor for an independent DNS resolver.
+
+		@see https://nodejs.org/docs/latest-v22.x/api/dns.html#class-dnsresolver
+	**/
+	static var Resolver:Class<ResolverObject>;
 }

--- a/src/js/node/DnsPromises.hx
+++ b/src/js/node/DnsPromises.hx
@@ -40,7 +40,7 @@ import js.Promise;
 	`ADDRCONFIG`, `V4MAPPED`, and `ALL` are not exported by `dns/promises` (they are `undefined`
 	there). For lookup `hints`, use `Dns.ADDRCONFIG`, `Dns.V4MAPPED`, and `Dns.ALL`.
 
-	@see https://nodejs.org/docs/latest-v22.x/api/dns.html#dns-promises-api
+	@see https://nodejs.org/docs/latest-v24.x/api/dns.html#dns-promises-api
 **/
 @:jsRequire("dns/promises")
 extern class DnsPromises {
@@ -166,7 +166,7 @@ extern class DnsPromises {
 	/**
 		`Resolver` class constructor for an independent promise-based DNS resolver.
 
-		@see https://nodejs.org/docs/latest-v22.x/api/dns.html#class-dnspromisesresolver
+		@see https://nodejs.org/docs/latest-v24.x/api/dns.html#class-dnspromisesresolver
 	**/
 	static var Resolver:Class<PromisesResolverObject>;
 }

--- a/src/js/node/DnsPromises.hx
+++ b/src/js/node/DnsPromises.hx
@@ -34,22 +34,17 @@ import js.Promise;
 	The `dns/promises` API provides an alternative set of asynchronous DNS methods
 	that return `Promise` objects rather than using callbacks.
 
+	This binding covers the common promise-based lookup/resolve helpers.
+	It does not yet include `Resolver`, `resolveAny` / `resolveCaa` / `resolveNaptr` /
+	`resolveTlsa`, or `setDefaultResultOrder`.
+
+	`ADDRCONFIG` and `V4MAPPED` are not exported by `dns/promises` (they are `undefined`
+	there). For lookup `hints`, use `Dns.ADDRCONFIG` and `Dns.V4MAPPED`.
+
 	@see https://nodejs.org/api/dns.html#dns-promises-api
 **/
 @:jsRequire("dns/promises")
 extern class DnsPromises {
-	/**
-		A flag passed in the `hints` argument of `lookup`.
-		Same as `Dns.ADDRCONFIG`.
-	**/
-	static var ADDRCONFIG(default, null):Int;
-
-	/**
-		A flag passed in the `hints` argument of `lookup`.
-		Same as `Dns.V4MAPPED`.
-	**/
-	static var V4MAPPED(default, null):Int;
-
 	/**
 		Returns an array of IP address strings, formatted according to
 		[RFC 5952](https://tools.ietf.org/html/rfc5952), that are currently configured for DNS resolution.

--- a/src/js/node/DnsPromises.hx
+++ b/src/js/node/DnsPromises.hx
@@ -24,6 +24,7 @@ package js.node;
 
 import haxe.extern.EitherType;
 import js.node.Dns;
+import js.node.dns.PromisesResolver as PromisesResolverObject;
 #if haxe4
 import js.lib.Promise;
 #else
@@ -34,14 +35,12 @@ import js.Promise;
 	The `dns/promises` API provides an alternative set of asynchronous DNS methods
 	that return `Promise` objects rather than using callbacks.
 
-	This binding covers the common promise-based lookup/resolve helpers.
-	It does not yet include `Resolver`, `resolveAny` / `resolveCaa` / `resolveNaptr` /
-	`resolveTlsa`, or `setDefaultResultOrder`.
+	The API is accessible via `require('dns/promises')` or `require('dns').promises`.
 
-	`ADDRCONFIG` and `V4MAPPED` are not exported by `dns/promises` (they are `undefined`
-	there). For lookup `hints`, use `Dns.ADDRCONFIG` and `Dns.V4MAPPED`.
+	`ADDRCONFIG`, `V4MAPPED`, and `ALL` are not exported by `dns/promises` (they are `undefined`
+	there). For lookup `hints`, use `Dns.ADDRCONFIG`, `Dns.V4MAPPED`, and `Dns.ALL`.
 
-	@see https://nodejs.org/api/dns.html#dns-promises-api
+	@see https://nodejs.org/docs/latest-v22.x/api/dns.html#dns-promises-api
 **/
 @:jsRequire("dns/promises")
 extern class DnsPromises {
@@ -59,7 +58,7 @@ extern class DnsPromises {
 	**/
 	@:overload(function(hostname:String):Promise<DnsPromisesLookupResult> {})
 	@:overload(function(hostname:String, options:DnsAddressFamily):Promise<DnsPromisesLookupResult> {})
-	@:overload(function(hostname:String, options:{family:DnsAddressFamily, ?hints:Int, all:Bool}):Promise<Array<DnsLookupCallbackAllEntry>> {})
+	@:overload(function(hostname:String, options:{family:EitherType<DnsAddressFamily, String>, ?hints:Int, all:Bool, ?order:DnsResultOrder, ?verbatim:Bool}):Promise<Array<DnsLookupCallbackAllEntry>> {})
 	static function lookup(hostname:String, options:EitherType<DnsAddressFamily, DnsLookupOptions>):Promise<EitherType<DnsPromisesLookupResult, Array<DnsLookupCallbackAllEntry>>>;
 
 	/**
@@ -75,13 +74,34 @@ extern class DnsPromises {
 
 	/**
 		Uses the DNS protocol to resolve IPv4 addresses (`A` records) for the `hostname`.
+
+		When `options.ttl` is `true`, each entry is `{ address, ttl }` instead of a string.
 	**/
+	@:overload(function(hostname:String, options:DnsResolveOptions):Promise<EitherType<Array<String>, Array<DnsRecordWithTtl>>> {})
 	static function resolve4(hostname:String):Promise<Array<String>>;
 
 	/**
 		Uses the DNS protocol to resolve IPv6 addresses (`AAAA` records) for the `hostname`.
+
+		When `options.ttl` is `true`, each entry is `{ address, ttl }` instead of a string.
 	**/
+	@:overload(function(hostname:String, options:DnsResolveOptions):Promise<EitherType<Array<String>, Array<DnsRecordWithTtl>>> {})
 	static function resolve6(hostname:String):Promise<Array<String>>;
+
+	/**
+		Uses the DNS protocol to resolve all records (also known as `ANY` or `*` query).
+	**/
+	static function resolveAny(hostname:String):Promise<Array<DnsAnyRecord>>;
+
+	/**
+		Uses the DNS protocol to resolve `CAA` records for the `hostname`.
+	**/
+	static function resolveCaa(hostname:String):Promise<Array<DnsResolvedAddressCAA>>;
+
+	/**
+		Uses the DNS protocol to resolve `CNAME` records for the `hostname`.
+	**/
+	static function resolveCname(hostname:String):Promise<Array<String>>;
 
 	/**
 		Uses the DNS protocol to resolve mail exchange records (`MX` records) for the `hostname`.
@@ -89,14 +109,14 @@ extern class DnsPromises {
 	static function resolveMx(hostname:String):Promise<Array<DnsResolvedAddressMX>>;
 
 	/**
-		Uses the DNS protocol to resolve text queries (`TXT` records) for the `hostname`.
+		Uses the DNS protocol to resolve regular expression-based records (`NAPTR` records) for the `hostname`.
 	**/
-	static function resolveTxt(hostname:String):Promise<Array<Array<String>>>;
+	static function resolveNaptr(hostname:String):Promise<Array<DnsResolvedAddressNAPTR>>;
 
 	/**
-		Uses the DNS protocol to resolve service records (`SRV` records) for the `hostname`.
+		Uses the DNS protocol to resolve name server records (`NS` records) for the `hostname`.
 	**/
-	static function resolveSrv(hostname:String):Promise<Array<DnsResolvedAddressSRV>>;
+	static function resolveNs(hostname:String):Promise<Array<String>>;
 
 	/**
 		Uses the DNS protocol to resolve pointer records (`PTR` records) for the `hostname`.
@@ -109,14 +129,19 @@ extern class DnsPromises {
 	static function resolveSoa(hostname:String):Promise<DnsResolvedAddressSOA>;
 
 	/**
-		Uses the DNS protocol to resolve name server records (`NS` records) for the `hostname`.
+		Uses the DNS protocol to resolve service records (`SRV` records) for the `hostname`.
 	**/
-	static function resolveNs(hostname:String):Promise<Array<String>>;
+	static function resolveSrv(hostname:String):Promise<Array<DnsResolvedAddressSRV>>;
 
 	/**
-		Uses the DNS protocol to resolve `CNAME` records for the `hostname`.
+		Uses the DNS protocol to resolve certificate associations (`TLSA` records) for the `hostname`.
 	**/
-	static function resolveCname(hostname:String):Promise<Array<String>>;
+	static function resolveTlsa(hostname:String):Promise<Array<DnsResolvedAddressTLSA>>;
+
+	/**
+		Uses the DNS protocol to resolve text queries (`TXT` records) for the `hostname`.
+	**/
+	static function resolveTxt(hostname:String):Promise<Array<Array<String>>>;
 
 	/**
 		Performs a reverse DNS query that resolves an IPv4 or IPv6 address to an array of hostnames.
@@ -127,6 +152,23 @@ extern class DnsPromises {
 		Sets the IP address and port of servers to be used when performing DNS resolution.
 	**/
 	static function setServers(servers:Array<String>):Void;
+
+	/**
+		Get the default value for `order` in `Dns.lookup` and `DnsPromises.lookup`.
+	**/
+	static function getDefaultResultOrder():DnsResultOrder;
+
+	/**
+		Set the default value of `order` in `Dns.lookup` and `DnsPromises.lookup`.
+	**/
+	static function setDefaultResultOrder(order:DnsResultOrder):Void;
+
+	/**
+		`Resolver` class constructor for an independent promise-based DNS resolver.
+
+		@see https://nodejs.org/docs/latest-v22.x/api/dns.html#class-dnspromisesresolver
+	**/
+	static var Resolver:Class<PromisesResolverObject>;
 }
 
 /**

--- a/src/js/node/DnsPromises.hx
+++ b/src/js/node/DnsPromises.hx
@@ -1,0 +1,151 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node;
+
+import haxe.extern.EitherType;
+import js.node.Dns;
+#if haxe4
+import js.lib.Promise;
+#else
+import js.Promise;
+#end
+
+/**
+	The `dns/promises` API provides an alternative set of asynchronous DNS methods
+	that return `Promise` objects rather than using callbacks.
+
+	@see https://nodejs.org/api/dns.html#dns-promises-api
+**/
+@:jsRequire("dns/promises")
+extern class DnsPromises {
+	/**
+		A flag passed in the `hints` argument of `lookup`.
+		Same as `Dns.ADDRCONFIG`.
+	**/
+	static var ADDRCONFIG(default, null):Int;
+
+	/**
+		A flag passed in the `hints` argument of `lookup`.
+		Same as `Dns.V4MAPPED`.
+	**/
+	static var V4MAPPED(default, null):Int;
+
+	/**
+		Returns an array of IP address strings, formatted according to
+		[RFC 5952](https://tools.ietf.org/html/rfc5952), that are currently configured for DNS resolution.
+	**/
+	static function getServers():Array<String>;
+
+	/**
+		Resolves a `hostname` into the first found A (IPv4) or AAAA (IPv6) record.
+
+		With `all: false` (default), fulfills with `{ address, family }`.
+		With `all: true`, fulfills with an array of such objects.
+	**/
+	@:overload(function(hostname:String):Promise<DnsPromisesLookupResult> {})
+	@:overload(function(hostname:String, options:DnsAddressFamily):Promise<DnsPromisesLookupResult> {})
+	@:overload(function(hostname:String, options:{family:DnsAddressFamily, ?hints:Int, all:Bool}):Promise<Array<DnsLookupCallbackAllEntry>> {})
+	static function lookup(hostname:String, options:EitherType<DnsAddressFamily, DnsLookupOptions>):Promise<EitherType<DnsPromisesLookupResult, Array<DnsLookupCallbackAllEntry>>>;
+
+	/**
+		Resolves the given `address` and `port` into a hostname and service using `getnameinfo`.
+	**/
+	static function lookupService(address:String, port:Int):Promise<DnsPromisesLookupServiceResult>;
+
+	/**
+		Uses the DNS protocol to resolve a hostname into an array of the record types specified by `rrtype`.
+	**/
+	@:overload(function(hostname:String):Promise<Array<DnsResolvedAddress>> {})
+	static function resolve(hostname:String, rrtype:DnsRrtype):Promise<Array<DnsResolvedAddress>>;
+
+	/**
+		Uses the DNS protocol to resolve IPv4 addresses (`A` records) for the `hostname`.
+	**/
+	static function resolve4(hostname:String):Promise<Array<String>>;
+
+	/**
+		Uses the DNS protocol to resolve IPv6 addresses (`AAAA` records) for the `hostname`.
+	**/
+	static function resolve6(hostname:String):Promise<Array<String>>;
+
+	/**
+		Uses the DNS protocol to resolve mail exchange records (`MX` records) for the `hostname`.
+	**/
+	static function resolveMx(hostname:String):Promise<Array<DnsResolvedAddressMX>>;
+
+	/**
+		Uses the DNS protocol to resolve text queries (`TXT` records) for the `hostname`.
+	**/
+	static function resolveTxt(hostname:String):Promise<Array<Array<String>>>;
+
+	/**
+		Uses the DNS protocol to resolve service records (`SRV` records) for the `hostname`.
+	**/
+	static function resolveSrv(hostname:String):Promise<Array<DnsResolvedAddressSRV>>;
+
+	/**
+		Uses the DNS protocol to resolve pointer records (`PTR` records) for the `hostname`.
+	**/
+	static function resolvePtr(hostname:String):Promise<Array<String>>;
+
+	/**
+		Uses the DNS protocol to resolve a start of authority record (`SOA` record) for the `hostname`.
+	**/
+	static function resolveSoa(hostname:String):Promise<DnsResolvedAddressSOA>;
+
+	/**
+		Uses the DNS protocol to resolve name server records (`NS` records) for the `hostname`.
+	**/
+	static function resolveNs(hostname:String):Promise<Array<String>>;
+
+	/**
+		Uses the DNS protocol to resolve `CNAME` records for the `hostname`.
+	**/
+	static function resolveCname(hostname:String):Promise<Array<String>>;
+
+	/**
+		Performs a reverse DNS query that resolves an IPv4 or IPv6 address to an array of hostnames.
+	**/
+	static function reverse(ip:String):Promise<Array<String>>;
+
+	/**
+		Sets the IP address and port of servers to be used when performing DNS resolution.
+	**/
+	static function setServers(servers:Array<String>):Void;
+}
+
+/**
+	Result of `DnsPromises.lookup` when `all` is not `true`.
+**/
+typedef DnsPromisesLookupResult = {
+	var address:String;
+	var family:DnsAddressFamily;
+}
+
+/**
+	Result of `DnsPromises.lookupService`.
+**/
+typedef DnsPromisesLookupServiceResult = {
+	var hostname:String;
+	var service:String;
+}

--- a/src/js/node/dns/PromisesResolver.hx
+++ b/src/js/node/dns/PromisesResolver.hx
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.dns;
+
+import haxe.extern.EitherType;
+import js.node.Dns;
+#if haxe4
+import js.lib.Promise;
+#else
+import js.Promise;
+#end
+
+/**
+	Promise-based independent resolver for DNS requests (`dns/promises.Resolver`).
+
+	@see https://nodejs.org/docs/latest-v22.x/api/dns.html#class-dnspromisesresolver
+**/
+@:jsRequire("dns/promises", "Resolver")
+extern class PromisesResolver {
+	function new(?options:DnsResolverOptions);
+
+	/**
+		Cancel all outstanding DNS queries made by this resolver.
+		The corresponding promises will be rejected with an error with the code `ECANCELLED`.
+	**/
+	function cancel():Void;
+
+	/**
+		The resolver instance will send its requests from the specified IP address.
+		This allows programs to specify outbound interfaces when used on multi-homed systems.
+	**/
+	function setLocalAddress(?ipv4:String, ?ipv6:String):Void;
+
+	function getServers():Array<String>;
+	function setServers(servers:Array<String>):Void;
+
+	@:overload(function(hostname:String):Promise<Array<DnsResolvedAddress>> {})
+	function resolve(hostname:String, rrtype:DnsRrtype):Promise<Array<DnsResolvedAddress>>;
+
+	@:overload(function(hostname:String, options:DnsResolveOptions):Promise<EitherType<Array<String>, Array<DnsRecordWithTtl>>> {})
+	function resolve4(hostname:String):Promise<Array<String>>;
+
+	@:overload(function(hostname:String, options:DnsResolveOptions):Promise<EitherType<Array<String>, Array<DnsRecordWithTtl>>> {})
+	function resolve6(hostname:String):Promise<Array<String>>;
+
+	function resolveAny(hostname:String):Promise<Array<DnsAnyRecord>>;
+	function resolveCaa(hostname:String):Promise<Array<DnsResolvedAddressCAA>>;
+	function resolveCname(hostname:String):Promise<Array<String>>;
+	function resolveMx(hostname:String):Promise<Array<DnsResolvedAddressMX>>;
+	function resolveNaptr(hostname:String):Promise<Array<DnsResolvedAddressNAPTR>>;
+	function resolveNs(hostname:String):Promise<Array<String>>;
+	function resolvePtr(hostname:String):Promise<Array<String>>;
+	function resolveSoa(hostname:String):Promise<DnsResolvedAddressSOA>;
+	function resolveSrv(hostname:String):Promise<Array<DnsResolvedAddressSRV>>;
+	function resolveTlsa(hostname:String):Promise<Array<DnsResolvedAddressTLSA>>;
+	function resolveTxt(hostname:String):Promise<Array<Array<String>>>;
+	function reverse(ip:String):Promise<Array<String>>;
+}

--- a/src/js/node/dns/PromisesResolver.hx
+++ b/src/js/node/dns/PromisesResolver.hx
@@ -33,7 +33,7 @@ import js.Promise;
 /**
 	Promise-based independent resolver for DNS requests (`dns/promises.Resolver`).
 
-	@see https://nodejs.org/docs/latest-v22.x/api/dns.html#class-dnspromisesresolver
+	@see https://nodejs.org/docs/latest-v24.x/api/dns.html#class-dnspromisesresolver
 **/
 @:jsRequire("dns/promises", "Resolver")
 extern class PromisesResolver {

--- a/src/js/node/dns/Resolver.hx
+++ b/src/js/node/dns/Resolver.hx
@@ -31,7 +31,7 @@ import js.node.Dns;
 	Creating a new resolver uses the default server settings.
 	Setting the servers used for a resolver using `setServers()` does not affect other resolvers.
 
-	@see https://nodejs.org/docs/latest-v22.x/api/dns.html#class-dnsresolver
+	@see https://nodejs.org/docs/latest-v24.x/api/dns.html#class-dnsresolver
 **/
 @:jsRequire("dns", "Resolver")
 extern class Resolver {

--- a/src/js/node/dns/Resolver.hx
+++ b/src/js/node/dns/Resolver.hx
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.dns;
+
+import haxe.extern.EitherType;
+import js.node.Dns;
+
+/**
+	An independent resolver for DNS requests.
+
+	Creating a new resolver uses the default server settings.
+	Setting the servers used for a resolver using `setServers()` does not affect other resolvers.
+
+	@see https://nodejs.org/docs/latest-v22.x/api/dns.html#class-dnsresolver
+**/
+@:jsRequire("dns", "Resolver")
+extern class Resolver {
+	function new(?options:DnsResolverOptions);
+
+	/**
+		Cancel all outstanding DNS queries made by this resolver.
+		The corresponding callbacks will be called with an error with code `ECANCELLED`.
+	**/
+	function cancel():Void;
+
+	/**
+		The resolver instance will send its requests from the specified IP address.
+		This allows programs to specify outbound interfaces when used on multi-homed systems.
+	**/
+	function setLocalAddress(?ipv4:String, ?ipv6:String):Void;
+
+	function getServers():Array<String>;
+	function setServers(servers:Array<String>):Void;
+
+	@:overload(function(hostname:String, callback:DnsError->Array<DnsResolvedAddress>->Void):Void {})
+	function resolve(hostname:String, rrtype:DnsRrtype, callback:DnsError->Array<DnsResolvedAddress>->Void):Void;
+
+	@:overload(function(hostname:String, options:DnsResolveOptions,
+		callback:DnsError->EitherType<Array<String>, Array<DnsRecordWithTtl>>->Void):Void {})
+	function resolve4(hostname:String, callback:DnsError->Array<String>->Void):Void;
+
+	@:overload(function(hostname:String, options:DnsResolveOptions,
+		callback:DnsError->EitherType<Array<String>, Array<DnsRecordWithTtl>>->Void):Void {})
+	function resolve6(hostname:String, callback:DnsError->Array<String>->Void):Void;
+
+	function resolveAny(hostname:String, callback:DnsError->Array<DnsAnyRecord>->Void):Void;
+	function resolveCaa(hostname:String, callback:DnsError->Array<DnsResolvedAddressCAA>->Void):Void;
+	function resolveCname(hostname:String, callback:DnsError->Array<String>->Void):Void;
+	function resolveMx(hostname:String, callback:DnsError->Array<DnsResolvedAddressMX>->Void):Void;
+	function resolveNaptr(hostname:String, callback:DnsError->Array<DnsResolvedAddressNAPTR>->Void):Void;
+	function resolveNs(hostname:String, callback:DnsError->Array<String>->Void):Void;
+	function resolvePtr(hostname:String, callback:DnsError->Array<String>->Void):Void;
+	function resolveSoa(hostname:String, callback:DnsError->DnsResolvedAddressSOA->Void):Void;
+	function resolveSrv(hostname:String, callback:DnsError->Array<DnsResolvedAddressSRV>->Void):Void;
+	function resolveTlsa(hostname:String, callback:DnsError->Array<DnsResolvedAddressTLSA>->Void):Void;
+	function resolveTxt(hostname:String, callback:DnsError->Array<Array<String>>->Void):Void;
+	function reverse(ip:String, callback:DnsError->Array<String>->Void):Void;
+}


### PR DESCRIPTION
## Summary
- Align `js.node.Dns` with the Node.js 24 LTS `dns` API: `ALL`, lookup `order`/`verbatim`, `resolveAny`/`resolveCaa`/`resolveNaptr`/`resolveTlsa`, `resolve4`/`resolve6` TTL options, `getDefaultResultOrder`/`setDefaultResultOrder`, and related record typedefs
- Expand `js.node.DnsPromises` (`@:jsRequire("dns/promises")`) to the matching promise surface
- Add `js.node.dns.Resolver` and `js.node.dns.PromisesResolver`, exposed via `Dns.Resolver` / `DnsPromises.Resolver`

## Test plan
- [x] `haxe build.hxml` succeeds
- [x] Spot-checked exported keys against Node v24.18.0 (`dns` / `dns/promises` / `Resolver`)
- [ ] Spot-check resolve helpers against [Node 24 dns docs](https://nodejs.org/docs/latest-v24.x/api/dns.html)