### PR TITLE
[ci] Add test workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,6 +45,11 @@ jobs:
       with:
         haxe-version: ${{ matrix.haxe_ver }}
 
+    - uses: actions/setup-node@v4
+      if: matrix.runner == 'windows-latest'
+      with:
+        node-version: 24
+
     - run: haxelib dev hxnodejs .
       name: Set haxelib dev path
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,50 @@ jobs:
       with:
         path: ./bin/api
 
+  test:
+    strategy:
+      matrix:
+        haxe_ver: [4.0.5, 4.3.7, latest]
+        runner: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.runner }}
+    steps:
+    - uses: actions/checkout@v7
+
+    - uses: krdlab/setup-haxe@v2
+      with:
+        haxe-version: ${{ matrix.haxe_ver }}
+
+    - run: haxelib dev hxnodejs .
+      name: Set haxelib dev path
+
+    - name: Get Haxe commit SHA
+      id: haxe_sha
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        version=$(haxe --version)
+        echo "Haxe version: $version"
+        short_sha=${version##*+}
+        full_sha=$(gh api repos/HaxeFoundation/haxe/commits/$short_sha --jq '.sha')
+        echo "Commit SHA: $short_sha, Full SHA: $full_sha"
+        echo "sha=$full_sha" >> "$GITHUB_OUTPUT"
+
+    - uses: actions/checkout@v7
+      with:
+        repository: HaxeFoundation/haxe
+        path: haxe
+        ref: ${{ steps.haxe_sha.outputs.sha }}
+
+    - name: Test
+      shell: bash
+      run: |
+        if [[ "${{ matrix.runner }}" == "macos-latest" ]]; then
+          echo "" > sys/compile-fs.hxml
+        fi
+        haxe --run RunCi js
+      working-directory: haxe/tests
+
   deploy:
     needs: build
     if: github.ref == 'refs/heads/master' && github.event_name == 'push'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,7 +82,7 @@ jobs:
       working-directory: haxe/tests
 
   deploy:
-    needs: build
+    needs: [build, test]
     if: github.ref == 'refs/heads/master' && github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,7 @@ jobs:
 
   test:
     strategy:
+      fail-fast: false
       matrix:
         haxe_ver: [4.0.5, 4.3.7, latest]
         runner: [ubuntu-latest, windows-latest, macos-latest]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        haxe_ver: [4.0.5, 4.3.7, latest]
+        haxe_ver: [4.3.7, latest]
         runner: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.runner }}
     steps:


### PR DESCRIPTION
Checks out the haxe repo and runs the test suite, including sys tests.

Due to a nodejs/libuv bug, we need minimum nodejs 24 to pass the tests on windows, see: https://github.com/HaxeFoundation/haxe/pull/12952

Closes #188.