### PR TITLE
Add stream/promises externs

### DIFF
--- a/src/js/node/Stream.hx
+++ b/src/js/node/Stream.hx
@@ -155,6 +155,37 @@ typedef StreamFinishedOptions = {
 }
 
 /**
+	Options for `Stream.pipeline` / `StreamPromises.pipeline`.
+**/
+typedef StreamPipelineOptions = {
+	/**
+		If present, the pipeline will be destroyed when the signal is aborted.
+	**/
+	@:optional var signal:AbortSignal;
+
+	/**
+		End the destination stream when the source stream ends.
+		Default: `true`.
+	**/
+	@:optional var end:Bool;
+}
+
+/**
+	Options for `Stream.pipeline` / `StreamPromises.pipeline`.
+**/
+typedef StreamPipelineOptions = {
+	/**
+		If specified, the pipeline will abort when the signal is aborted.
+	**/
+	@:optional var signal:AbortSignal;
+
+	/**
+		End the destination stream when the source stream ends. Default: `true`.
+	**/
+	@:optional var end:Bool;
+}
+
+/**
 	`IStream` interface is used as "any Stream".
 
 	See `Stream` for actual class.

--- a/src/js/node/Stream.hx
+++ b/src/js/node/Stream.hx
@@ -159,22 +159,6 @@ typedef StreamFinishedOptions = {
 **/
 typedef StreamPipelineOptions = {
 	/**
-		If present, the pipeline will be destroyed when the signal is aborted.
-	**/
-	@:optional var signal:AbortSignal;
-
-	/**
-		End the destination stream when the source stream ends.
-		Default: `true`.
-	**/
-	@:optional var end:Bool;
-}
-
-/**
-	Options for `Stream.pipeline` / `StreamPromises.pipeline`.
-**/
-typedef StreamPipelineOptions = {
-	/**
 		If specified, the pipeline will abort when the signal is aborted.
 	**/
 	@:optional var signal:AbortSignal;

--- a/src/js/node/StreamPromises.hx
+++ b/src/js/node/StreamPromises.hx
@@ -46,28 +46,27 @@ extern class StreamPromises {
 		A module method to pipe between streams forwarding errors and properly cleaning up,
 		returning a Promise when the pipeline is complete.
 
-		Pass `options` (including `signal`) as the last argument when needed.
+		Requires at least a source and a destination. Pass `options` (including `signal`)
+		as the last argument when needed.
 	**/
-	@:overload(function(readable:IReadable, ?options:StreamFinishedOptions):Promise<Void> {})
-	@:overload(function(readable:IReadable, writable1:IWritable, ?options:StreamFinishedOptions):Promise<Void> {})
-	@:overload(function(readable:IReadable, writable1:IWritable, writable2:IWritable, ?options:StreamFinishedOptions):Promise<Void> {})
-	@:overload(function(readable:IReadable, writable1:IWritable, writable2:IWritable, writable3:IWritable, ?options:StreamFinishedOptions):Promise<Void> {})
+	@:overload(function(readable:IReadable, writable1:IWritable, ?options:StreamPipelineOptions):Promise<Void> {})
+	@:overload(function(readable:IReadable, writable1:IWritable, writable2:IWritable, ?options:StreamPipelineOptions):Promise<Void> {})
+	@:overload(function(readable:IReadable, writable1:IWritable, writable2:IWritable, writable3:IWritable, ?options:StreamPipelineOptions):Promise<Void> {})
 	@:overload(function(readable:IReadable, writable1:IWritable, writable2:IWritable, writable3:IWritable, writable4:IWritable,
-		?options:StreamFinishedOptions):Promise<Void> {})
+		?options:StreamPipelineOptions):Promise<Void> {})
 	@:overload(function(readable:IReadable, writable1:IWritable, writable2:IWritable, writable3:IWritable, writable4:IWritable, writable5:IWritable,
-		?options:StreamFinishedOptions):Promise<Void> {})
+		?options:StreamPipelineOptions):Promise<Void> {})
 	@:overload(function(readable:IReadable, writable1:IWritable, writable2:IWritable, writable3:IWritable, writable4:IWritable, writable5:IWritable,
-		writable6:IWritable, ?options:StreamFinishedOptions):Promise<Void> {})
+		writable6:IWritable, ?options:StreamPipelineOptions):Promise<Void> {})
 	@:overload(function(readable:IReadable, writable1:IWritable, writable2:IWritable, writable3:IWritable, writable4:IWritable, writable5:IWritable,
-		writable6:IWritable, writable7:IWritable, ?options:StreamFinishedOptions):Promise<Void> {})
+		writable6:IWritable, writable7:IWritable, ?options:StreamPipelineOptions):Promise<Void> {})
 	@:overload(function(readable:IReadable, writable1:IWritable, writable2:IWritable, writable3:IWritable, writable4:IWritable, writable5:IWritable,
-		writable6:IWritable, writable7:IWritable, writable8:IWritable, ?options:StreamFinishedOptions):Promise<Void> {})
+		writable6:IWritable, writable7:IWritable, writable8:IWritable, ?options:StreamPipelineOptions):Promise<Void> {})
 	static function pipeline(readable:IReadable, streams:Rest<IWritable>):Promise<Void>;
 
 	/**
 		Returns a Promise that fulfills when the stream is no longer readable,
 		writable or has experienced an error or a premature close event.
 	**/
-	@:overload(function(stream:IStream):Promise<Void> {})
-	static function finished(stream:IStream, options:StreamFinishedOptions):Promise<Void>;
+	static function finished(stream:IStream, ?options:StreamFinishedOptions):Promise<Void>;
 }

--- a/src/js/node/StreamPromises.hx
+++ b/src/js/node/StreamPromises.hx
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node;
+
+import haxe.extern.Rest;
+import js.node.Stream;
+import js.node.stream.Readable.IReadable;
+import js.node.stream.Writable.IWritable;
+#if haxe4
+import js.lib.Error;
+import js.lib.Promise;
+#else
+import js.Error;
+import js.Promise;
+#end
+
+/**
+	The `stream/promises` API provides an alternative set of asynchronous stream
+	utilities that return `Promise` objects rather than using callbacks.
+
+	Accessible via `require('stream/promises')` or `require('stream').promises`.
+
+	@see https://nodejs.org/api/stream.html#streams-promises-api
+**/
+@:jsRequire("stream/promises")
+extern class StreamPromises {
+	/**
+		A module method to pipe between streams forwarding errors and properly cleaning up,
+		returning a Promise when the pipeline is complete.
+	**/
+	@:overload(function(readable:IReadable, ?options:StreamFinishedOptions):Promise<Void> {})
+	@:overload(function(readable:IReadable, writable1:IWritable, ?options:StreamFinishedOptions):Promise<Void> {})
+	@:overload(function(readable:IReadable, writable1:IWritable, writable2:IWritable, ?options:StreamFinishedOptions):Promise<Void> {})
+	@:overload(function(readable:IReadable, writable1:IWritable, writable2:IWritable, writable3:IWritable, ?options:StreamFinishedOptions):Promise<Void> {})
+	@:overload(function(readable:IReadable, writable1:IWritable, writable2:IWritable, writable3:IWritable, writable4:IWritable,
+		?options:StreamFinishedOptions):Promise<Void> {})
+	@:overload(function(readable:IReadable, writable1:IWritable, writable2:IWritable, writable3:IWritable, writable4:IWritable, writable5:IWritable,
+		?options:StreamFinishedOptions):Promise<Void> {})
+	@:overload(function(readable:IReadable, writable1:IWritable, writable2:IWritable, writable3:IWritable, writable4:IWritable, writable5:IWritable,
+		writable6:IWritable, ?options:StreamFinishedOptions):Promise<Void> {})
+	@:overload(function(readable:IReadable, writable1:IWritable, writable2:IWritable, writable3:IWritable, writable4:IWritable, writable5:IWritable,
+		writable6:IWritable, writable7:IWritable, ?options:StreamFinishedOptions):Promise<Void> {})
+	@:overload(function(readable:IReadable, writable1:IWritable, writable2:IWritable, writable3:IWritable, writable4:IWritable, writable5:IWritable,
+		writable6:IWritable, writable7:IWritable, writable8:IWritable, ?options:StreamFinishedOptions):Promise<Void> {})
+	static function pipeline(readable:IReadable, streams:Rest<EitherType<IWritable, StreamFinishedOptions>>):Promise<Void>;
+
+	/**
+		Returns a Promise that fulfills when the stream is no longer readable,
+		writable or has experienced an error or a premature close event.
+	**/
+	@:overload(function(stream:IStream):Promise<Void> {})
+	static function finished(stream:IStream, options:StreamFinishedOptions):Promise<Void>;
+}
+
+// local alias so Rest overload typing can use EitherType without extra import noise
+private typedef EitherType<T1, T2> = haxe.extern.EitherType<T1, T2>;

--- a/src/js/node/StreamPromises.hx
+++ b/src/js/node/StreamPromises.hx
@@ -27,10 +27,8 @@ import js.node.Stream;
 import js.node.stream.Readable.IReadable;
 import js.node.stream.Writable.IWritable;
 #if haxe4
-import js.lib.Error;
 import js.lib.Promise;
 #else
-import js.Error;
 import js.Promise;
 #end
 
@@ -47,6 +45,8 @@ extern class StreamPromises {
 	/**
 		A module method to pipe between streams forwarding errors and properly cleaning up,
 		returning a Promise when the pipeline is complete.
+
+		Pass `options` (including `signal`) as the last argument when needed.
 	**/
 	@:overload(function(readable:IReadable, ?options:StreamFinishedOptions):Promise<Void> {})
 	@:overload(function(readable:IReadable, writable1:IWritable, ?options:StreamFinishedOptions):Promise<Void> {})
@@ -62,7 +62,7 @@ extern class StreamPromises {
 		writable6:IWritable, writable7:IWritable, ?options:StreamFinishedOptions):Promise<Void> {})
 	@:overload(function(readable:IReadable, writable1:IWritable, writable2:IWritable, writable3:IWritable, writable4:IWritable, writable5:IWritable,
 		writable6:IWritable, writable7:IWritable, writable8:IWritable, ?options:StreamFinishedOptions):Promise<Void> {})
-	static function pipeline(readable:IReadable, streams:Rest<EitherType<IWritable, StreamFinishedOptions>>):Promise<Void>;
+	static function pipeline(readable:IReadable, streams:Rest<IWritable>):Promise<Void>;
 
 	/**
 		Returns a Promise that fulfills when the stream is no longer readable,
@@ -71,6 +71,3 @@ extern class StreamPromises {
 	@:overload(function(stream:IStream):Promise<Void> {})
 	static function finished(stream:IStream, options:StreamFinishedOptions):Promise<Void>;
 }
-
-// local alias so Rest overload typing can use EitherType without extra import noise
-private typedef EitherType<T1, T2> = haxe.extern.EitherType<T1, T2>;


### PR DESCRIPTION
## Summary
- Add `js.node.StreamPromises` (`@:jsRequire("stream/promises")`) as a thin façade over Promise-based `finished` and `pipeline`
- Reuses `StreamFinishedOptions` / `IStream` / `IReadable` / `IWritable` from existing stream externs
- Mirrors the Promise overloads already present on `Stream`, exposed via the dedicated `stream/promises` entry point

## Test plan
- [ ] `haxe build.hxml` succeeds
- [ ] Spot-check `finished` / `pipeline` against Node 24 stream/promises docs

Made with [Cursor](https://cursor.com)