### PR TITLE
Audit networking externs for Node 24 + Haxe 4

### DIFF
--- a/src/js/node/Dns.hx
+++ b/src/js/node/Dns.hx
@@ -24,13 +24,8 @@ package js.node;
 
 import haxe.extern.EitherType;
 import js.node.dns.Resolver as ResolverObject;
-#if haxe4
 import js.lib.ArrayBuffer;
 import js.lib.Error;
-#else
-import js.html.ArrayBuffer;
-import js.Error;
-#end
 
 /**
 	Enumeration of possible Int `options` values for `Dns.lookup`.
@@ -445,11 +440,11 @@ extern enum abstract DnsErrorCode(String) {
 	var CANCELLED;
 }
 
-typedef DnsLookupCallbackSingle = #if (haxe_ver >= 4) (err:DnsError, address:String,
-		family:DnsAddressFamily) -> Void; #else DnsError->String->DnsAddressFamily->Void #end
+typedef DnsLookupCallbackSingle = (err:DnsError, address:String,
+		family:DnsAddressFamily) -> Void;
 
-typedef DnsLookupCallbackAll = #if (haxe_ver >= 4) (err:DnsError,
-		addresses:Array<DnsLookupCallbackAllEntry>) -> Void; #else DnsError->Array<DnsLookupCallbackAllEntry>->Void; #end
+typedef DnsLookupCallbackAll = (err:DnsError,
+		addresses:Array<DnsLookupCallbackAllEntry>) -> Void;
 
 typedef DnsLookupCallbackAllEntry = {address:String, family:DnsAddressFamily};
 

--- a/src/js/node/DnsPromises.hx
+++ b/src/js/node/DnsPromises.hx
@@ -25,11 +25,7 @@ package js.node;
 import haxe.extern.EitherType;
 import js.node.Dns;
 import js.node.dns.PromisesResolver as PromisesResolverObject;
-#if haxe4
 import js.lib.Promise;
-#else
-import js.Promise;
-#end
 
 /**
 	The `dns/promises` API provides an alternative set of asynchronous DNS methods

--- a/src/js/node/Http.hx
+++ b/src/js/node/Http.hx
@@ -28,11 +28,8 @@ import js.node.http.*;
 import js.node.net.Socket;
 import js.node.stream.Duplex;
 import js.node.url.URL;
-#if haxe4
+import js.node.web.AbortSignal;
 import js.lib.Error;
-#else
-import js.Error;
-#end
 
 /**
 	The HTTP interfaces in Node are designed to support many features of the protocol
@@ -67,13 +64,8 @@ extern class Http {
 
 		The `requestListener` is a function which is automatically added to the `'request'` event.
 	**/
-	#if haxe4
 	@:overload(function(options:HttpCreateServerOptions, ?requestListener:(request:IncomingMessage, response:ServerResponse) -> Void):Server {})
 	static function createServer(?requestListener:(request:IncomingMessage, response:ServerResponse) -> Void):Server;
-	#else
-	@:overload(function(options:HttpCreateServerOptions, ?requestListener:IncomingMessage->ServerResponse->Void):Server {})
-	static function createServer(?requestListener:IncomingMessage->ServerResponse->Void):Server;
-	#end
 
 	/**
 		Since most requests are GET requests without bodies, Node.js provides this convenience method.
@@ -110,6 +102,50 @@ extern class Http {
 	@:overload(function(url:URL, ?options:HttpRequestOptions, ?callback:IncomingMessage->Void):ClientRequest {})
 	@:overload(function(url:String, ?options:HttpRequestOptions, ?callback:IncomingMessage->Void):ClientRequest {})
 	static function request(options:HttpRequestOptions, ?callback:IncomingMessage->Void):ClientRequest;
+
+	/**
+		Performs the low-level validations on the provided `name` that are done when `res.setHeader(name, value)` is called.
+		@throws `TypeError` if the `name` is invalid.
+	**/
+	static function validateHeaderName(name:String, ?label:String):Void;
+
+	/**
+		Performs the low-level validations on the provided `value` that are done when `res.setHeader(name, value)` is called.
+		@throws `TypeError` if the `value` is invalid.
+	**/
+	static function validateHeaderValue(name:String, value:EitherType<String, Array<String>>):Void;
+
+	/**
+		Set the maximum number of idle HTTP parsers that can stay around for reuse.
+		Default: `1000`.
+	**/
+	static function setMaxIdleHTTPParsers(max:Int):Void;
+
+	/**
+		Undici `WebSocket` constructor exposed via `node:http`.
+
+		// TODO(section-6): prefer `js.node.web` WebSocket typing once section 6 lands
+	**/
+	static var WebSocket:Class<Any>;
+
+	/**
+		Parent class of `http.ClientRequest` and `http.ServerResponse`.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/http.html#class-httpoutgoingmessage
+	**/
+	static var OutgoingMessage:Class<OutgoingMessage>;
+
+	/**
+		Dynamically resets the global configurations to enable built-in proxy support for
+		`fetch()` and `http.request()` / `https.request()` at runtime.
+
+		Returns a restore function for the previous agent/dispatcher settings.
+
+		Added in: v24.14.0.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/http.html#httpsetglobalproxyfromenvproxyenv
+	**/
+	static function setGlobalProxyFromEnv(?proxyEnv:DynamicAccess<String>):() -> Void;
 }
 
 typedef HttpCreateServerOptions = {
@@ -118,14 +154,81 @@ typedef HttpCreateServerOptions = {
 
 		Default: `js.node.http.IncomingMessage`.
 	**/
-	@:optional var IncomingMessage:Class<Dynamic>;
+	@:optional var IncomingMessage:Class<IncomingMessage>;
 
 	/**
 		Specifies the `ServerResponse` class to be used. Useful for extending the original `ServerResponse`.
 
 		Default: `ServerResponse`.
 	**/
-	@:optional var ServerResponse:Class<Dynamic>;
+	@:optional var ServerResponse:Class<ServerResponse>;
+
+	/**
+		Sets the timeout value in milliseconds for receiving the entire request from the client.
+		See `server.requestTimeout`.
+	**/
+	@:optional var requestTimeout:Int;
+
+	/**
+		Sets the timeout value in milliseconds for receiving the complete HTTP headers from the client.
+		See `server.headersTimeout`.
+	**/
+	@:optional var headersTimeout:Int;
+
+	/**
+		The number of milliseconds of inactivity a server needs to wait for additional incoming data,
+		after it has finished writing the last response, before a socket will be destroyed.
+	**/
+	@:optional var keepAliveTimeout:Int;
+
+	/**
+		Additional milliseconds of inactivity to allow before destroying a keep-alive socket
+		after `keepAliveTimeout` elapses. Default: `1000`.
+	**/
+	@:optional var keepAliveTimeoutBuffer:Int;
+
+	/**
+		Sets the interval value in milliseconds to check for request and headers timeout in incomplete requests.
+	**/
+	@:optional var connectionsCheckingInterval:Int;
+
+	/**
+		Sets the maximum number of requests that may be made on a single socket before it is closed.
+		Default: `0` (no limit).
+	**/
+	@:optional var maxRequestsPerSocket:Int;
+
+	/**
+		Whether or not to enable keep-alive on incoming connections.
+	**/
+	@:optional var keepAlive:Bool;
+
+	/**
+		Initial delay for keep-alive in milliseconds.
+	**/
+	@:optional var keepAliveInitialDelay:Int;
+
+	/**
+		Optionally overrides all `net.Socket`s' `readableHighWaterMark` and `writableHighWaterMark`.
+	**/
+	@:optional var highWaterMark:Int;
+
+	/**
+		If set to `true`, it disables the use of Nagle's algorithm immediately after a new incoming connection is received.
+	**/
+	@:optional var noDelay:Bool;
+
+	/**
+		Sets the maximum number of unique header names allowed per request. Default: `2000`.
+	**/
+	@:optional var joinDuplicateHeaders:Bool;
+
+	/**
+		`uniqueHeaders` is an optional configuration specific to HTTP servers.
+
+		@see https://nodejs.org/api/http.html#httpcreateserveroptions-requestlistener
+	**/
+	@:optional var uniqueHeaders:Array<EitherType<String, Array<String>>>;
 }
 
 /**
@@ -154,11 +257,7 @@ typedef HttpRequestOptions = {
 		See [agent.createConnection()](https://nodejs.org/api/http.html#http_agent_createconnection_options_callback) for more details.
 		Any `Duplex` stream is a valid return value.
 	**/
-	#if haxe4
 	@:optional var createConnection:(options:SocketConnectOptionsTcp, ?callabck:(err:Error, stream:IDuplex) -> Void) -> IDuplex;
-	#else
-	@:optional var createConnection:SocketConnectOptionsTcp->?(Error->IDuplex->Void)->IDuplex;
-	#end
 
 	/**
 		Default port for the protocol.
@@ -242,4 +341,39 @@ typedef HttpRequestOptions = {
 		This will set the timeout before the socket is connected.
 	**/
 	@:optional var timeout:Int;
+
+	/**
+		Local port to bind to for network connections.
+	**/
+	@:optional var localPort:Int;
+
+	/**
+		Optional dns.lookup() hints.
+	**/
+	@:optional var hints:Int;
+
+	/**
+		An AbortSignal that may be used to abort an ongoing request.
+	**/
+	@:optional var signal:AbortSignal;
+
+	/**
+		Headers names which values are treated as arrays of values.
+	**/
+	@:optional var uniqueHeaders:Array<EitherType<String, Array<String>>>;
+
+	/**
+		Join duplicate headers into a comma-separated string for select headers.
+	**/
+	@:optional var joinDuplicateHeaders:Bool;
+
+	/**
+		Optionally overrides the value of `--max-http-header-size` for request parsing.
+	**/
+	@:optional var maxHeaderSize:Int;
+
+	/**
+		If `true`, use an insecure HTTP parser that accepts invalid HTTP headers.
+	**/
+	@:optional var insecureHTTPParser:Bool;
 }

--- a/src/js/node/Http2.hx
+++ b/src/js/node/Http2.hx
@@ -34,6 +34,7 @@ import js.node.http2.ServerHttp2Session;
 import js.node.stream.Duplex;
 import js.node.tls.SecureContext.SecureContextOptions;
 import js.node.url.URL;
+import js.node.web.AbortSignal;
 import js.lib.Symbol;
 
 /**
@@ -201,8 +202,8 @@ typedef Http2SecureClientSessionOptions = {
 	Options for HTTP/1 fallback classes used by HTTP/2 servers.
 **/
 typedef Http2Http1Options = {
-	@:optional var IncomingMessage:Class<Dynamic>;
-	@:optional var ServerResponse:Class<Dynamic>;
+	@:optional var IncomingMessage:Class<js.node.http.IncomingMessage>;
+	@:optional var ServerResponse:Class<js.node.http.ServerResponse>;
 	@:optional var keepAliveTimeout:Int;
 }
 
@@ -222,14 +223,14 @@ typedef Http2ServerOptions = {
 		See DEP0202.
 	**/
 	@:deprecated("Use http1Options.IncomingMessage instead")
-	@:optional var Http1IncomingMessage:Class<Dynamic>;
+	@:optional var Http1IncomingMessage:Class<js.node.http.IncomingMessage>;
 
 	/**
 		Deprecated. Use `http1Options.ServerResponse` instead.
 		See DEP0202.
 	**/
 	@:deprecated("Use http1Options.ServerResponse instead")
-	@:optional var Http1ServerResponse:Class<Dynamic>;
+	@:optional var Http1ServerResponse:Class<js.node.http.ServerResponse>;
 
 	/**
 		Options for configuring the HTTP/1 fallback when `allowHTTP1` is `true`.
@@ -237,8 +238,8 @@ typedef Http2ServerOptions = {
 	**/
 	@:optional var http1Options:Http2Http1Options;
 
-	@:optional var Http2ServerRequest:Class<Dynamic>;
-	@:optional var Http2ServerResponse:Class<Dynamic>;
+	@:optional var Http2ServerRequest:Class<Http2ServerRequest>;
+	@:optional var Http2ServerResponse:Class<Http2ServerResponse>;
 
 	/**
 		If `true`, strict validation is used for headers and trailers defined as
@@ -276,7 +277,7 @@ typedef Http2ClientSessionRequestOptions = {
 	@:optional var exclusive:Bool;
 	@:optional var parent:Int;
 	@:optional var waitForTrailers:Bool;
-	@:optional var signal:js.html.AbortSignal;
+	@:optional var signal:AbortSignal;
 }
 
 /**

--- a/src/js/node/Https.hx
+++ b/src/js/node/Https.hx
@@ -37,13 +37,8 @@ extern class Https {
 	/**
 		Returns a new HTTPS web server object.
 	**/
-	#if haxe4
 	@:overload(function(options:HttpsCreateServerOptions, ?requestListener:(request:IncomingMessage, response:ServerResponse) -> Void):Server {})
 	static function createServer(?requestListener:(request:IncomingMessage, response:ServerResponse) -> Void):Server;
-	#else
-	@:overload(function(options:HttpsCreateServerOptions, ?requestListener:IncomingMessage->ServerResponse->Void):Server {})
-	static function createServer(?requestListener:IncomingMessage->ServerResponse->Void):Server;
-	#end
 
 	/**
 		Like `Http.get` but for HTTPS.
@@ -90,5 +85,4 @@ typedef HttpsCreateServerOptions = {
 typedef HttpsRequestOptions = {
 	> js.node.Http.HttpRequestOptions,
 	> js.node.Tls.TlsConnectOptions,
-	// TODO: clean those options up
 }

--- a/src/js/node/Net.hx
+++ b/src/js/node/Net.hx
@@ -41,6 +41,31 @@ typedef NetCreateServerOptions = {
 		Default: false
 	**/
 	@:optional var pauseOnConnect:Bool;
+
+	/**
+		If set to `true`, it enables keep-alive functionality on the socket immediately after the connection is established.
+	**/
+	@:optional var keepAlive:Bool;
+
+	/**
+		If set to a positive number, it sets the initial delay before the first keepalive probe is sent on an idle socket.
+	**/
+	@:optional var keepAliveInitialDelay:Int;
+
+	/**
+		If set to `true`, it disables the use of Nagle's algorithm immediately after a connection is established.
+	**/
+	@:optional var noDelay:Bool;
+
+	/**
+		Optionally overrides all `net.Socket`s' `readableHighWaterMark` and `writableHighWaterMark`.
+	**/
+	@:optional var highWaterMark:Int;
+
+	/**
+		`net.BlockList` used as an IP allow/deny list for incoming connections.
+	**/
+	@:optional var blockList:BlockListObject;
 }
 
 /**

--- a/src/js/node/Tls.hx
+++ b/src/js/node/Tls.hx
@@ -22,17 +22,14 @@
 
 package js.node;
 
+import haxe.DynamicAccess;
 import haxe.extern.EitherType;
 import js.node.Buffer;
 import js.node.tls.SecureContext;
 import js.node.tls.SecurePair;
 import js.node.tls.Server;
 import js.node.tls.TLSSocket;
-#if haxe4
 import js.lib.Error;
-#else
-import js.Error;
-#end
 
 typedef TlsOptionsBase = {
 	/**
@@ -44,8 +41,17 @@ typedef TlsOptionsBase = {
 
 	/**
 		possible NPN protocols. (Protocols should be ordered by their priority).
+
+		@deprecated Use `ALPNProtocols` instead.
 	**/
+	@:deprecated("Use ALPNProtocols instead")
 	@:optional var NPNProtocols:EitherType<Array<String>, Buffer>;
+
+	/**
+		An array of strings or a Buffer naming possible ALPN protocols.
+		(Protocols should be ordered by their priority.)
+	**/
+	@:optional var ALPNProtocols:EitherType<Array<EitherType<String, Buffer>>, Buffer>;
 }
 
 typedef TlsServerOptionsBase = {
@@ -65,7 +71,7 @@ typedef TlsServerOptionsBase = {
 		(You can use tls.createSecureContext(...) to get proper `SecureContext`).
 		If `SNICallback` wasn't provided - default callback with high-level API will be used.
 	**/
-	@:optional var SNICallback:#if (haxe_ver >= 4)(servername:String, cb:(Error->SecureContext)) -> Void #else String->(Error->SecureContext)->Void #end;
+	@:optional var SNICallback:(servername:String, cb:(Null<Error>, SecureContext) -> Void) -> Void;
 }
 
 typedef TlsClientOptionsBase = {
@@ -111,6 +117,21 @@ typedef TlsCreateServerOptions = {
 		NOTE: Automatically shared between cluster module workers.
 	**/
 	@:optional var ticketKeys:Buffer;
+
+	/**
+		If true, `tls.TLSSocket.enableTrace()` is called on new connections.
+
+		@see https://nodejs.org/api/tls.html#tlscreateserveroptions-secureconnectionlistener
+	**/
+	@:optional var enableTrace:Bool;
+
+	/**
+		If set, called when a client opens a connection using the ALPN extension.
+		Return one of the client's protocols, or `undefined` to reject.
+
+		@see https://nodejs.org/api/tls.html#tlscreateserveroptions-secureconnectionlistener
+	**/
+	@:optional var ALPNCallback:(arg:{servername:String, protocols:Array<String>}) -> Null<String>;
 }
 
 typedef TlsConnectOptions = {
@@ -149,8 +170,39 @@ typedef TlsConnectOptions = {
 		An override for checking server's hostname against the certificate.
 		Should return an error if verification fails. Return `js.Lib.undefined` if passing.
 	**/
-	@:optional var checkServerIdentity:String -> {}->Dynamic; // TODO: peer cerficicate structure
+	@:optional var checkServerIdentity:(servername:String, cert:PeerCertificate) -> Null<Error>;
+}
 
+/**
+	Common fields of the certificate object returned by `TLSSocket.getPeerCertificate`.
+
+	// TODO(section-3): expand full PeerCertificate / DetailedPeerCertificate field set from OpenSSL
+**/
+typedef PeerCertificate = {
+	@:optional var subject:CertificateSubject;
+	@:optional var issuer:CertificateSubject;
+	@:optional var subjectaltname:String;
+	@:optional var infoAccess:haxe.DynamicAccess<Array<String>>;
+	@:optional var modulus:String;
+	@:optional var exponent:String;
+	@:optional var valid_from:String;
+	@:optional var valid_to:String;
+	@:optional var fingerprint:String;
+	@:optional var fingerprint256:String;
+	@:optional var fingerprint512:String;
+	@:optional var serialNumber:String;
+	@:optional var raw:Buffer;
+	// present when detailed=true
+	@:optional var issuerCertificate:PeerCertificate;
+}
+
+typedef CertificateSubject = {
+	@:optional var C:String;
+	@:optional var ST:String;
+	@:optional var L:String;
+	@:optional var O:String;
+	@:optional var OU:String;
+	@:optional var CN:String;
 }
 
 /**
@@ -234,6 +286,20 @@ extern class Tls {
 	static function getCiphers():Array<String>;
 
 	/**
+		Verifies the certificate `cert` is issued to `hostname`.
+
+		Returns an `Error` object on failure, or `undefined` on success.
+	**/
+	static function checkServerIdentity(hostname:String, cert:PeerCertificate):Null<Error>;
+
+	/**
+		Converts the given ALPN protocols list into wire-format expected by OpenSSL.
+
+		@see https://nodejs.org/api/tls.html#tlsconvertalpnprotocolsprotocols-out
+	**/
+	static function convertALPNProtocols(protocols:EitherType<Array<EitherType<String, Buffer>>, Buffer>, out:{}):Void;
+
+	/**
 		Creates a new `Server`.
 		The `connectionListener` argument is automatically set as a listener for the 'secureConnection' event.
 	**/
@@ -247,6 +313,7 @@ extern class Tls {
 	@:overload(function(port:Int, options:TlsConnectOptions, ?callback:Void->Void):TLSSocket {})
 	@:overload(function(port:Int, host:String, ?callback:Void->Void):TLSSocket {})
 	@:overload(function(port:Int, host:String, options:TlsConnectOptions, ?callback:Void->Void):TLSSocket {})
+	@:overload(function(path:String, ?options:TlsConnectOptions, ?callback:Void->Void):TLSSocket {})
 	static function connect(options:TlsConnectOptions, ?callback:Void->Void):TLSSocket;
 
 	/**
@@ -260,5 +327,6 @@ extern class Tls {
 		Generally the encrypted one is piped to/from an incoming encrypted data stream,
 		and the cleartext one is used as a replacement for the initial encrypted stream.
 	**/
+	@:deprecated("Use Tls.TLSSocket instead")
 	static function createSecurePair(?context:SecureContext, ?isServer:Bool, ?requestCert:Bool, ?rejectUnauthorized:Bool):SecurePair;
 }

--- a/src/js/node/dgram/Socket.hx
+++ b/src/js/node/dgram/Socket.hx
@@ -22,13 +22,10 @@
 
 package js.node.dgram;
 
+import haxe.extern.EitherType;
 import js.node.events.EventEmitter;
 import js.node.net.Socket.SocketAdress;
-#if haxe4
 import js.lib.Error;
-#else
-import js.Error;
-#end
 
 /**
 	Enumeration of events for the `Socket` object.
@@ -58,6 +55,11 @@ enum abstract SocketEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 		Emitted when an error occurs.
 	**/
 	var Error:SocketEvent<Error->Void> = "error";
+
+	/**
+		Emitted when a socket has been connected with `socket.connect()`.
+	**/
+	var Connect:SocketEvent<Void->Void> = "connect";
 }
 
 /**
@@ -83,7 +85,7 @@ enum abstract SocketType(String) from String to String {
 }
 
 /**
-	Options passed to the Socket consturctor.
+	Options passed to the Socket constructor.
 **/
 typedef SocketOptions = {
 	/**
@@ -96,6 +98,49 @@ typedef SocketOptions = {
 		Defaults to false.
 	**/
 	@:optional var reuseAddr:Bool;
+
+	/**
+		When `true`, enables `SO_REUSEPORT` so multiple processes can bind to the same address/port.
+	**/
+	@:optional var reusePort:Bool;
+
+	/**
+		Used to set the `IPV6_V6ONLY` socket option.
+	**/
+	@:optional var ipv6Only:Bool;
+
+	/**
+		Sets the `SO_RCVBUF` socket value.
+	**/
+	@:optional var recvBufferSize:Int;
+
+	/**
+		Sets the `SO_SNDBUF` socket value.
+	**/
+	@:optional var sendBufferSize:Int;
+
+	/**
+		Custom lookup function. Defaults to `Dns.lookup`.
+	**/
+	@:optional var lookup:String->js.node.Dns.DnsLookupOptions->js.node.Dns.DnsLookupCallbackSingle->Void;
+
+	/**
+		AbortSignal that can be used to close the socket.
+	**/
+	@:optional var signal:js.node.web.AbortSignal;
+
+	/**
+		When `true`, the receive buffer receives a cloned, shared `ArrayBuffer`.
+		Default: `false`.
+		Stability: 1 - Experimental.
+	**/
+	@:optional var receiveBlockList:js.node.net.BlockList;
+
+	/**
+		When `true`, messages to blocked destinations are dropped.
+		Stability: 1 - Experimental.
+	**/
+	@:optional var sendBlockList:js.node.net.BlockList;
 }
 
 /**
@@ -136,7 +181,32 @@ extern class Socket extends EventEmitter<Socket> {
 		to reuse the buf object. Note that DNS lookups delay the time to send for at least one tick.
 		The only way to know for sure that the datagram has been sent is by using a `callback`.
 	**/
+	@:overload(function(msg:EitherType<Buffer, EitherType<String, Array<EitherType<Buffer, String>>>>, ?callback:Error->Int->Void):Void {})
+	@:overload(function(msg:EitherType<Buffer, EitherType<String, Array<EitherType<Buffer, String>>>>, port:Int, ?callback:Error->Int->Void):Void {})
+	@:overload(function(msg:EitherType<Buffer, EitherType<String, Array<EitherType<Buffer, String>>>>, port:Int, address:String,
+		?callback:Error->Int->Void):Void {})
+	@:overload(function(msg:Buffer, offset:Int, length:Int, ?callback:Error->Int->Void):Void {})
+	@:overload(function(msg:Buffer, offset:Int, length:Int, port:Int, ?callback:Error->Int->Void):Void {})
 	function send(buf:Buffer, offset:Int, length:Int, port:Int, address:String, ?callback:Error->Int->Void):Void;
+
+	/**
+		Associates the `dgram.Socket` to a remote address and port. Subsequent messages will be sent to that
+		destination. Calling `connect()` on an already-connected socket regenerates an `ERR_SOCKET_DGRAM_IS_CONNECTED` error.
+	**/
+	@:overload(function(port:Int, callback:Void->Void):Void {})
+	@:overload(function(port:Int, address:String, ?callback:Void->Void):Void {})
+	function connect(port:Int, ?callback:Void->Void):Void;
+
+	/**
+		A synchronous function that disassociates a connected `dgram.Socket` from its remote address.
+	**/
+	function disconnect():Void;
+
+	/**
+		Returns an object containing the `address`, `family`, and `port` of the remote endpoint.
+		Throws `ERR_SOCKET_DGRAM_NOT_CONNECTED` if the socket is not connected.
+	**/
+	function remoteAddress():SocketAdress;
 
 	/**
 		Listen for datagrams on a named `port` and optional `address`.
@@ -214,6 +284,51 @@ extern class Socket extends EventEmitter<Socket> {
 		If `multicastInterface` is not specified, the OS will try to drop membership to all valid interfaces.
 	**/
 	function dropMembership(multicastAddress:String, ?multicastInterface:String):Void;
+
+	/**
+		Instructs the kernel to join a source-specific multicast channel with the `IP_ADD_SOURCE_MEMBERSHIP` socket option.
+	**/
+	function addSourceSpecificMembership(sourceAddress:String, groupAddress:String, ?multicastInterface:String):Void;
+
+	/**
+		Instructs the kernel to leave a source-specific multicast channel with the `IP_DROP_SOURCE_MEMBERSHIP` socket option.
+	**/
+	function dropSourceSpecificMembership(sourceAddress:String, groupAddress:String, ?multicastInterface:String):Void;
+
+	/**
+		Sets the default outgoing multicast interface of the socket to a chosen interface or back to system interface selection.
+	**/
+	function setMulticastInterface(multicastInterface:String):Void;
+
+	/**
+		Sets the `SO_RCVBUF` socket option.
+	**/
+	function setRecvBufferSize(size:Int):Void;
+
+	/**
+		Sets the `SO_SNDBUF` socket option.
+	**/
+	function setSendBufferSize(size:Int):Void;
+
+	/**
+		Gets the current value of the `SO_RCVBUF` socket option.
+	**/
+	function getRecvBufferSize():Int;
+
+	/**
+		Gets the current value of the `SO_SNDBUF` socket option.
+	**/
+	function getSendBufferSize():Int;
+
+	/**
+		Number of bytes queued for sending.
+	**/
+	function getSendQueueSize():Int;
+
+	/**
+		Number of send requests currently in the queue awaiting to be processed.
+	**/
+	function getSendQueueCount():Int;
 
 	/**
 		Calling `unref` on a socket will allow the program to exit if this is the only active socket in the event system.

--- a/src/js/node/dns/PromisesResolver.hx
+++ b/src/js/node/dns/PromisesResolver.hx
@@ -24,11 +24,7 @@ package js.node.dns;
 
 import haxe.extern.EitherType;
 import js.node.Dns;
-#if haxe4
 import js.lib.Promise;
-#else
-import js.Promise;
-#end
 
 /**
 	Promise-based independent resolver for DNS requests (`dns/promises.Resolver`).

--- a/src/js/node/http/Agent.hx
+++ b/src/js/node/http/Agent.hx
@@ -24,11 +24,7 @@ package js.node.http;
 
 import haxe.DynamicAccess;
 import js.node.net.Socket;
-#if haxe4
 import js.lib.Error;
-#else
-import js.Error;
-#end
 
 /**
 	An `Agent` is responsible for managing connection persistence and reuse for HTTP clients.
@@ -76,11 +72,7 @@ extern class Agent {
 
 		`callback` has a signature of `(err, stream)`.
 	**/
-	#if haxe4
 	function createConnection(options:SocketConnectOptionsTcp, ?callback:(err:Error, stream:Socket) -> Void):Socket;
-	#else
-	function createConnection(options:SocketConnectOptionsTcp, ?callback:Error->Socket->Void):Socket;
-	#end
 
 	/**
 		Called when `socket` is detached from a request and could be persisted by the `Agent`.
@@ -130,6 +122,12 @@ extern class Agent {
 		Determines how many concurrent sockets the agent can have open per origin. Origin is the returned value of `getName()`.
 	**/
 	var maxSockets:Float;
+
+	/**
+		By default set to `Infinity`.
+		Determines how many concurrent sockets the agent can have open across all hosts in total.
+	**/
+	var maxTotalSockets:Float;
 
 	/**
 		An object which contains queues of requests that have not yet been assigned to sockets.
@@ -183,7 +181,17 @@ typedef HttpAgentOptions = {
 	@:optional var maxFreeSockets:Int;
 
 	/**
+		Maximum total number of sockets allowed across all hosts. Default: `Infinity`.
+	**/
+	@:optional var maxTotalSockets:Int;
+
+	/**
 		Socket timeout in milliseconds. This will set the timeout when the socket is created.
 	**/
 	@:optional var timeout:Int;
+
+	/**
+		Scheduling strategy when picking an idle socket. One of `'fifo'` or `'lifo'`. Default: `'lifo'`.
+	**/
+	@:optional var scheduling:String;
 }

--- a/src/js/node/http/ClientRequest.hx
+++ b/src/js/node/http/ClientRequest.hx
@@ -39,14 +39,20 @@ enum abstract ClientRequestEvent<T:haxe.Constraints.Function>(Event<T>) to Event
 	var Abort:ClientRequestEvent<Void->Void> = "abort";
 
 	/**
+		Emitted when the request has been closed / completed.
+	**/
+	var Close:ClientRequestEvent<Void->Void> = "close";
+
+	/**
+		Emitted when the request has been sent / finished writing.
+	**/
+	var Finish:ClientRequestEvent<Void->Void> = "finish";
+
+	/**
 		Emitted each time a server responds to a request with a `CONNECT` method.
 		If this event is not being listened for, clients receiving a `CONNECT` method will have their connections closed.
 	**/
-	#if haxe4
 	var Connect:ClientRequestEvent<(response:IncomingMessage, socket:Socket, head:Buffer) -> Void> = "connect";
-	#else
-	var Connect:ClientRequestEvent<IncomingMessage->Socket->Buffer->Void> = "connect";
-	#end
 
 	/**
 		Emitted when the server sends a '100 Continue' HTTP response,
@@ -85,12 +91,8 @@ enum abstract ClientRequestEvent<T:haxe.Constraints.Function>(Event<T>) to Event
 		If this event is not being listened for and the response status code is 101 Switching Protocols,
 		clients receiving an upgrade header will have their connections closed.
 	**/
-	#if haxe4
 	var Upgrade:ClientRequestEvent<(response:IncomingMessage, socket:Socket, head:Buffer) -> Void> = "upgrade";
-	#else
-	var Upgrade:ClientRequestEvent<IncomingMessage->Socket->Buffer->Void> = "upgrade";
-	#end
-}
+	}
 
 /**
 	This object is created internally and returned from http.request().
@@ -156,6 +158,27 @@ extern class ClientRequest extends Writable<ClientRequest> {
 	function getHeader(name:String):haxe.extern.EitherType<String, Array<String>>;
 
 	/**
+		Returns an array containing the unique names of the current outgoing headers.
+	**/
+	function getHeaderNames():Array<String>;
+
+	/**
+		Returns a shallow copy of the current outgoing headers.
+	**/
+	function getHeaders():DynamicAccess<haxe.extern.EitherType<String, Array<String>>>;
+
+	/**
+		Returns an array containing the unique names of the current outgoing raw headers.
+		Header names are returned with their exact casing.
+	**/
+	function getRawHeaderNames():Array<String>;
+
+	/**
+		Returns `true` if the header identified by `name` is currently set in the outgoing headers.
+	**/
+	function hasHeader(name:String):Bool;
+
+	/**
 		Limits maximum response headers count. If set to 0, no limit will be applied.
 
 		Default: `2000`
@@ -165,7 +188,27 @@ extern class ClientRequest extends Writable<ClientRequest> {
 	/**
 		The request path.
 	**/
-	var path(default, null):String;
+	var path:String;
+
+	/**
+		The HTTP request method.
+	**/
+	var method:Method;
+
+	/**
+		The request host header value.
+	**/
+	var host(default, null):String;
+
+	/**
+		The request protocol (`http:` / `https:`).
+	**/
+	var protocol(default, null):String;
+
+	/**
+		Whether the request reused an existing socket.
+	**/
+	var reusedSocket(default, null):Bool;
 
 	/**
 		Removes a header that's already defined into headers object.
@@ -181,6 +224,22 @@ extern class ClientRequest extends Writable<ClientRequest> {
 	**/
 	@:overload(function(name:String, value:Array<String>):Void {})
 	function setHeader(name:String, value:String):Void;
+
+	/**
+		Append a single header value for the header object.
+
+		@see https://nodejs.org/api/http.html#outgoingmessageappendheadername-value
+	**/
+	@:overload(function(name:String, value:Array<String>):ClientRequest {})
+	function appendHeader(name:String, value:String):ClientRequest;
+
+	/**
+		Sets multiple header values for implicit headers.
+
+		@see https://nodejs.org/api/http.html#outgoingmessagesetheadersheaders
+	**/
+	@:overload(function(headers:DynamicAccess<haxe.extern.EitherType<String, Array<String>>>):Void {})
+	function setHeaders(headers:js.node.web.Headers):Void;
 
 	/**
 		Once a socket is assigned to this request and is connected

--- a/src/js/node/http/IncomingMessage.hx
+++ b/src/js/node/http/IncomingMessage.hx
@@ -26,11 +26,7 @@ import haxe.DynamicAccess;
 import js.node.events.EventEmitter.Event;
 import js.node.net.Socket;
 import js.node.stream.Readable;
-#if haxe4
 import js.lib.Error;
-#else
-import js.Error;
-#end
 
 /**
 	Enumeration of events emitted by the `IncomingMessage` objects in addition to its parent class events.
@@ -85,6 +81,11 @@ extern class IncomingMessage extends Readable<IncomingMessage> {
 		- For all other headers, the values are joined together with ', '.
 	**/
 	var headers(default, null):DynamicAccess<haxe.extern.EitherType<String, Array<String>>>;
+
+	/**
+		Similar to `headers`, but with header values as arrays of values, without joining.
+	**/
+	var headersDistinct(default, null):DynamicAccess<Array<String>>;
 
 	/**
 		In case of server request, the HTTP version sent by the client.
@@ -161,6 +162,11 @@ extern class IncomingMessage extends Readable<IncomingMessage> {
 		Only populated after the `'end'` event.
 	**/
 	var trailers(default, null):DynamicAccess<String>;
+
+	/**
+		Similar to `trailers`, but with values as arrays of strings.
+	**/
+	var trailersDistinct(default, null):DynamicAccess<Array<String>>;
 
 	/**
 		*Only valid for request obtained from* `Server`.

--- a/src/js/node/http/OutgoingMessage.hx
+++ b/src/js/node/http/OutgoingMessage.hx
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.http;
+
+import haxe.DynamicAccess;
+import haxe.extern.EitherType;
+import js.node.net.Socket;
+import js.node.stream.Writable;
+import js.node.web.Headers;
+
+/**
+	This class serves as the parent class of `http.ClientRequest` and `http.ServerResponse`.
+	It is an abstract outgoing message from the perspective of the participants of an HTTP transaction.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/http.html#class-httpoutgoingmessage
+**/
+@:jsRequire("http", "OutgoingMessage")
+extern class OutgoingMessage extends Writable<OutgoingMessage> {
+	/**
+		Append a single header value for the header object.
+
+		If the value is an array, this is equivalent to calling this method multiple times.
+	**/
+	@:overload(function(name:String, value:Array<String>):OutgoingMessage {})
+	function appendHeader(name:String, value:String):OutgoingMessage;
+
+	/**
+		Flushes the message headers.
+	**/
+	function flushHeaders():Void;
+
+	/**
+		Reads out a header that's already been queued but not sent.
+		The name is case-insensitive.
+	**/
+	function getHeader(name:String):EitherType<String, Array<String>>;
+
+	/**
+		Returns an array containing the unique names of the current outgoing headers.
+		All header names are lowercase.
+	**/
+	function getHeaderNames():Array<String>;
+
+	/**
+		Returns a shallow copy of the current outgoing headers.
+	**/
+	function getHeaders():DynamicAccess<EitherType<String, Array<String>>>;
+
+	/**
+		Returns an array containing the unique names of the current outgoing raw headers.
+		Header names are returned with their exact casing being set.
+	**/
+	function getRawHeaderNames():Array<String>;
+
+	/**
+		Returns `true` if the header identified by `name` is currently set in the outgoing headers.
+	**/
+	function hasHeader(name:String):Bool;
+
+	/**
+		Boolean (read-only). `true` if headers were sent, otherwise `false`.
+	**/
+	var headersSent(default, null):Bool;
+
+	/**
+		Removes a header that's queued for implicit sending.
+	**/
+	function removeHeader(name:String):Void;
+
+	/**
+		Sets a single header value. If the header already exists in the to-be-sent headers, its value will be replaced.
+	**/
+	@:overload(function(name:String, value:Array<String>):Void {})
+	function setHeader(name:String, value:String):Void;
+
+	/**
+		Sets multiple header values for implicit headers.
+
+		`headers` must be an instance of `Headers` or a key/value map-like object.
+	**/
+	@:overload(function(headers:DynamicAccess<EitherType<String, Array<String>>>):Void {})
+	function setHeaders(headers:Headers):Void;
+
+	/**
+		Once a socket is associated with the message and is connected,
+		`socket.setTimeout()` will be called with `msecs` as the first parameter.
+	**/
+	function setTimeout(msecs:Int, ?callback:Void->Void):OutgoingMessage;
+
+	/**
+		Reference to the underlying socket.
+	**/
+	var socket(default, null):Socket;
+
+	/**
+		Alias of `socket`.
+	**/
+	var connection(default, null):Socket;
+}

--- a/src/js/node/http/Server.hx
+++ b/src/js/node/http/Server.hx
@@ -25,11 +25,7 @@ package js.node.http;
 import js.node.Buffer;
 import js.node.events.EventEmitter.Event;
 import js.node.net.Socket;
-#if haxe4
 import js.lib.Error;
-#else
-import js.Error;
-#end
 
 /**
 	Enumeration of events emitted by `http.Server` class in addition to
@@ -46,11 +42,7 @@ enum abstract ServerEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 
 		When this event is emitted and handled, the 'request' event will not be emitted.
 	**/
-	#if haxe4
 	var CheckContinue:ServerEvent<(request:IncomingMessage, response:ServerResponse) -> Void> = "checkContinue";
-	#else
-	var CheckContinue:ServerEvent<IncomingMessage->ServerResponse->Void> = "checkContinue";
-	#end
 
 	/**
 		Emitted each time a request with an HTTP `Expect` header is received, where the value is not `100-continue`.
@@ -58,11 +50,7 @@ enum abstract ServerEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 
 		When this event is emitted and handled, the `'request'` event will not be emitted.
 	**/
-	#if haxe4
 	var CheckExpectation:ServerEvent<(request:IncomingMessage, response:ServerResponse) -> Void> = "checkExpectation";
-	#else
-	var CheckExpectation:ServerEvent<IncomingMessage->ServerResponse->Void> = "checkExpectation";
-	#end
 
 	/**
 		If a client connection emits an `'error'` event, it will be forwarded here.
@@ -72,11 +60,7 @@ enum abstract ServerEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 		Default behavior is to try close the socket with a HTTP '400 Bad Request', or a HTTP '431 Request Header Fields Too Large'
 		in the case of a `HPE_HEADER_OVERFLOW` error. If the socket is not writable it is immediately destroyed.
 	**/
-	#if haxe4
 	var ClientError:ServerEvent<(exception:Error, socket:Socket) -> Void> = "clientError";
-	#else
-	var ClientError:ServerEvent<Error->Socket->Void> = "clientError";
-	#end
 
 	/**
 		Emitted when the server closes.
@@ -90,11 +74,7 @@ enum abstract ServerEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 		After this event is emitted, the request's socket will not have a `'data'` event listener,
 		meaning it will need to be bound in order to handle data sent to the server on that socket.
 	**/
-	#if haxe4
 	var Connect:ServerEvent<(request:IncomingMessage, socekt:Socket, head:Buffer) -> Void> = "connect";
-	#else
-	var Connect:ServerEvent<IncomingMessage->Socket->Buffer->Void> = "connect";
-	#end
 
 	/**
 		This event is emitted when a new TCP stream is established.
@@ -114,11 +94,7 @@ enum abstract ServerEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 		Emitted each time there is a request.
 		There may be multiple requests per connection (in the case of HTTP Keep-Alive connections).
 	**/
-	#if haxe4
 	var Request:ServerEvent<(request:IncomingMessage, response:ServerResponse) -> Void> = "request";
-	#else
-	var Request:ServerEvent<IncomingMessage->ServerResponse->Void> = "request";
-	#end
 
 	/**
 		Emitted each time a client requests an HTTP upgrade.
@@ -127,11 +103,14 @@ enum abstract ServerEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 		After this event is emitted, the request's socket will not have a `'data'` event listener,
 		meaning it will need to be bound in order to handle data sent to the server on that socket.
 	**/
-	#if haxe4
 	var Upgrade:ServerEvent<(request:IncomingMessage, socket:Socket, buffer:Buffer) -> Void> = "upgrade";
-	#else
-	var Upgrade:ServerEvent<IncomingMessage->Socket->Buffer->Void> = "upgrade";
-	#end
+
+	/**
+		Emitted when a request could not be completed due to exceeding `server.maxRequestsPerSocket`.
+
+		@see https://nodejs.org/api/http.html#event-droprequest
+	**/
+	var DropRequest:ServerEvent<(request:IncomingMessage, socket:Socket) -> Void> = "dropRequest";
 }
 
 /**
@@ -155,11 +134,23 @@ extern class Server extends js.node.net.Server {
 	var headersTimeout:Int;
 
 	/**
+		Sets the timeout value in milliseconds for receiving the entire request from the client.
+		Default: `300000`.
+	**/
+	var requestTimeout:Int;
+
+	/**
 		Limits maximum incoming headers count. If set to 0, no limit will be applied.
 
 		Default: `2000`
 	**/
 	var maxHeadersCount:Null<Int>;
+
+	/**
+		The maximum number of requests socket can handle before closing keep alive connection.
+		Default: `0` (no limit).
+	**/
+	var maxRequestsPerSocket:Int;
 
 	/**
 		Sets the timeout value for sockets, and emits a `'timeout'` event on the Server object,
@@ -172,6 +163,7 @@ extern class Server extends js.node.net.Server {
 
 		To change the default timeout use the `--http-server-default-timeout` flag.
 	**/
+	@:overload(function(?callback:js.node.net.Socket->Void):Void {})
 	function setTimeout(msecs:Int, ?callback:js.node.net.Socket->Void):Void;
 
 	/**
@@ -201,4 +193,20 @@ extern class Server extends js.node.net.Server {
 		Default: `5000` (5 seconds).
 	**/
 	var keepAliveTimeout:Int;
+
+	/**
+		Additional buffer of inactivity after `keepAliveTimeout` before destroying a keep-alive socket.
+		Default: `1000`.
+	**/
+	var keepAliveTimeoutBuffer:Int;
+
+	/**
+		Closes all connections connected to this server.
+	**/
+	function closeAllConnections():Void;
+
+	/**
+		Closes all connections connected to this server which are not sending a request or waiting for a response.
+	**/
+	function closeIdleConnections():Void;
 }

--- a/src/js/node/http/ServerResponse.hx
+++ b/src/js/node/http/ServerResponse.hx
@@ -125,6 +125,17 @@ extern class ServerResponse extends Writable<ServerResponse> {
 	var sendDate:Bool;
 
 	/**
+		A reference to the original HTTP `request` object.
+	**/
+	var req(default, null):IncomingMessage;
+
+	/**
+		If set to `true`, Node.js checks that `Content-Length` and the length of the body being transmitted are equal.
+		Default: `false`.
+	**/
+	var strictContentLength:Bool;
+
+	/**
 		Sets a single header value for implicit headers.
 		If this header already exists in the to-be-sent headers, its value will be replaced.
 		Use an array of strings here to send multiple headers with the same name.
@@ -134,6 +145,27 @@ extern class ServerResponse extends Writable<ServerResponse> {
 	**/
 	@:overload(function(name:String, value:Array<String>):Void {})
 	function setHeader(name:String, value:String):Void;
+
+	/**
+		Append a single header value to the header object.
+
+		@see https://nodejs.org/api/http.html#outgoingmessageappendheadername-value
+	**/
+	@:overload(function(name:String, value:Array<String>):ServerResponse {})
+	function appendHeader(name:String, value:String):ServerResponse;
+
+	/**
+		Sets multiple header values for implicit headers.
+
+		@see https://nodejs.org/api/http.html#outgoingmessagesetheadersheaders
+	**/
+	@:overload(function(headers:DynamicAccess<haxe.extern.EitherType<String, Array<String>>>):Void {})
+	function setHeaders(headers:js.node.web.Headers):Void;
+
+	/**
+		Returns an array containing the unique names of the current outgoing raw headers.
+	**/
+	function getRawHeaderNames():Array<String>;
 
 	/**
 		Sets the Socket's timeout value to `msecs`.
@@ -173,6 +205,21 @@ extern class ServerResponse extends Writable<ServerResponse> {
 		See the `'checkContinue'` event on `Server`.
 	 */
 	function writeContinue():Void;
+
+	/**
+		Sends an HTTP/1.1 103 Early Hints message to the client with a Link header,
+		used to allow the user agent to preload/preconnect to resources while the full response is prepared.
+
+		@see https://nodejs.org/api/http.html#responsewriteearlyhintshints-callback
+	**/
+	function writeEarlyHints(hints:DynamicAccess<haxe.extern.EitherType<String, Array<String>>>, ?callback:Void->Void):Void;
+
+	/**
+		Sends an informational 1xx response to the client.
+
+		@see https://nodejs.org/api/http.html#responsewriteinformationstatuscode-headers-callback
+	**/
+	function writeInformation(statusCode:Int, ?headers:DynamicAccess<String>, ?callback:Void->Void):Void;
 
 	/**
 		Sends a response header to the request.

--- a/src/js/node/http2/Http2Stream.hx
+++ b/src/js/node/http2/Http2Stream.hx
@@ -145,9 +145,11 @@ extern class Http2Stream extends Duplex<Http2Stream> {
 
 	/**
 		Priority signaling is no longer supported in Node.js.
+
+		// TODO(section-3): remove once callers migrate off deprecated stream.priority
 	**/
 	@:deprecated("Priority signaling is no longer supported in Node.js")
-	function priority(options:Dynamic):Void;
+	function priority(options:Any):Void;
 
 	/**
 		Sets the stream timeout value.

--- a/src/js/node/net/BlockList.hx
+++ b/src/js/node/net/BlockList.hx
@@ -37,7 +37,7 @@ extern class BlockList {
 
 		@see https://nodejs.org/api/net.html#blocklistisblocklistvalue
 	**/
-	static function isBlockList(value:Dynamic):Bool;
+	static function isBlockList(value:Any):Bool;
 
 	/**
 		Adds a rule to block the given IP address.

--- a/src/js/node/net/Server.hx
+++ b/src/js/node/net/Server.hx
@@ -25,11 +25,7 @@ package js.node.net;
 import haxe.extern.EitherType;
 import js.node.events.EventEmitter;
 import js.node.net.Socket.SocketAdress;
-#if haxe4
 import js.lib.Error;
-#else
-import js.Error;
-#end
 
 /**
 	Enumeration of events emitted by the `Server` objects
@@ -56,6 +52,13 @@ enum abstract ServerEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 		The 'close' event will be called directly following this event. See example in discussion of server.listen.
 	**/
 	var Error:ServerEvent<Error->Void> = "error";
+
+	/**
+		Emitted when a connection is dropped because of `maxConnections` being reached.
+
+		@see https://nodejs.org/api/net.html#event-drop
+	**/
+	var Drop:ServerEvent<Null<Socket>->Void> = "drop";
 }
 
 private typedef ServerListenOptionsBase = {
@@ -107,7 +110,7 @@ extern class Server extends EventEmitter<Server> {
 		The last parameter `callback` will be added as an listener for the 'listening' event.
 	**/
 	@:overload(function(path:String, ?callback:Void->Void):Void {})
-	@:overload(function(handle:EitherType<Dynamic, {fd:Int}>, ?callback:Void->Void):Void {})
+	@:overload(function(handle:EitherType<Server, EitherType<Socket, {fd:Int}>>, ?callback:Void->Void):Void {})
 	@:overload(function(port:Int, ?callback:Void->Void):Void {})
 	@:overload(function(port:Int, backlog:Int, ?callback:Void->Void):Void {})
 	@:overload(function(port:Int, hostname:String, ?callback:Void->Void):Void {})
@@ -155,6 +158,14 @@ extern class Server extends EventEmitter<Server> {
 		It is not recommended to use this option once a socket has been sent to a child with child_process.fork().
 	**/
 	var maxConnections:Int;
+
+	/**
+		If `true`, when the connection count reaches `maxConnections`, Node.js drops the connection
+		instead of handing it to another cluster worker.
+
+		@see https://nodejs.org/api/net.html#serverdropmaxconnection
+	**/
+	var dropMaxConnection:Bool;
 
 	/**
 		The number of concurrent connections on the server.

--- a/src/js/node/net/Socket.hx
+++ b/src/js/node/net/Socket.hx
@@ -25,11 +25,7 @@ package js.node.net;
 import haxe.extern.EitherType;
 import js.node.Dns;
 import js.node.events.EventEmitter.Event;
-#if haxe4
 import js.lib.Error;
-#else
-import js.Error;
-#end
 
 /**
 	Enumeration of events for `Socket` objects.
@@ -92,6 +88,37 @@ enum abstract SocketEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 			had_error - true if the socket had a transmission error
 	**/
 	var Close:SocketEvent<Bool->Void> = "close";
+
+	/**
+		Emitted when a socket is ready to be used.
+
+		Triggered immediately after `'connect'`.
+	**/
+	var Ready:SocketEvent<Void->Void> = "ready";
+
+	/**
+		Emitted when a new connection attempt is started.
+		Only emitted for family-agnostic (`family: 0` / autoSelectFamily) connects.
+
+		@see https://nodejs.org/api/net.html#event-connectionattempt
+	**/
+	var ConnectionAttempt:SocketEvent<(ip:String, port:Int, family:Int) -> Void> = "connectionAttempt";
+
+	/**
+		Emitted when a connection attempt fails.
+		Only emitted for family-agnostic connects.
+
+		@see https://nodejs.org/api/net.html#event-connectionattemptfailed
+	**/
+	var ConnectionAttemptFailed:SocketEvent<(ip:String, port:Int, family:Int, error:Error) -> Void> = "connectionAttemptFailed";
+
+	/**
+		Emitted when a connection attempt times out.
+		Only emitted for family-agnostic connects.
+
+		@see https://nodejs.org/api/net.html#event-connectionattempttimeout
+	**/
+	var ConnectionAttemptTimeout:SocketEvent<(ip:String, port:Int, family:Int) -> Void> = "connectionAttemptTimeout";
 }
 
 typedef SocketOptionsBase = {
@@ -127,6 +154,25 @@ typedef SocketOptions = {
 		allow writes on this socket (NOTE: Works only when `fd` is passed)
 	**/
 	@:optional var writable:Bool;
+
+	/**
+		If set to `false`, then the socket will automatically end the stream when the other end of the socket sends a FIN packet.
+		See `allowHalfOpen` for more information. Default: `false`.
+	**/
+	@:optional var onread:SocketOnReadOptions;
+
+	/**
+		AbortSignal used to abort an ongoing connect / read.
+	**/
+	@:optional var signal:js.node.web.AbortSignal;
+}
+
+/**
+	Optional `onread` callback options for `Socket`.
+**/
+typedef SocketOnReadOptions = {
+	var buffer:EitherType<js.node.Buffer, () -> js.node.Buffer>;
+	var callback:(bytesWritten:Int, buffer:js.node.Buffer) -> Bool;
 }
 
 /**
@@ -156,6 +202,7 @@ typedef SocketConnectOptionsTcp = {
 
 	/**
 		Version of IP stack. Defaults to 4.
+		Use `0` for dual-stack / auto family selection.
 	**/
 	@:optional var family:DnsAddressFamily;
 
@@ -163,6 +210,46 @@ typedef SocketConnectOptionsTcp = {
 		Custom lookup function. Defaults to `Dns.lookup`.
 	**/
 	@:optional var lookup:String->DnsLookupOptions->DnsLookupCallbackSingle->Void;
+
+	/**
+		Optional dns.lookup() hints.
+	**/
+	@:optional var hints:Int;
+
+	/**
+		If true, connecting sockets enable TCP keep-alive (SO_KEEPALIVE).
+	**/
+	@:optional var keepAlive:Bool;
+
+	/**
+		Initial TCP keep-alive delay in milliseconds, when `keepAlive` is enabled.
+	**/
+	@:optional var keepAliveInitialDelay:Int;
+
+	/**
+		If set to `true`, disables the Nagle algorithm.
+	**/
+	@:optional var noDelay:Bool;
+
+	/**
+		If set to `true`, enables TCP_KEEPALIVE on the connection.
+	**/
+	@:optional var autoSelectFamily:Bool;
+
+	/**
+		Timeout in milliseconds for autoSelectFamily connection attempts.
+	**/
+	@:optional var autoSelectFamilyAttemptTimeout:Int;
+
+	/**
+		Connection timeout in milliseconds. Defaults to no timeout.
+	**/
+	@:optional var timeout:Int;
+
+	/**
+		AbortSignal used to abort an ongoing connect.
+	**/
+	@:optional var signal:js.node.web.AbortSignal;
 }
 
 /**
@@ -173,6 +260,21 @@ typedef SocketConnectOptionsUnix = {
 		Path the client should connect to
 	**/
 	var path:String;
+
+	/**
+		AbortSignal used to abort an ongoing connect.
+	**/
+	@:optional var signal:js.node.web.AbortSignal;
+}
+
+/**
+	Possible values of `socket.readyState`.
+**/
+enum abstract SocketReadyState(String) from String to String {
+	var Opening = "opening";
+	var Open = "open";
+	var ReadOnly = "readOnly";
+	var WriteOnly = "writeOnly";
 }
 
 /**
@@ -254,7 +356,6 @@ extern class Socket extends js.node.stream.Duplex<Socket> {
 	**/
 	// var destroyed(default, null):Bool;
 
-	#if haxe4
 	/**
 		Ensures that no more I/O activity happens on this socket.
 		Only necessary in case of errors (parse error or so).
@@ -263,7 +364,18 @@ extern class Socket extends js.node.stream.Duplex<Socket> {
 		any listeners for that event will receive exception as an argument.
 	**/
 	function destroy(?exception:Error):Void;
-	#end
+
+	/**
+		Destroys the socket after all data has been written.
+		If there is remaining data in the write buffer, it will wait until that data has been flushed.
+	**/
+	function destroySoon():Void;
+
+	/**
+		Half-closes the socket by sending a FIN packet, then destroys it upon error / when fully closed.
+		Useful for HTTP/1 agents that need to reset a pooled connection.
+	**/
+	function resetAndDestroy():Socket;
 
 	/**
 		Sets the socket to timeout after `timeout` milliseconds of inactivity on the socket.
@@ -347,6 +459,42 @@ extern class Socket extends js.node.stream.Duplex<Socket> {
 		The numeric representation of the local port. For example, 80 or 21.
 	**/
 	var localPort(default, null):Int;
+
+	/**
+		The string representation of the local IP family. `'IPv4'` or `'IPv6'`.
+	**/
+	var localFamily(default, null):SocketAdressFamily;
+
+	/**
+		This property is only present when using `autoSelectFamily` and represents attempted addresses.
+
+		@see https://nodejs.org/api/net.html#socketautoselectfamilyattemptedaddresses
+	**/
+	var autoSelectFamilyAttemptedAddresses(default, null):Array<String>;
+
+	/**
+		If `true`, `socket.connect(options[, connectListener])` was called and has not yet finished.
+	**/
+	var connecting(default, null):Bool;
+
+	/**
+		This is `true` if the socket is not connected yet, either because `.connect()` has not yet been called
+		or because it is still in the process of connecting (see `connecting`).
+	**/
+	var pending(default, null):Bool;
+
+	/**
+		The socket timeout in milliseconds as set by `socket.setTimeout()`.
+		`undefined` if a timeout has not been set.
+	**/
+	var timeout(default, null):Null<Int>;
+
+	/**
+		This property represents the state of the connection as a string.
+
+		@see https://nodejs.org/api/net.html#socketreadystate
+	**/
+	var readyState(default, null):SocketReadyState;
 
 	/**
 		The amount of received bytes.

--- a/src/js/node/tls/SecureContext.hx
+++ b/src/js/node/tls/SecureContext.hx
@@ -106,6 +106,36 @@ typedef SecureContextOptions = {
 		Default: true.
 	**/
 	@:optional var honorCipherOrder:Bool;
+
+	/**
+		Optionally set the minimum TLS version to allow. One of `'TLSv1.3'`, `'TLSv1.2'`, `'TLSv1.1'`, or `'TLSv1'`.
+	**/
+	@:optional var minVersion:String;
+
+	/**
+		Optionally set the maximum TLS version to allow. One of `'TLSv1.3'`, `'TLSv1.2'`, `'TLSv1.1'`, or `'TLSv1'`.
+	**/
+	@:optional var maxVersion:String;
+
+	/**
+		An array of strings or a Buffer naming possible ALPN protocols.
+	**/
+	@:optional var ALPNProtocols:EitherType<Array<EitherType<String, Buffer>>, Buffer>;
+
+	/**
+		Name of an OpenSSL engine to get private key from.
+	**/
+	@:optional var privateKeyEngine:String;
+
+	/**
+		Identifier of a private key to get from an OpenSSL engine.
+	**/
+	@:optional var privateKeyIdentifier:String;
+
+	/**
+		Colon-separated list of supported signature algorithms.
+	**/
+	@:optional var sigalgs:String;
 }
 
 extern class SecureContext {}

--- a/src/js/node/tls/Server.hx
+++ b/src/js/node/tls/Server.hx
@@ -22,15 +22,13 @@
 
 package js.node.tls;
 
+import haxe.extern.EitherType;
 import js.node.Buffer;
 import js.node.events.EventEmitter.Event;
+import js.node.tls.SecureContext;
 import js.node.tls.SecureContext.SecureContextOptions;
 import js.node.tls.TLSSocket;
-#if haxe4
 import js.lib.Error;
-#else
-import js.Error;
-#end
 
 /**
 	Enumeration of events emitted by `Server` in addition to its parent classes.
@@ -49,7 +47,18 @@ enum abstract ServerEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 			exception - error object
 			securePair - the `TLSSocket` that the error originated from
 	**/
+	var TlsClientError:ServerEvent<(exception:Error, tlsSocket:TLSSocket) -> Void> = "tlsClientError";
+
+	/**
+		@deprecated Use `TlsClientError` (`tlsClientError`) instead.
+	**/
+	@:deprecated("Use ServerEvent.TlsClientError / 'tlsClientError'")
 	var ClientError:ServerEvent<Error->TLSSocket->Void> = "clientError";
+
+	/**
+		Emitted when key material is generated or received from a client for generating TLS session tickets.
+	**/
+	var Keylog:ServerEvent<(line:Buffer, tlsSocket:TLSSocket) -> Void> = "keylog";
 
 	/**
 		Emitted on creation of TLS session.
@@ -62,7 +71,7 @@ enum abstract ServerEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 			sessionData
 			callback
 	**/
-	var NewSession:ServerEvent<Buffer->Buffer->(Void->Void)->Void> = "newSession";
+	var NewSession:ServerEvent<(sessionId:Buffer, sessionData:Buffer, callback:Void->Void) -> Void> = "newSession";
 
 	/**
 		Emitted when client wants to resume previous TLS session.
@@ -78,7 +87,7 @@ enum abstract ServerEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 			sessionId
 			callback
 	**/
-	var ResumeSession:ServerEvent<Buffer->(Error->?Buffer->Void)->Void> = "resumeSession";
+	var ResumeSession:ServerEvent<(sessionId:Buffer, callback:(Null<Error>, Null<Buffer>) -> Void) -> Void> = "resumeSession";
 
 	/**
 		Emitted when the client sends a certificate status request.
@@ -91,7 +100,7 @@ enum abstract ServerEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 
 		Calling `callback(err)` will result in a `socket.destroy(err)` call.
 	**/
-	var OCSPRequest:ServerEvent<Buffer->Buffer->(Error->?Buffer->Void)->Void> = "OCSPRequest";
+	var OCSPRequest:ServerEvent<(certificate:Buffer, issuer:Buffer, callback:(Null<Error>, Null<Buffer>) -> Void) -> Void> = "OCSPRequest";
 }
 
 /**
@@ -120,5 +129,11 @@ extern class Server extends js.node.net.Server {
 		Add secure context that will be used if client request's SNI hostname
 		is matching passed hostname (wildcards can be used).
 	**/
-	function addContext(hostname:String, credentials:SecureContextOptions):Void;
+	function addContext(hostname:String, credentials:EitherType<SecureContext, SecureContextOptions>):Void;
+
+	/**
+		The `server.setSecureContext()` method replaces the secure context of an existing server.
+		Existing connections to the server are not interrupted.
+	**/
+	function setSecureContext(options:SecureContextOptions):Void;
 }

--- a/src/js/node/tls/TLSSocket.hx
+++ b/src/js/node/tls/TLSSocket.hx
@@ -23,15 +23,13 @@
 package js.node.tls;
 
 import haxe.Constraints.Function;
+import haxe.extern.EitherType;
 import js.node.Buffer;
 import js.node.Tls.TlsClientOptionsBase;
 import js.node.Tls.TlsServerOptionsBase;
 import js.node.events.EventEmitter.Event;
-#if haxe4
+import js.node.tls.SecureContext.SecureContextOptions;
 import js.lib.Error;
-#else
-import js.Error;
-#end
 
 /**
 	Enumeration of events emitted by `TLSSocket` objects in addition to its parent class events.
@@ -50,6 +48,11 @@ enum abstract TLSSocketEvent<T:Function>(Event<T>) to Event<T> {
 	var SecureConnect:TLSSocketEvent<Void->Void> = "secureConnect";
 
 	/**
+		Emitted once when the connection is established and the handshake completes (server-side companion of secureConnect).
+	**/
+	var Secure:TLSSocketEvent<Void->Void> = "secure";
+
+	/**
 		This event will be emitted if `requestOCSP` option was set.
 
 		`response` is a `Buffer` object, containing server's OCSP response.
@@ -58,6 +61,16 @@ enum abstract TLSSocketEvent<T:Function>(Event<T>) to Event<T> {
 		that contains information about server's certificate revocation status.
 	**/
 	var OCSPResponse:TLSSocketEvent<Buffer->Void> = "OCSPResponse";
+
+	/**
+		Emitted when key material is generated / received for the purpose of generating a TLS session ticket.
+	**/
+	var Keylog:TLSSocketEvent<Buffer->Void> = "keylog";
+
+	/**
+		Emitted on session establishment / update with the TLS session `Buffer`.
+	**/
+	var Session:TLSSocketEvent<Null<Buffer>->Void> = "session";
 }
 
 typedef TLSSocketOptions = {
@@ -103,9 +116,18 @@ extern class TLSSocket extends js.node.net.Socket {
 	var authorizationError(default, null):Null<String>;
 
 	/**
-		Negotiated protocol name.
+		Negotiated protocol name via NPN.
+
+		@deprecated Use `alpnProtocol` instead.
 	**/
+	@:deprecated("Use alpnProtocol instead")
 	var npnProtocol(default, null):String;
+
+	/**
+		String containing the selected ALPN protocol. When ALPN has no selected protocol, this is
+		the empty string. When ALPN has not been negotiated / disabled, this is `false`.
+	**/
+	var alpnProtocol(default, null):EitherType<String, Bool>;
 
 	/**
 		Returns an object representing the peer's certificate.
@@ -114,7 +136,12 @@ extern class TLSSocket extends js.node.net.Socket {
 		If `detailed` argument is true - the full chain with issuer property will be returned,
 		if false - only the top certificate without issuer property.
 	**/
-	function getPeerCertificate(?detailed:Bool):Dynamic; // TODO: is there a well defined structure for this?
+	function getPeerCertificate(?detailed:Bool):js.node.Tls.PeerCertificate;
+
+	/**
+		Returns the local certificate as an object.
+	**/
+	function getCertificate():Null<js.node.Tls.PeerCertificate>;
 
 	/**
 		Returns an object representing the cipher name and the SSL/TLS protocol version of the current connection.
@@ -123,7 +150,69 @@ extern class TLSSocket extends js.node.net.Socket {
 
 		See SSL_CIPHER_get_name() and SSL_CIPHER_get_version() in http://www.openssl.org/docs/ssl/ssl.html#DEALING_WITH_CIPHERS for more information.
 	**/
-	function getCipher():{name:String, version:String};
+	function getCipher():{name:String, standardName:String, version:String};
+
+	/**
+		Returns an object representing the type, name, and size of parameter of an ephemeral key exchange
+		in Perfect Forward Secrecy on a client connection. Returns empty object when key exchange is not ephemeral.
+	**/
+	function getEphemeralKeyInfo():Null<{type:String, name:String, size:Int}>;
+
+	/**
+		As the `Finished` messages are message digests of the complete handshake
+		(with a total of 192 bits for TLS 1.0 and more for SSL 3.0), they can
+		be used for external authentication procedures when the authentication provided by SSL/TLS is not desired or is not enough.
+	**/
+	function getFinished():Null<Buffer>;
+
+	/**
+		Returns the latest `Finished` message received from the peer as a `Buffer`.
+	**/
+	function getPeerFinished():Null<Buffer>;
+
+	/**
+		Returns a list of signature algorithms shared between the server and the client in order of decreasing preference.
+	**/
+	function getSharedSigalgs():Array<String>;
+
+	/**
+		Returns `true` if the session was reused, `false` otherwise.
+	**/
+	function isSessionReused():Bool;
+
+	/**
+		Disables TLS renegotiation for this `TLSSocket` instance.
+	**/
+	function disableRenegotiation():Void;
+
+	/**
+		Enables TLS trace data for debugging.
+	**/
+	function enableTrace():Void;
+
+	/**
+		Keying material is used for validations for secure channel integrity and confidentially.
+	**/
+	function exportKeyingMaterial(length:Int, label:String, ?context:Buffer):Buffer;
+
+	/**
+		See `Socket.setKeyCert` / set credentials for the socket when using tickets for session resumption or for delayed certificate availability.
+	**/
+	function setKeyCert(context:EitherType<SecureContext, SecureContextOptions>):Void;
+
+	/**
+		Returns the peer certificate as an `X509Certificate` object.
+
+		// TODO(section-3): type against crypto.X509Certificate once crypto audit exposes it
+	**/
+	function getPeerX509Certificate():Any;
+
+	/**
+		Returns the local certificate as an `X509Certificate` object.
+
+		// TODO(section-3): type against crypto.X509Certificate once crypto audit exposes it
+	**/
+	function getX509Certificate():Any;
 
 	/**
 		Initiate TLS renegotiation process.

--- a/src/js/node/tty/ReadStream.hx
+++ b/src/js/node/tty/ReadStream.hx
@@ -29,6 +29,8 @@ package js.node.tty;
 **/
 @:jsRequire("tty", "ReadStream")
 extern class ReadStream extends js.node.net.Socket {
+	function new(fd:Int, ?options:js.node.net.Socket.SocketOptions);
+
 	/**
 		A boolean that is initialized to false.
 		It represents the current "raw" state of the tty.ReadStream instance.
@@ -40,5 +42,5 @@ extern class ReadStream extends js.node.net.Socket {
 		This sets the properties of the tty.ReadStream to act either as a raw device or default.
 		`isRaw` will be set to the resulting mode.
 	**/
-	function setRawMode(mode:Bool):Void;
+	function setRawMode(mode:Bool):ReadStream;
 }

--- a/src/js/node/tty/WriteStream.hx
+++ b/src/js/node/tty/WriteStream.hx
@@ -22,6 +22,8 @@
 
 package js.node.tty;
 
+import haxe.DynamicAccess;
+import haxe.extern.EitherType;
 import js.node.events.EventEmitter;
 
 /**
@@ -35,12 +37,23 @@ enum abstract WriteStreamEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T
 }
 
 /**
+	Direction for `WriteStream.clearLine`.
+**/
+enum abstract WriteStreamClearLineDirection(Int) from Int to Int {
+	var Left = -1;
+	var Right = 1;
+	var EntireLine = 0;
+}
+
+/**
 	A net.Socket subclass that represents the writable portion of a tty.
 	In normal circumstances, process.stdout will be the only tty.WriteStream instance
 	ever created (and only when isatty(1) is true).
 **/
 @:jsRequire("tty", "WriteStream")
 extern class WriteStream extends js.node.net.Socket {
+	function new(fd:Int);
+
 	/**
 		The number of columns the TTY currently has.
 		This property gets updated on "resize" events.
@@ -52,4 +65,47 @@ extern class WriteStream extends js.node.net.Socket {
 		This property gets updated on "resize" events.
 	**/
 	var rows(default, null):Int;
+
+	/**
+		`writeStream.clearLine()` clears the current line of this `WriteStream` in a direction identified by `dir`.
+	**/
+	function clearLine(dir:WriteStreamClearLineDirection, ?callback:Void->Void):Bool;
+
+	/**
+		`writeStream.clearScreenDown()` clears this `WriteStream` from the current cursor down.
+	**/
+	function clearScreenDown(?callback:Void->Void):Bool;
+
+	/**
+		`writeStream.cursorTo()` moves this `WriteStream`'s cursor to the specified position.
+	**/
+	@:overload(function(x:Int, callback:Void->Void):Bool {})
+	function cursorTo(x:Int, ?y:Int, ?callback:Void->Void):Bool;
+
+	/**
+		`writeStream.moveCursor()` moves this `WriteStream`'s cursor relative to its current position.
+	**/
+	function moveCursor(dx:Int, dy:Int, ?callback:Void->Void):Bool;
+
+	/**
+		Returns:
+		- `1` for 2,
+		- `4` for 16,
+		- `8` for 256,
+		- `24` for 16,777,216 colors supported.
+	**/
+	function getColorDepth(?env:DynamicAccess<String>):Int;
+
+	/**
+		`writeStream.getWindowSize()` returns the size of the TTY corresponding to this `WriteStream`
+		as `[numColumns, numRows]`.
+	**/
+	function getWindowSize():Array<Int>;
+
+	/**
+		Returns `true` if the `writeStream` supports at least as many colors as provided in `count`.
+	**/
+	@:overload(function(env:DynamicAccess<String>):Bool {})
+	@:overload(function(count:Int, ?env:DynamicAccess<String>):Bool {})
+	function hasColors(?count:EitherType<Int, DynamicAccess<String>>, ?env:DynamicAccess<String>):Bool;
 }


### PR DESCRIPTION
## Summary
- Aligns **net / http / https / http2 / tls / dgram / dns(+promises) / tty** externs with Node.js v24 Active LTS APIs (missing events, options, helpers, OutgoingMessage, validateHeader*, tty cursor APIs, dgram connect/SSM buffers, tls PeerCertificate + session helpers, etc.).
- Drops Haxe 3 `#if haxe4` / `haxe_ver` / `js.html` fallbacks in these modules; keeps Haxe 4.0.5-safe arrow/`js.lib` typing.
- Replaces several `Class<Dynamic>` / bare `Dynamic` usages with concrete types or `Any`, and documents remaining certificate / WebSocket TODOs.

## Test plan
- [x] `haxe build.hxml` (ImportAll) succeeds for changed networking modules
- [ ] Spot-check examples that use `http` / `net` / `tls` / `dns` still typecheck
- [ ] Review coordination TODOs with section-4 (crypto X509Certificate) and section-6 (WebSocket typing)

## Remaining TODOs
- `TODO(section-3)`: expand `PeerCertificate` field set; type `getPeerX509Certificate` / `getX509Certificate` against crypto `X509Certificate`
- `TODO(section-3)`: remove deprecated `Http2Stream.priority` once callers migrate
- `TODO(section-6)`: prefer `js.node.web` WebSocket typing for `http.WebSocket`


Made with [Cursor](https://cursor.com)