### PR TITLE
Audit fs/path/os/zlib for Node 24 and Haxe 4

### DIFF
--- a/src/Sys.hx
+++ b/src/Sys.hx
@@ -82,18 +82,14 @@ class Sys {
 		return process.uptime();
 	}
 
-	#if (haxe_ver >= 3.3)
 	@:deprecated("Use programPath instead")
-	#end
 	public static inline function executablePath():String {
 		return process.argv[0];
 	}
 
-	#if (haxe_ver >= 3.3)
 	public static inline function programPath():String {
 		return js.Node.__filename;
 	}
-	#end
 
 	public static function getChar(echo:Bool):Int {
 		throw "Sys.getChar is currently not implemented on node.js";
@@ -132,7 +128,7 @@ private class FileOutput extends haxe.io.Output {
 		return Fs.writeSync(fd, Buffer.hxFromBytes(s), pos, len);
 	}
 
-	override public function writeString(s:String #if (haxe_ver >= 4), ?encoding:haxe.io.Encoding #end) {
+	override public function writeString(s:String, ?encoding:haxe.io.Encoding) {
 		Fs.writeSync(fd, s);
 	}
 
@@ -154,6 +150,7 @@ private class FileInput extends haxe.io.Input {
 
 	override public function readByte():Int {
 		var buf = Buffer.alloc(1);
+		// TODO(section-2): typed Node ErrnoException instead of Dynamic catch
 		try {
 			Fs.readSync(fd, buf, 0, 1, null);
 		} catch (e:Dynamic) {
@@ -167,6 +164,7 @@ private class FileInput extends haxe.io.Input {
 
 	override public function readBytes(s:Bytes, pos:Int, len:Int):Int {
 		var buf = Buffer.hxFromBytes(s);
+		// TODO(section-2): typed Node ErrnoException instead of Dynamic catch
 		try {
 			return Fs.readSync(fd, buf, pos, len, null);
 		} catch (e:Dynamic) {

--- a/src/js/node/Fs.hx
+++ b/src/js/node/Fs.hx
@@ -31,10 +31,12 @@ import js.node.fs.FSWatcher;
 import js.node.fs.ReadStream;
 import js.node.fs.Stats;
 import js.node.fs.StatsFs;
+import js.node.fs.StatWatcher;
 import js.node.fs.WriteStream;
 import js.lib.Error;
 import js.lib.Promise;
 import js.node.web.Blob;
+import js.node.url.URL;
 
 /**
 	Most FS functions now support passing `String` and `Buffer`.
@@ -85,6 +87,12 @@ typedef FsWriteFileOptions = {
 		default: 'w' for `Fs.writeFile`, 'a' for `Fs.appendFile`
 	**/
 	@:optional var flag:FsOpenFlag;
+
+	/**
+		If `true`, the underlying file descriptor is flushed prior to closing it.
+		Default: `false`.
+	**/
+	@:optional var flush:Bool;
 }
 
 /**
@@ -635,7 +643,7 @@ typedef FsGlobOptions = {
 		Current working directory.
 		Default: `process.cwd()`.
 	**/
-	@:optional var cwd:String;
+	@:optional var cwd:EitherType<String, URL>;
 
 	/**
 		Function to filter out files/directories, or a list of glob patterns to be excluded.
@@ -709,6 +717,15 @@ extern class Fs {
 		An object containing commonly used constants for file system operations.
 	**/
 	static var constants(default, null):FsConstants;
+
+	/**
+		Promise-based file system methods (`require('fs').promises`).
+		Same module object as `js.node.FsPromises`.
+
+		Prefer calling static methods on `FsPromises` for Haxe typing of overloads.
+	**/
+	// TODO(section-2): value type mirroring FsPromises static surface (static-method extern cannot be reused as value type)
+	static var promises(default, null):Dynamic;
 
 	/**
 		Asynchronous rename(2).
@@ -1070,7 +1087,7 @@ extern class Fs {
 	@:overload(function(pattern:EitherType<String, Array<String>>, callback:Error->Array<String>->Void):Void {})
 	@:overload(function(pattern:EitherType<String, Array<String>>, options:FsGlobOptions, callback:Error->Array<String>->Void):Void {})
 	static function glob(pattern:EitherType<String, Array<String>>, options:{
-		?cwd:String,
+		?cwd:EitherType<String, URL>,
 		?exclude:EitherType<String->Bool, Array<String>>,
 		?followSymlinks:Bool,
 		withFileTypes:Bool
@@ -1085,7 +1102,7 @@ extern class Fs {
 	@:overload(function(pattern:EitherType<String, Array<String>>):Array<String> {})
 	@:overload(function(pattern:EitherType<String, Array<String>>, options:FsGlobOptions):Array<String> {})
 	static function globSync(pattern:EitherType<String, Array<String>>, options:{
-		?cwd:String,
+		?cwd:EitherType<String, URL>,
 		?exclude:EitherType<String->Bool, Array<String>>,
 		?followSymlinks:Bool,
 		withFileTypes:Bool
@@ -1373,8 +1390,8 @@ extern class Fs {
 
 		The `listener` gets two arguments: the current stat object and the previous stat object.
 	**/
-	@:overload(function(filename:FsPath, listener:Stats->Stats->Void):Void {})
-	static function watchFile(filename:FsPath, options:FsWatchFileOptions, listener:Stats->Stats->Void):Void;
+	@:overload(function(filename:FsPath, listener:Stats->Stats->Void):StatWatcher {})
+	static function watchFile(filename:FsPath, options:FsWatchFileOptions, listener:Stats->Stats->Void):StatWatcher;
 
 	/**
 		Unstable. Use `watch` instead, if possible.
@@ -1444,6 +1461,7 @@ extern class Fs {
 		File is visible to the calling process.
 		This is useful for determining if a file exists, but says nothing about rwx permissions.
 	**/
+	@:deprecated("Use Fs.constants.F_OK instead")
 	static var F_OK(default, null):Int;
 
 	/**
@@ -1451,6 +1469,7 @@ extern class Fs {
 
 		File can be read by the calling process.
 	**/
+	@:deprecated("Use Fs.constants.R_OK instead")
 	static var R_OK(default, null):Int;
 
 	/**
@@ -1458,6 +1477,7 @@ extern class Fs {
 
 		File can be written by the calling process.
 	**/
+	@:deprecated("Use Fs.constants.W_OK instead")
 	static var W_OK(default, null):Int;
 
 	/**
@@ -1466,6 +1486,7 @@ extern class Fs {
 		File can be executed by the calling process.
 		This has no effect on Windows.
 	**/
+	@:deprecated("Use Fs.constants.X_OK instead")
 	static var X_OK(default, null):Int;
 
 	/**

--- a/src/js/node/Fs.hx
+++ b/src/js/node/Fs.hx
@@ -32,11 +32,9 @@ import js.node.fs.ReadStream;
 import js.node.fs.Stats;
 import js.node.fs.StatsFs;
 import js.node.fs.WriteStream;
-#if haxe4
 import js.lib.Error;
-#else
-import js.Error;
-#end
+import js.lib.Promise;
+import js.node.web.Blob;
 
 /**
 	Most FS functions now support passing `String` and `Buffer`.
@@ -659,6 +657,32 @@ typedef FsGlobOptions = {
 }
 
 /**
+	Disposable temporary directory returned by `Fs.mkdtempDisposableSync`.
+**/
+typedef FsMkdtempDisposable = {
+	/**
+		The path of the created directory.
+	**/
+	var path:String;
+
+	/**
+		Removes the created directory and its contents.
+		Same as the `[Symbol.dispose]` method on the returned object.
+	**/
+	function remove():Void;
+}
+
+/**
+	Options for `Fs.openAsBlob`.
+**/
+typedef FsOpenAsBlobOptions = {
+	/**
+		An optional MIME type for the blob.
+	**/
+	@:optional var type:String;
+}
+
+/**
 	A buffer for `Fs.readv` / `Fs.writev`.
 
 	Node.js accepts an `ArrayBufferView` (Buffer, TypedArray, or DataView).
@@ -914,6 +938,7 @@ extern class Fs {
 		`cache` is an object literal of mapped paths that can be used to force a specific path resolution
 		or avoid additional `stat` calls for known real paths.
 	**/
+	// TODO(section-2): model `realpath.native` / `realpathSync.native` function properties
 	@:overload(function(path:FsPath, callback:Error->String->Void):Void {})
 	static function realpath(path:FsPath, cache:DynamicAccess<String>, callback:Error->String->Void):Void;
 
@@ -980,6 +1005,7 @@ extern class Fs {
 
 		The created folder path is passed as a string to the `callback`'s second parameter.
 	**/
+	@:overload(function(prefix:String, options:EitherType<String, {?encoding:String}>, callback:Error->String->Void):Void {})
 	static function mkdtemp(prefix:String, callback:Error->String->Void):Void;
 
 	/**
@@ -987,7 +1013,19 @@ extern class Fs {
 
 		Returns the created folder path.
 	**/
-	static function mkdtempSync(template:String):String;
+	@:overload(function(prefix:String, options:EitherType<String, {?encoding:String}>):String {})
+	static function mkdtempSync(prefix:String):String;
+
+	/**
+		Synchronously creates a unique temporary directory and returns a disposable object.
+
+		When the object is disposed (or `remove` is called), the directory and its contents are removed
+		if they still exist.
+
+		@see https://nodejs.org/api/fs.html#fsmkdtempdisposablesyncprefix-options
+	**/
+	@:overload(function(prefix:String, options:EitherType<String, {?encoding:String}>):FsMkdtempDisposable {})
+	static function mkdtempDisposableSync(prefix:String):FsMkdtempDisposable;
 
 	/**
 		Asynchronous readdir(3).
@@ -1081,6 +1119,17 @@ extern class Fs {
 	**/
 	@:overload(function(path:FsPath, flags:FsOpenFlag):Int {})
 	static function openSync(path:FsPath, flags:FsOpenFlag, mode:FsMode):Int;
+
+	/**
+		Returns a `Blob` whose data is backed by the given file.
+
+		The file must not be modified after the `Blob` is created.
+		Any modifications will cause reading the `Blob` data to fail with a `DOMException` error.
+
+		@see https://nodejs.org/api/fs.html#fsopenasblobpath-options
+	**/
+	@:overload(function(path:FsPath):Promise<Blob> {})
+	static function openAsBlob(path:FsPath, options:FsOpenAsBlobOptions):Promise<Blob>;
 
 	/**
 		Change file timestamps of the file referenced by the supplied path.
@@ -1184,17 +1233,17 @@ extern class Fs {
 		On Linux, positional writes don't work when the file is opened in append mode. The kernel ignores the position
 		argument and always appends the data to the end of the file.
 	**/
-	@:overload(function(fd:Int, data:Dynamic, position:Int, encoding:String, callback:Error->Int->String->Void):Void {})
-	@:overload(function(fd:Int, data:Dynamic, position:Int, callback:Error->Int->String->Void):Void {})
-	@:overload(function(fd:Int, data:Dynamic, callback:Error->Int->String->Void):Void {})
+	@:overload(function(fd:Int, data:String, position:Int, encoding:String, callback:Error->Int->String->Void):Void {})
+	@:overload(function(fd:Int, data:String, position:Int, callback:Error->Int->String->Void):Void {})
+	@:overload(function(fd:Int, data:String, callback:Error->Int->String->Void):Void {})
 	@:overload(function(fd:Int, buffer:Buffer, offset:Int, length:Int, callback:Error->Int->Buffer->Void):Void {})
 	static function write(fd:Int, buffer:Buffer, offset:Int, length:Int, position:Int, callback:Error->Int->Buffer->Void):Void;
 
 	/**
 		Synchronous version of `write`. Returns the number of bytes written.
 	**/
-	@:overload(function(fd:Int, data:Dynamic, position:Int, encoding:String):Int {})
-	@:overload(function(fd:Int, data:Dynamic, ?position:Int):Int {})
+	@:overload(function(fd:Int, data:String, position:Int, encoding:String):Int {})
+	@:overload(function(fd:Int, data:String, ?position:Int):Int {})
 	static function writeSync(fd:Int, buffer:Buffer, offset:Int, length:Int, ?position:Int):Int;
 
 	/**

--- a/src/js/node/FsPromises.hx
+++ b/src/js/node/FsPromises.hx
@@ -29,11 +29,7 @@ import js.node.fs.Dirent;
 import js.node.fs.FileHandle;
 import js.node.fs.Stats;
 import js.node.fs.StatsFs;
-#if haxe4
 import js.lib.Promise;
-#else
-import js.Promise;
-#end
 
 /**
 	Minimal async iterator surface used by `glob` / `watch` (for `for await...of`).
@@ -148,6 +144,17 @@ extern class FsPromises {
 	**/
 	@:overload(function(prefix:String):Promise<String> {})
 	static function mkdtemp(prefix:String, options:EitherType<String, {?encoding:String}>):Promise<String>;
+
+	/**
+		Asynchronously creates a unique temporary directory and returns an async-disposable object.
+
+		When the object is disposed (or `remove` is awaited), the directory and its contents are removed
+		if they still exist.
+
+		@see https://nodejs.org/api/fs.html#fspromisesmkdtempdisposableprefix-options
+	**/
+	@:overload(function(prefix:String):Promise<FsPromisesMkdtempDisposable> {})
+	static function mkdtempDisposable(prefix:String, options:EitherType<String, {?encoding:String}>):Promise<FsPromisesMkdtempDisposable>;
 
 	/**
 		Opens a `FileHandle`.
@@ -297,4 +304,20 @@ typedef FsPromisesWatchEvent = {
 		The name of the file that changed.
 	**/
 	var filename:Null<EitherType<String, Buffer>>;
+}
+
+/**
+	Async-disposable temporary directory returned by `FsPromises.mkdtempDisposable`.
+**/
+typedef FsPromisesMkdtempDisposable = {
+	/**
+		The path of the created directory.
+	**/
+	var path:String;
+
+	/**
+		Asynchronously removes the created directory and its contents.
+		Same as the `[Symbol.asyncDispose]` method on the returned object.
+	**/
+	function remove():Promise<Void>;
 }

--- a/src/js/node/FsPromises.hx
+++ b/src/js/node/FsPromises.hx
@@ -95,7 +95,7 @@ extern class FsPromises {
 	@:overload(function(pattern:EitherType<String, Array<String>>):FsPromisesAsyncIterator<String> {})
 	@:overload(function(pattern:EitherType<String, Array<String>>, options:FsGlobOptions):FsPromisesAsyncIterator<String> {})
 	static function glob(pattern:EitherType<String, Array<String>>, options:{
-		?cwd:String,
+		?cwd:haxe.extern.EitherType<String, js.node.url.URL>,
 		?exclude:EitherType<String->Bool, Array<String>>,
 		?followSymlinks:Bool,
 		withFileTypes:Bool

--- a/src/js/node/Path.hx
+++ b/src/js/node/Path.hx
@@ -201,4 +201,5 @@ private typedef PathModule = {
 	var delimiter(default, null):String;
 	function parse(pathString:String):PathObject;
 	function format(pathObject:PathObject):String;
+	function toNamespacedPath(path:String):String;
 }

--- a/src/js/node/Zlib.hx
+++ b/src/js/node/Zlib.hx
@@ -26,11 +26,7 @@ import haxe.DynamicAccess;
 import haxe.extern.EitherType;
 import js.node.Buffer;
 import js.node.zlib.*;
-#if haxe4
 import js.lib.Error;
-#else
-import js.Error;
-#end
 
 typedef ZlibOptions = {
 	/**
@@ -104,8 +100,52 @@ typedef BrotliOptions = {
 }
 
 /**
+	Options for Zstandard (zstd) compression and decompression.
+
+	Stability: 1 - Experimental
+**/
+typedef ZstdOptions = {
+	/**
+		default: `zlib.constants.ZSTD_e_continue`
+	**/
+	@:optional var flush:Int;
+
+	/**
+		default: `zlib.constants.ZSTD_e_end`
+	**/
+	@:optional var finishFlush:Int;
+
+	/**
+		default: 16*1024
+	**/
+	@:optional var chunkSize:Int;
+
+	/**
+		Key-value object containing indexed Zstd parameters.
+	**/
+	@:optional var params:DynamicAccess<Int>;
+
+	/**
+		The maximum length of the output that can be produced by zlib streams.
+		Default: `buffer.kMaxLength`
+	**/
+	@:optional var maxOutputLength:Int;
+
+	/**
+		If `true`, returns an object with `buffer` and `engine`.
+		Default: `false`
+	**/
+	@:optional var info:Bool;
+
+	/**
+		Optional dictionary used to improve compression efficiency.
+	**/
+	@:optional var dictionary:Buffer;
+}
+
+/**
 	This provides bindings to Gzip/Gunzip, Deflate/Inflate, DeflateRaw/InflateRaw,
-	and BrotliCompress/BrotliDecompress classes.
+	BrotliCompress/BrotliDecompress, and ZstdCompress/ZstdDecompress classes.
 	Each class takes options, and is a readable/writable Stream.
 **/
 @:jsRequire("zlib")
@@ -176,6 +216,13 @@ extern class Zlib {
 	static var Z_NULL(default, null):Int;
 
 	/**
+		Object containing all zlib constants (including Z_*, BROTLI_*, and ZSTD_*).
+		Prefer this over the legacy top-level `Z_*` fields on this class.
+	**/
+	// TODO(section-2): typed ZlibConstants covering Z_*/BROTLI_*/ZSTD_* instead of DynamicAccess
+	static var constants(default, null):DynamicAccess<Int>;
+
+	/**
 		Returns a new `Gzip` object with an `options`.
 	**/
 	static function createGzip(?options:ZlibOptions):Gzip;
@@ -219,6 +266,20 @@ extern class Zlib {
 		Returns a new `BrotliDecompress` object with an `options`.
 	**/
 	static function createBrotliDecompress(?options:BrotliOptions):BrotliDecompress;
+
+	/**
+		Returns a new `ZstdCompress` object with an `options`.
+
+		Stability: 1 - Experimental
+	**/
+	static function createZstdCompress(?options:ZstdOptions):ZstdCompress;
+
+	/**
+		Returns a new `ZstdDecompress` object with an `options`.
+
+		Stability: 1 - Experimental
+	**/
+	static function createZstdDecompress(?options:ZstdOptions):ZstdDecompress;
 
 	/**
 		Computes a 32-bit Cyclic Redundancy Check checksum of `data`.
@@ -324,4 +385,34 @@ extern class Zlib {
 		Decompress a Buffer with `BrotliDecompress` (synchronous version).
 	**/
 	static function brotliDecompressSync(buf:EitherType<String, Buffer>, ?options:BrotliOptions):Buffer;
+
+	/**
+		Compress a chunk of data with `ZstdCompress`.
+
+		Stability: 1 - Experimental
+	**/
+	@:overload(function(buf:EitherType<String, Buffer>, options:ZstdOptions, callback:Error->Buffer->Void):Void {})
+	static function zstdCompress(buf:EitherType<String, Buffer>, callback:Error->Buffer->Void):Void;
+
+	/**
+		Compress a chunk of data with `ZstdCompress` (synchronous version).
+
+		Stability: 1 - Experimental
+	**/
+	static function zstdCompressSync(buf:EitherType<String, Buffer>, ?options:ZstdOptions):Buffer;
+
+	/**
+		Decompress a chunk of data with `ZstdDecompress`.
+
+		Stability: 1 - Experimental
+	**/
+	@:overload(function(buf:EitherType<String, Buffer>, options:ZstdOptions, callback:Error->Buffer->Void):Void {})
+	static function zstdDecompress(buf:EitherType<String, Buffer>, callback:Error->Buffer->Void):Void;
+
+	/**
+		Decompress a chunk of data with `ZstdDecompress` (synchronous version).
+
+		Stability: 1 - Experimental
+	**/
+	static function zstdDecompressSync(buf:EitherType<String, Buffer>, ?options:ZstdOptions):Buffer;
 }

--- a/src/js/node/Zlib.hx
+++ b/src/js/node/Zlib.hx
@@ -35,6 +35,11 @@ typedef ZlibOptions = {
 	@:optional var flush:Int;
 
 	/**
+		default: `Zlib.Z_FINISH`
+	**/
+	@:optional var finishFlush:Int;
+
+	/**
 		default: 16*1024
 	**/
 	@:optional var chunkSize:Int;
@@ -60,6 +65,18 @@ typedef ZlibOptions = {
 		deflate/inflate only, empty dictionary by default
 	**/
 	@:optional var dictionary:Buffer;
+
+	/**
+		Limits output size when using convenience methods.
+		Default: `buffer.kMaxLength`
+	**/
+	@:optional var maxOutputLength:Int;
+
+	/**
+		If `true`, returns an object with `buffer` and `engine`.
+		Default: `false`
+	**/
+	@:optional var info:Bool;
 }
 
 /**

--- a/src/js/node/fs/Dir.hx
+++ b/src/js/node/fs/Dir.hx
@@ -22,11 +22,8 @@
 
 package js.node.fs;
 
-#if haxe4
 import js.lib.Error;
-#else
-import js.Error;
-#end
+import js.lib.Promise;
 
 /**
 	A class representing a directory stream.
@@ -43,7 +40,10 @@ extern class Dir {
 	/**
 		Asynchronously close the directory's underlying resource handle.
 		Subsequent reads will result in errors.
+
+		Without a callback, returns a `Promise` that is fulfilled after the resource has been closed.
 	**/
+	@:overload(function():Promise<Void> {})
 	function close(callback:Error->Void):Void;
 
 	/**
@@ -55,8 +55,10 @@ extern class Dir {
 	/**
 		Asynchronously read the next directory entry via readdir(3) as a `Dirent`.
 
-		The callback is called with a `Dirent`, or `null` if there are no more directory entries to read.
+		Without a callback, returns a `Promise` fulfilled with a `Dirent`, or `null` if there are no more entries.
+		With a callback, it is called with a `Dirent`, or `null` if there are no more directory entries to read.
 	**/
+	@:overload(function():Promise<Null<Dirent>> {})
 	function read(callback:Error->Null<Dirent>->Void):Void;
 
 	/**

--- a/src/js/node/fs/FileHandle.hx
+++ b/src/js/node/fs/FileHandle.hx
@@ -28,11 +28,7 @@ import js.node.Fs;
 import js.node.events.EventEmitter;
 import js.node.events.EventEmitter.Event;
 import js.node.readline.Interface;
-#if haxe4
 import js.lib.Promise;
-#else
-import js.Promise;
-#end
 
 /**
 	A `FileHandle` object is a wrapper for a numeric file descriptor.
@@ -111,9 +107,8 @@ extern class FileHandle extends EventEmitter<FileHandle> {
 
 	/**
 		Returns a byte-oriented `ReadableStream` for the file contents.
-
-		Typed as `Dynamic` until web streams externs are added (same pattern as `Blob.stream`).
 	**/
+	// TODO(section-2): return typed ReadableStream once web streams externs are available
 	function readableWebStream(?options:FileHandleReadableWebStreamOptions):Dynamic;
 
 	/**

--- a/src/js/node/fs/FileHandle.hx
+++ b/src/js/node/fs/FileHandle.hx
@@ -108,7 +108,7 @@ extern class FileHandle extends EventEmitter<FileHandle> {
 	/**
 		Returns a byte-oriented `ReadableStream` for the file contents.
 	**/
-	// TODO(section-2): return typed ReadableStream once web streams externs are available
+	// TODO(section-6): return typed ReadableStream once web streams externs are available
 	function readableWebStream(?options:FileHandleReadableWebStreamOptions):Dynamic;
 
 	/**

--- a/src/js/node/fs/StatWatcher.hx
+++ b/src/js/node/fs/StatWatcher.hx
@@ -22,55 +22,21 @@
 
 package js.node.fs;
 
-import js.node.Fs.FsPath;
-import js.node.events.EventEmitter;
-import js.lib.Error;
-
 /**
-	Enumeration of possible types of changes for 'change' event.
+	Objects returned from `Fs.watchFile` are of this type.
+
+	@see https://nodejs.org/api/fs.html#class-fsstatwatcher
 **/
-enum abstract FSWatcherChangeType(String) from String to String {
-	var Change = "change";
-	var Rename = "rename";
-}
-
-/**
-	Enumeration of the events emitted by `FSWatcher`.
-**/
-enum abstract FSWatcherEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
+extern class StatWatcher {
 	/**
-		Emitted when something changes in a watched directory or file. See more details in `Fs.watch`.
-
-		Listener arguments:
-			event - The type of fs change
-			filename - The filename that changed (if relevant/available)
-	**/
-	var Change:FSWatcherEvent<FSWatcherChangeType->FsPath->Void> = "change";
-
-	/**
-		Emitted when an error occurs.
-	**/
-	var Error:FSWatcherEvent<Error->Void> = "error";
-}
-
-/**
-	Objects returned from `Fs.watch` are of this type.
-**/
-extern class FSWatcher extends EventEmitter<FSWatcher> {
-	/**
-		Stop watching for changes on the given `FSWatcher`.
-	**/
-	function close():Void;
-
-	/**
-		When called, requests that the Node.js event loop not exit so long as the `FSWatcher` is active.
+		When called, requests that the Node.js event loop not exit so long as the `StatWatcher` is active.
 		Calling `ref()` multiple times has no effect.
 	**/
-	function ref():FSWatcher;
+	function ref():StatWatcher;
 
 	/**
-		When called, the active `FSWatcher` will not require the Node.js event loop to remain active.
+		When called, the active `StatWatcher` will not require the Node.js event loop to remain active.
 		Calling `unref()` multiple times has no effect.
 	**/
-	function unref():FSWatcher;
+	function unref():StatWatcher;
 }

--- a/src/js/node/fs/Stats.hx
+++ b/src/js/node/fs/Stats.hx
@@ -38,6 +38,28 @@ extern class Stats {
 	var blocks:Null<Float>;
 
 	/**
+		Milliseconds timestamp of `atime`.
+	**/
+	var atimeMs:Float;
+
+	/**
+		Milliseconds timestamp of `mtime`.
+	**/
+	var mtimeMs:Float;
+
+	/**
+		Milliseconds timestamp of `ctime`.
+	**/
+	var ctimeMs:Float;
+
+	/**
+		Milliseconds timestamp of `birthtime`.
+	**/
+	var birthtimeMs:Float;
+
+	// TODO(section-2): atimeNs/mtimeNs/ctimeNs/birthtimeNs (bigint when `{bigint: true}` is passed to stat)
+
+	/**
 		"Access Time" - Time when file data last accessed.
 
 		Changed by the mknod(2), utimes(2), and read(2) system calls.

--- a/src/js/node/fs/Utf8Stream.hx
+++ b/src/js/node/fs/Utf8Stream.hx
@@ -1,0 +1,236 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.fs;
+
+import haxe.extern.EitherType;
+import js.lib.Error;
+import js.node.Buffer;
+import js.node.Fs.FsMode;
+import js.node.Fs.FsPath;
+import js.node.events.EventEmitter;
+import js.node.events.EventEmitter.Event;
+
+/**
+	An optimized UTF-8 stream writer with on-demand flushing.
+
+	Stability: 1 - Experimental (added in Node.js v24.6.0).
+
+	@see https://nodejs.org/api/fs.html#class-fsutf8stream
+**/
+@:jsRequire("fs", "Utf8Stream")
+extern class Utf8Stream extends EventEmitter<Utf8Stream> {
+	/**
+		Whether the stream is appending to the file or truncating it.
+	**/
+	var append(default, null):Bool;
+
+	/**
+		The type of data that can be written: `'utf8'` or `'buffer'`.
+	**/
+	var contentMode(default, null):String;
+
+	/**
+		The file descriptor being written to.
+	**/
+	var fd(default, null):Null<Int>;
+
+	/**
+		The file being written to.
+	**/
+	var file(default, null):Null<FsPath>;
+
+	/**
+		Whether `fs.fsyncSync()` is performed after every write.
+	**/
+	var fsync(default, null):Bool;
+
+	/**
+		Maximum length of the internal buffer.
+	**/
+	var maxLength(default, null):Null<Int>;
+
+	/**
+		Minimum length of the internal buffer required before flushing.
+	**/
+	var minLength(default, null):Null<Int>;
+
+	/**
+		Whether the stream ensures the destination directory exists.
+	**/
+	var mkdir(default, null):Bool;
+
+	/**
+		Mode of the file being written to.
+	**/
+	var mode(default, null):Null<FsMode>;
+
+	/**
+		Milliseconds between periodic flushes (`0` disables).
+	**/
+	var periodicFlush(default, null):Int;
+
+	/**
+		Whether the stream writes synchronously.
+	**/
+	var sync(default, null):Bool;
+
+	/**
+		Whether the stream is currently writing.
+	**/
+	var writing(default, null):Bool;
+
+	function new(?options:Utf8StreamOptions);
+
+	/**
+		Close the stream immediately, without flushing the internal buffer.
+	**/
+	function destroy():Void;
+
+	/**
+		Close the stream gracefully, flushing the internal buffer before closing.
+	**/
+	function end():Void;
+
+	/**
+		Writes the current buffer to the file if a write is not already in progress.
+	**/
+	function flush(callback:Null<Error>->Void):Void;
+
+	/**
+		Flushes buffered data synchronously.
+	**/
+	function flushSync():Void;
+
+	/**
+		Reopen the file in place (useful for log rotation).
+	**/
+	function reopen(file:FsPath):Void;
+
+	/**
+		Write `data` to the stream.
+		Returns `true` if the data was written / buffered successfully.
+	**/
+	function write(data:EitherType<String, Buffer>):Bool;
+}
+
+/**
+	Events emitted by `Utf8Stream`.
+**/
+enum abstract Utf8StreamEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
+	var Close:Utf8StreamEvent<Void->Void> = "close";
+	var Drain:Utf8StreamEvent<Void->Void> = "drain";
+
+	/**
+		Emitted when `maxLength` is reached and data is dropped.
+	**/
+	var Drop:Utf8StreamEvent<EitherType<String, Buffer>->Void> = "drop";
+
+	var Error:Utf8StreamEvent<Error->Void> = "error";
+	var Finish:Utf8StreamEvent<Void->Void> = "finish";
+	var Ready:Utf8StreamEvent<Void->Void> = "ready";
+
+	/**
+		Emitted when a write completes; argument is bytes written.
+	**/
+	var Write:Utf8StreamEvent<Int->Void> = "write";
+}
+
+/**
+	Options for `new Utf8Stream()`.
+**/
+typedef Utf8StreamOptions = {
+	/**
+		Append writes instead of truncating.
+		Default: `true`.
+	**/
+	@:optional var append:Bool;
+
+	/**
+		`'utf8'` or `'buffer'`.
+		Default: `'utf8'`.
+	**/
+	@:optional var contentMode:String;
+
+	/**
+		Destination file path.
+	**/
+	@:optional var dest:FsPath;
+
+	/**
+		Existing file descriptor.
+	**/
+	@:optional var fd:Int;
+
+	/**
+		Custom `fs` implementation for mocking / testing.
+	**/
+	// TODO(section-2): type as structural fs subset once practical
+	@:optional var fs:Dynamic;
+
+	/**
+		Perform `fsyncSync` after every write.
+	**/
+	@:optional var fsync:Bool;
+
+	/**
+		Maximum internal buffer length; excess writes emit `drop`.
+	**/
+	@:optional var maxLength:Int;
+
+	/**
+		Maximum bytes per write.
+		Default: `16384`.
+	**/
+	@:optional var maxWrite:Int;
+
+	/**
+		Minimum buffer length required before flushing.
+	**/
+	@:optional var minLength:Int;
+
+	/**
+		Ensure directory for `dest` exists.
+		Default: `false`.
+	**/
+	@:optional var mkdir:Bool;
+
+	/**
+		File mode when creating.
+	**/
+	@:optional var mode:FsMode;
+
+	/**
+		Call flush every `periodicFlush` milliseconds.
+	**/
+	@:optional var periodicFlush:Int;
+
+	/**
+		Called on `EAGAIN` / `EBUSY`; return `true` to retry.
+	**/
+	@:optional var retryEAGAIN:Null<Error>->Int->Int->Bool;
+
+	/**
+		Perform writes synchronously.
+	**/
+	@:optional var sync:Bool;
+}

--- a/src/js/node/zlib/Zlib.hx
+++ b/src/js/node/zlib/Zlib.hx
@@ -28,6 +28,12 @@ package js.node.zlib;
 **/
 extern class Zlib extends js.node.stream.Transform<Zlib> {
 	/**
+		The number of bytes written to the engine before the bytes are processed
+		(compressed or decompressed, as appropriate for the derived class).
+	**/
+	var bytesWritten(default, null):Float;
+
+	/**
 		Flush pending data.
 
 		`kind` defaults to `Zlib.Z_FULL_FLUSH`.

--- a/src/js/node/zlib/ZstdCompress.hx
+++ b/src/js/node/zlib/ZstdCompress.hx
@@ -20,45 +20,12 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-package js.node.fs;
-
-import js.node.Fs.FsPath;
-import js.node.events.EventEmitter;
-import js.lib.Error;
+package js.node.zlib;
 
 /**
-	Enumeration of possible types of changes for 'change' event.
+	Compress data using the Zstandard (zstd) algorithm.
+
+	Stability: 1 - Experimental
 **/
-enum abstract FSWatcherChangeType(String) from String to String {
-	var Change = "change";
-	var Rename = "rename";
-}
-
-/**
-	Enumeration of the events emitted by `FSWatcher`.
-**/
-enum abstract FSWatcherEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
-	/**
-		Emitted when something changes in a watched directory or file. See more details in `Fs.watch`.
-
-		Listener arguments:
-			event - The type of fs change
-			filename - The filename that changed (if relevant/available)
-	**/
-	var Change:FSWatcherEvent<FSWatcherChangeType->FsPath->Void> = "change";
-
-	/**
-		Emitted when an error occurs.
-	**/
-	var Error:FSWatcherEvent<Error->Void> = "error";
-}
-
-/**
-	Objects returned from `Fs.watch` are of this type.
-**/
-extern class FSWatcher extends EventEmitter<FSWatcher> {
-	/**
-		Stop watching for changes on the given `FSWatcher`.
-	**/
-	function close():Void;
-}
+@:jsRequire("zlib", "ZstdCompress")
+extern class ZstdCompress extends Zlib {}

--- a/src/js/node/zlib/ZstdDecompress.hx
+++ b/src/js/node/zlib/ZstdDecompress.hx
@@ -20,45 +20,12 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-package js.node.fs;
-
-import js.node.Fs.FsPath;
-import js.node.events.EventEmitter;
-import js.lib.Error;
+package js.node.zlib;
 
 /**
-	Enumeration of possible types of changes for 'change' event.
+	Decompress data using the Zstandard (zstd) algorithm.
+
+	Stability: 1 - Experimental
 **/
-enum abstract FSWatcherChangeType(String) from String to String {
-	var Change = "change";
-	var Rename = "rename";
-}
-
-/**
-	Enumeration of the events emitted by `FSWatcher`.
-**/
-enum abstract FSWatcherEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
-	/**
-		Emitted when something changes in a watched directory or file. See more details in `Fs.watch`.
-
-		Listener arguments:
-			event - The type of fs change
-			filename - The filename that changed (if relevant/available)
-	**/
-	var Change:FSWatcherEvent<FSWatcherChangeType->FsPath->Void> = "change";
-
-	/**
-		Emitted when an error occurs.
-	**/
-	var Error:FSWatcherEvent<Error->Void> = "error";
-}
-
-/**
-	Objects returned from `Fs.watch` are of this type.
-**/
-extern class FSWatcher extends EventEmitter<FSWatcher> {
-	/**
-		Stop watching for changes on the given `FSWatcher`.
-	**/
-	function close():Void;
-}
+@:jsRequire("zlib", "ZstdDecompress")
+extern class ZstdDecompress extends Zlib {}

--- a/src/sys/FileSystem.hx
+++ b/src/sys/FileSystem.hx
@@ -2,16 +2,13 @@ package sys;
 
 import js.node.Fs;
 import js.node.Path;
-#if haxe4
 import js.lib.Error;
-#else
-import js.Error;
-#end
 
 @:dce
 @:coreApi
 class FileSystem {
 	public static function exists(path:String):Bool {
+		// TODO(section-2): typed Node ErrnoException instead of Dynamic catch
 		return try {
 			Fs.accessSync(path);
 			true;
@@ -27,6 +24,7 @@ class FileSystem {
 	}
 
 	public static inline function fullPath(relPath:String):String {
+		// TODO(section-2): typed Node ErrnoException instead of Dynamic catch
 		return try Fs.realpathSync(relPath) catch (e:Dynamic) null;
 	}
 
@@ -37,10 +35,12 @@ class FileSystem {
 	}
 
 	public static function isDirectory(path:String):Bool {
+		// TODO(section-2): typed Node ErrnoException instead of Dynamic catch
 		return try Fs.statSync(path).isDirectory() catch (e:Dynamic) false;
 	}
 
 	public static function createDirectory(path:String):Void {
+		// TODO(section-2): typed Node ErrnoException instead of Dynamic catch
 		try {
 			Fs.mkdirSync(path);
 		} catch (e:Dynamic) {

--- a/src/sys/NodeSync.hx
+++ b/src/sys/NodeSync.hx
@@ -6,7 +6,7 @@ private extern class Deasync {
 }
 
 class NodeSync {
-	public static function callMany(f:Dynamic->Void):Array<Dynamic> {
+	public static function callMany(f:Dynamic->Void):Array<Dynamic> { // TODO(section-2): replace Dynamic with typed callback/result once ErrnoException lands
 		var retArgs = null;
 		var wait = Reflect.makeVarArgs(function(args) retArgs = args);
 		f(wait);

--- a/src/sys/io/FileInput.hx
+++ b/src/sys/io/FileInput.hx
@@ -26,6 +26,7 @@ class FileInput extends haxe.io.Input {
 
 	override public function readByte():Int {
 		var buf = Buffer.alloc(1);
+		// TODO(section-2): typed Node ErrnoException instead of Dynamic catch
 		var bytesRead = try {
 			Fs.readSync(fd, buf, 0, 1, pos);
 		} catch (e:Dynamic) {
@@ -44,6 +45,7 @@ class FileInput extends haxe.io.Input {
 		var bytesRead = try {
 			Fs.readSync(fd, buf, pos, len, this.pos);
 		} catch (e:Dynamic) {
+			// TODO(section-2): typed Node ErrnoException instead of Dynamic catch
 			if (e.code == "EOF")
 				throwEof();
 			throw Error.Custom(e);

--- a/src/sys/net/Host.hx
+++ b/src/sys/net/Host.hx
@@ -3,7 +3,7 @@ package sys.net;
 @:coreApi
 @:allow(sys.net.Socket)
 class Host {
-	#if (haxe_ver >= 3.3) public #end var host(default, null):String;
+	public var host(default, null):String;
 
 	public var ip(default, null):Int;
 


### PR DESCRIPTION
## Summary
- Completes the Section 2 Node.js v24 + Haxe 4 audit for `fs` (+promises), `path`, `os`, `zlib`, and related `sys`/`Sys`/`haxe.zip` surfaces.
- Adds missing public APIs: `Fs.openAsBlob`, `Fs.promises`, `Fs.mkdtempDisposableSync`, `FsPromises.mkdtempDisposable`, `StatWatcher`, experimental `Utf8Stream`, Zstd compress/decompress (classes + convenience methods), `Zlib.constants`, `Stats` millisecond fields, Promise overloads on `Dir.close`/`Dir.read`, `FSWatcher.ref`/`unref`, and glob `cwd` as `String|URL`.
- Marks legacy `Fs.F_OK`/`R_OK`/`W_OK`/`X_OK` as `@:deprecated` in favor of `Fs.constants.*`.
- Drops Haxe 3 `#if haxe4` / `haxe_ver` gates in this section (Haxe 4+ only) and tightens `Dynamic` where safe (`Fs.write`/`writeSync` string overloads); remaining `Dynamic` sites are marked `TODO(section-2)` / `TODO(section-6)`.

## Remaining TODOs (inline)
- Typed `Fs.promises` module value type (currently `Dynamic`)
- `realpath.native` / `realpathSync.native` function properties
- Typed `ZlibConstants` (currently `DynamicAccess<Int>`)
- `Stats` bigint nanosecond fields (`atimeNs` etc.)
- Node `ErrnoException` typing for `sys`/`Sys` catch sites
- `FileHandle.readableWebStream` → typed `ReadableStream` (coord with section 6)
- `Utf8StreamOptions.fs` mock object typing

## Test plan
- [x] Targeted Haxe compile of audited modules (`-D nodejs` + `allowPackage('sys')`)
- [x] `haxe completion.hxml` succeeds
- [ ] Spot-check new APIs against Node.js v24 docs (`openAsBlob`, `mkdtempDisposable*`, Zstd, `Utf8Stream`)
- [ ] Confirm no regressions for existing fs/promises / zlib Brotli callers