### PR TITLE
Add readline/promises externs

### DIFF
--- a/src/js/node/Readline.hx
+++ b/src/js/node/Readline.hx
@@ -26,6 +26,7 @@ import haxe.extern.EitherType;
 import js.node.readline.*;
 import js.node.stream.Readable.IReadable;
 import js.node.stream.Writable.IWritable;
+import js.node.web.AbortSignal;
 
 /**
 	The readline module provides an interface for reading data from a `Readable` stream (such as `process.stdin`) one
@@ -114,6 +115,15 @@ typedef ReadlineOptions = {
 	@:optional var terminal:Bool;
 
 	/**
+		Initial list of history lines.
+		This option makes sense only if `terminal` is set to `true` by the user or by an internal `output` check,
+		otherwise the history caching mechanism is not initialized at all.
+
+		Default: `[]`.
+	**/
+	@:optional var history:Array<String>;
+
+	/**
 		Maximum number of history lines retained.
 		To disable the history set this value to `0`.
 		This option makes sense only if `terminal` is set to `true` by the user or by an internal `output` check,
@@ -157,6 +167,19 @@ typedef ReadlineOptions = {
 		Default: `500`.
 	**/
 	@:optional var escapeCodeTimeout:Int;
+
+	/**
+		The number of spaces a tab is equal to (minimum 1).
+
+		Default: `8`.
+	**/
+	@:optional var tabSize:Int;
+
+	/**
+		Allows closing the interface using an `AbortSignal`.
+		Aborting the signal will internally call `close` on the interface.
+	**/
+	@:optional var signal:AbortSignal;
 }
 
 #if haxe4

--- a/src/js/node/ReadlinePromises.hx
+++ b/src/js/node/ReadlinePromises.hx
@@ -22,10 +22,101 @@
 
 package js.node;
 
-import js.node.Readline;
+import haxe.extern.EitherType;
 import js.node.readline.PromisesInterface;
 import js.node.stream.Readable.IReadable;
 import js.node.stream.Writable.IWritable;
+import js.node.web.AbortSignal;
+#if haxe4
+import js.lib.Promise;
+#else
+import js.Promise;
+#end
+
+/**
+	Completer result: matching entries, then the substring used for matching.
+**/
+typedef ReadlinePromisesCompleterResult = Array<EitherType<Array<String>, String>>;
+
+/**
+	Tab autocompletion for `readline/promises`.
+	Unlike the callback API, the completer may return a `Promise`.
+**/
+#if haxe4
+typedef ReadlinePromisesCompleterCallback = (line:String) -> EitherType<ReadlinePromisesCompleterResult, Promise<ReadlinePromisesCompleterResult>>;
+#else
+typedef ReadlinePromisesCompleterCallback = String->EitherType<ReadlinePromisesCompleterResult, Promise<ReadlinePromisesCompleterResult>>;
+#end
+
+/**
+	Options for `ReadlinePromises.createInterface`.
+
+	Same surface as `ReadlineOptions`, but `completer` may return a `Promise`.
+
+	@see https://nodejs.org/api/readline.html#readlinepromisescreateinterfaceoptions
+**/
+typedef ReadlinePromisesOptions = {
+	/**
+		The `Readable` stream to listen to.
+	**/
+	var input:IReadable;
+
+	/**
+		The `Writable` stream to write readline data to.
+	**/
+	@:optional var output:IWritable;
+
+	/**
+		An optional function used for Tab autocompletion.
+		May return a `Promise` resolving to the completer result.
+	**/
+	@:optional var completer:ReadlinePromisesCompleterCallback;
+
+	/**
+		`true` if the `input` and `output` streams should be treated like a TTY.
+	**/
+	@:optional var terminal:Bool;
+
+	/**
+		Initial list of history lines.
+	**/
+	@:optional var history:Array<String>;
+
+	/**
+		Maximum number of history lines retained.
+	**/
+	@:optional var historySize:Int;
+
+	/**
+		The prompt string to use.
+	**/
+	@:optional var prompt:String;
+
+	/**
+		Delay threshold for treating `\r\n` as a single newline.
+	**/
+	@:optional var crlfDelay:Int;
+
+	/**
+		If `true`, remove older duplicate history entries.
+	**/
+	@:optional var removeHistoryDuplicates:Bool;
+
+	/**
+		Ambiguous key sequence timeout in milliseconds.
+	**/
+	@:optional var escapeCodeTimeout:Int;
+
+	/**
+		The number of spaces a tab is equal to (minimum 1).
+	**/
+	@:optional var tabSize:Int;
+
+	/**
+		Allows closing the interface using an `AbortSignal`.
+	**/
+	@:optional var signal:AbortSignal;
+}
 
 /**
 	The `readline/promises` API provides an alternative set of interfaces that return promises.
@@ -37,6 +128,6 @@ extern class ReadlinePromises {
 	/**
 		Creates a new `readlinePromises.Interface` instance.
 	**/
-	@:overload(function(input:IReadable, ?output:IWritable, ?completer:ReadlineCompleterCallback, ?terminal:Bool):PromisesInterface {})
-	static function createInterface(options:ReadlineOptions):PromisesInterface;
+	@:overload(function(input:IReadable, ?output:IWritable, ?completer:ReadlinePromisesCompleterCallback, ?terminal:Bool):PromisesInterface {})
+	static function createInterface(options:ReadlinePromisesOptions):PromisesInterface;
 }

--- a/src/js/node/ReadlinePromises.hx
+++ b/src/js/node/ReadlinePromises.hx
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node;
+
+import js.node.Readline;
+import js.node.readline.PromisesInterface;
+import js.node.stream.Readable.IReadable;
+import js.node.stream.Writable.IWritable;
+
+/**
+	The `readline/promises` API provides an alternative set of interfaces that return promises.
+
+	@see https://nodejs.org/api/readline.html#promises-api
+**/
+@:jsRequire("readline/promises")
+extern class ReadlinePromises {
+	/**
+		Creates a new `readlinePromises.Interface` instance.
+	**/
+	@:overload(function(input:IReadable, ?output:IWritable, ?completer:ReadlineCompleterCallback, ?terminal:Bool):PromisesInterface {})
+	static function createInterface(options:ReadlineOptions):PromisesInterface;
+}

--- a/src/js/node/readline/PromisesInterface.hx
+++ b/src/js/node/readline/PromisesInterface.hx
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.readline;
+
+import js.html.AbortSignal;
+import js.node.readline.Interface;
+#if haxe4
+import js.lib.Promise;
+#else
+import js.Promise;
+#end
+
+/**
+	Instances of `readlinePromises.Interface` are constructed using
+	`ReadlinePromises.createInterface()`.
+
+	Differs from `readline.Interface` mainly in that `question` returns a `Promise`.
+
+	@see https://nodejs.org/api/readline.html#class-readlinepromisesinterface
+**/
+@:jsRequire("readline/promises", "Interface")
+extern class PromisesInterface extends Interface {
+	/**
+		Displays `query` by writing it to `output`, waits for user input on `input`,
+		then fulfills with the provided input.
+
+		When called, resumes the `input` stream if it has been paused.
+		If called after `close()`, returns a rejected promise.
+	**/
+	@:overload(function(query:String):Promise<String> {})
+	function question(query:String, options:{?signal:AbortSignal}):Promise<String>;
+}

--- a/src/js/node/readline/PromisesInterface.hx
+++ b/src/js/node/readline/PromisesInterface.hx
@@ -22,8 +22,8 @@
 
 package js.node.readline;
 
-import js.html.AbortSignal;
 import js.node.readline.Interface;
+import js.node.web.AbortSignal;
 #if haxe4
 import js.lib.Promise;
 #else

--- a/src/js/node/readline/PromisesReadline.hx
+++ b/src/js/node/readline/PromisesReadline.hx
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.readline;
+
+import js.node.Readline.ClearLineDirection;
+import js.node.stream.Writable.IWritable;
+#if haxe4
+import js.lib.Promise;
+#else
+import js.Promise;
+#end
+
+/**
+	Options for constructing a `PromisesReadline`.
+**/
+typedef PromisesReadlineOptions = {
+	/**
+		If `true`, no need to call `commit()`.
+	**/
+	@:optional var autoCommit:Bool;
+}
+
+/**
+	The `readlinePromises.Readline` class provides an abstraction for collecting
+	pending actions on a TTY stream and applying them with `commit()`.
+
+	@see https://nodejs.org/api/readline.html#class-readlinepromisesreadline
+**/
+@:jsRequire("readline/promises", "Readline")
+extern class PromisesReadline {
+	function new(stream:IWritable, ?options:PromisesReadlineOptions);
+
+	/**
+		Adds an action that clears the current line of the associated stream.
+	**/
+	function clearLine(dir:ClearLineDirection):PromisesReadline;
+
+	/**
+		Adds an action that clears the associated stream from the current cursor position down.
+	**/
+	function clearScreenDown():PromisesReadline;
+
+	/**
+		Sends all pending actions to the associated stream and clears the internal list.
+	**/
+	function commit():Promise<Void>;
+
+	/**
+		Adds an action that moves the cursor to the specified position.
+	**/
+	function cursorTo(x:Int, ?y:Int):PromisesReadline;
+
+	/**
+		Adds an action that moves the cursor relative to its current position.
+	**/
+	function moveCursor(dx:Int, dy:Int):PromisesReadline;
+
+	/**
+		Clears the internal list of pending actions without sending it to the stream.
+	**/
+	function rollback():PromisesReadline;
+}


### PR DESCRIPTION
## Summary
- Add `js.node.ReadlinePromises` (`@:jsRequire("readline/promises")`) with `createInterface`
- Add `js.node.readline.PromisesInterface` whose `question` returns `Promise<String>` (extends existing `Interface`)
- Add `js.node.readline.PromisesReadline` for batched cursor/line TTY actions (`commit`/`rollback`)
- Reuses `ReadlineOptions` / `ClearLineDirection` from existing readline externs

## Test plan
- [ ] `haxe build.hxml` succeeds
- [ ] Spot-check `createInterface` + `question` against Node 24 readline/promises docs

Made with [Cursor](https://cursor.com)