### PR TITLE
Audit process/CLI/VM externs for Node 24 and Haxe 4

### DIFF
--- a/src/js/node/AsyncHooks.hx
+++ b/src/js/node/AsyncHooks.hx
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node;
+
+/**
+	The `async_hooks` module provides an API to track asynchronous resources.
+
+	Prefer `js.node.async_hooks.AsyncLocalStorage` for most application-level async context tracking.
+	`createHook` remains available but is a lower-level / less recommended API.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/async_hooks.html
+**/
+@:jsRequire("async_hooks")
+extern class AsyncHooks {
+	/**
+		Registers functions to be called for different lifetime events of each async operation.
+	**/
+	static function createHook(options:AsyncHookOptions):js.node.async_hooks.AsyncHook;
+
+	/**
+		Returns the `asyncId` of the current execution context.
+	**/
+	static function executionAsyncId():Float;
+
+	/**
+		Returns the resource object associated with the topmost async frame.
+		Using undocumented handle APIs on the returned object may crash the process.
+	**/
+	// TODO(section-5): type executionAsyncResource beyond Dynamic when handle shapes are modeled
+	static function executionAsyncResource():Dynamic;
+
+	/**
+		Returns the `asyncId` of the resource that caused (or "triggered") the current execution.
+	**/
+	static function triggerAsyncId():Float;
+}
+
+/**
+	Callbacks for `AsyncHooks.createHook`.
+**/
+typedef AsyncHookOptions = {
+	/**
+		Called during object construction when the resource is initialized.
+		// TODO(section-5): type resource beyond Dynamic
+	**/
+	@:optional var init:Float->String->Float->Dynamic->Void;
+
+	/**
+		Called just before the resource's callback is called.
+	**/
+	@:optional var before:Float->Void;
+
+	/**
+		Called immediately after the resource's callback has completed.
+	**/
+	@:optional var after:Float->Void;
+
+	/**
+		Called after the resource is destroyed.
+	**/
+	@:optional var destroy:Float->Void;
+
+	/**
+		Called when the Promise-related callback is resolved.
+	**/
+	@:optional var promiseResolve:Float->Void;
+}

--- a/src/js/node/ChildProcess.hx
+++ b/src/js/node/ChildProcess.hx
@@ -24,24 +24,35 @@ package js.node;
 
 import haxe.DynamicAccess;
 import haxe.extern.EitherType;
-import js.node.child_process.ChildProcess as ChildProcessObject;
-#if haxe4
 import js.lib.Error;
-#else
-import js.Error;
-#end
+import js.node.child_process.ChildProcess as ChildProcessObject;
+import js.node.web.AbortSignal;
+import js.node.url.URL;
+
+/**
+	Serialization mode for IPC messages between processes.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/child_process.html#advanced-serialization
+**/
+enum abstract ChildProcessSerialization(String) from String to String {
+	var Json = "json";
+	var Advanced = "advanced";
+}
 
 /**
 	Common options for all `ChildProcess` methods.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/child_process.html
 **/
 private typedef ChildProcessCommonOptions = {
 	/**
 		Current working directory of the child process.
+		Accepts a path string or WHATWG `URL` object with `file:` protocol.
 	**/
-	@:optional var cwd:String;
+	@:optional var cwd:EitherType<String, URL>;
 
 	/**
-		Environment key-value pairs
+		Environment key-value pairs.
 	**/
 	@:optional var env:DynamicAccess<String>;
 
@@ -57,12 +68,40 @@ private typedef ChildProcessCommonOptions = {
 
 	/**
 		Shell to execute the command with.
-		Default: '/bin/sh' on UNIX, 'cmd.exe' on Windows.
+		Default: `'/bin/sh'` on UNIX, `'cmd.exe'` on Windows.
 
-		The shell should understand the -c switch on UNIX or /s /c on Windows.
-		On Windows, command line parsing should be compatible with cmd.exe.
+		The shell should understand the `-c` switch on UNIX or `/s /c` on Windows.
+		On Windows, command line parsing should be compatible with `cmd.exe`.
 	**/
 	@:optional var shell:EitherType<Bool, String>;
+
+	/**
+		Hide the subprocess console window that would normally be created on Windows.
+		Default: `false`.
+	**/
+	@:optional var windowsHide:Bool;
+
+	/**
+		No quoting or escaping of arguments is done on Windows.
+		Ignored on Unix. Default: `false`.
+	**/
+	@:optional var windowsVerbatimArguments:Bool;
+
+	/**
+		Allows aborting the child process using an `AbortSignal`.
+	**/
+	@:optional var signal:AbortSignal;
+
+	/**
+		Maximum amount of time in milliseconds the process is allowed to run.
+	**/
+	@:optional var timeout:Int;
+
+	/**
+		The signal value to be used when the spawned process will be killed
+		by timeout or abort signal. Default: `'SIGTERM'`.
+	**/
+	@:optional var killSignal:EitherType<String, Int>;
 }
 
 /**
@@ -75,6 +114,12 @@ private typedef ChildProcessSpawnOptionsBase = {
 		Child's stdio configuration.
 	**/
 	@:optional var stdio:ChildProcessSpawnOptionsStdio;
+
+	/**
+		Specify the kind of serialization used for sending messages between processes.
+		Possible values are `'json'` and `'advanced'`. Default: `'json'`.
+	**/
+	@:optional var serialization:ChildProcessSerialization;
 }
 
 /**
@@ -84,9 +129,15 @@ typedef ChildProcessSpawnOptions = {
 	> ChildProcessSpawnOptionsBase,
 
 	/**
-		The child will be a process group leader.
+		The child will be a process group leader / can keep running after parent exits.
 	**/
 	@:optional var detached:Bool;
+
+	/**
+		Explicitly set the value of `argv[0]` sent to the child process.
+		This will be set to `command` if not specified.
+	**/
+	@:optional var argv0:String;
 }
 
 /**
@@ -104,29 +155,14 @@ typedef ChildProcessSpawnSyncOptions = {
 	The value is one of the following:
 
 		* 'pipe' - Create a pipe between the child process and the parent process.
-				   The parent end of the pipe is exposed to the parent as a property on the child_process object as ChildProcess.stdio[fd].
-				   Pipes created for fds 0 - 2 are also available as ChildProcess.stdin, ChildProcess.stdout and ChildProcess.stderr, respectively.
+		* 'ipc' - Create an IPC channel for passing messages/file descriptors.
+		* 'ignore' - Do not set this file descriptor in the child.
+		* 'inherit' - Pass through the corresponding stdio stream to/from the parent.
+		* Stream object - Share a readable or writable stream with the child process.
+		* Positive integer - A file descriptor that is currently open in the parent.
+		* null / undefined - Use default value.
 
-		* 'ipc' - Create an IPC channel for passing messages/file descriptors between parent and child.
-				  A ChildProcess may have at most one IPC stdio file descriptor. Setting this option enables the ChildProcess.send() method.
-				  If the child writes JSON messages to this file descriptor, then this will trigger ChildProcess.on('message').
-				  If the child is a Node.js program, then the presence of an IPC channel will enable process.send() and process.on('message').
-
-		* 'ignore' - Do not set this file descriptor in the child. Note that Node will always open fd 0 - 2 for the processes it spawns.
-					 When any of these is ignored node will open /dev/null and attach it to the child's fd.
-
-		* Stream object - Share a readable or writable stream that refers to a tty, file, socket, or a pipe with the child process.
-						  The stream's underlying file descriptor is duplicated in the child process to the fd that corresponds to the index
-						  in the stdio array. Note that the stream must have an underlying descriptor (file streams do not until the 'open'
-						  event has occurred).
-
-		* Positive integer - The integer value is interpreted as a file descriptor that is is currently open in the parent process.
-							 It is shared with the child process, similar to how Stream objects can be shared.
-
-		* null - Use default value. For stdio fds 0, 1 and 2 (in other words, stdin, stdout, and stderr) a pipe is created.
-				 For fd 3 and up, the default is 'ignore'.
-
-	 As a shorthand, the stdio argument may also be one of the following strings, rather than an array:
+	 As a shorthand, the stdio argument may also be one of the following strings:
 		ignore - ['ignore', 'ignore', 'ignore']
 		pipe - ['pipe', 'pipe', 'pipe']
 		inherit - [process.stdin, process.stdout, process.stderr] or [0,1,2]
@@ -138,19 +174,24 @@ typedef ChildProcessSpawnOptionsStdio = EitherType<ChildProcessSpawnOptionsStdio
 **/
 enum abstract ChildProcessSpawnOptionsStdioSimple(String) from String to String {
 	/**
-		Equivalent to ['ignore', 'ignore', 'ignore']
+		Equivalent to `['ignore', 'ignore', 'ignore']`
 	**/
 	var Ignore = "ignore";
 
 	/**
-		Equivalent to ['pipe', 'pipe', 'pipe']
+		Equivalent to `['pipe', 'pipe', 'pipe']`
 	**/
 	var Pipe = "pipe";
 
 	/**
-		Equivalent to [process.stdin, process.stdout, process.stderr] or [0,1,2]
+		Equivalent to `[process.stdin, process.stdout, process.stderr]` or `[0,1,2]`
 	**/
 	var Inherit = "inherit";
+
+	/**
+		Equivalent to `['overlapped', 'overlapped', 'overlapped']`
+	**/
+	var Overlapped = "overlapped";
 }
 
 /**
@@ -159,35 +200,33 @@ enum abstract ChildProcessSpawnOptionsStdioSimple(String) from String to String 
 enum abstract ChildProcessSpawnOptionsStdioBehaviour(String) from String to String {
 	/**
 		Create a pipe between the child process and the parent process.
-		The parent end of the pipe is exposed to the parent as a property on the child_process object as ChildProcess.stdio[fd].
-		Pipes created for fds 0 - 2 are also available as ChildProcess.stdin, ChildProcess.stdout and ChildProcess.stderr, respectively.
 	**/
 	var Pipe = "pipe";
 
 	/**
+		Same as `'pipe'` with overlapped I/O on Windows.
+	**/
+	var Overlapped = "overlapped";
+
+	/**
 		Create an IPC channel for passing messages/file descriptors between parent and child.
-		A ChildProcess may have at most one IPC stdio file descriptor.
-
-		Setting this option enables the ChildProcess.send() method.
-
-		If the child writes JSON messages to this file descriptor, then this will trigger
-		ChildProcess.on('message').
-
-		If the child is a Node.js program, then the presence of an IPC channel will
-		enable process.send() and process.on('message').
 	**/
 	var Ipc = "ipc";
 
 	/**
 		Do not set this file descriptor in the child.
-		Note that Node will always open fd 0 - 2 for the processes it spawns.
-		When any of these is ignored node will open /dev/null and attach it to the child's fd.
 	**/
 	var Ignore = "ignore";
+
+	/**
+		Pass through the corresponding stdio stream to/from the parent process.
+	**/
+	var Inherit = "inherit";
 }
 
 // see https://github.com/HaxeFoundation/haxe/issues/3499
-// typedef ChildProcessSpawnOptionsStdioFull = Array<EitherType<ChildProcessSpawnOptionsStdioBehaviour,EitherType<IStream,Int>>>;
+// Ideal type: Array<EitherType<ChildProcessSpawnOptionsStdioBehaviour, EitherType<IStream, Int>>>
+// TODO(section-5): replace Array<Dynamic> once nested EitherType arrays type-check reliably
 typedef ChildProcessSpawnOptionsStdioFull = Array<Dynamic>;
 
 /**
@@ -197,24 +236,14 @@ private typedef ChildProcessExecOptionsBase = {
 	> ChildProcessCommonOptions,
 
 	/**
-		Default: 'utf8'
+		Default: `'utf8'`
 	**/
 	@:optional var encoding:String;
 
 	/**
-		If greater than 0, then it will kill the child process if it runs longer than timeout milliseconds.
-	**/
-	@:optional var timeout:Int;
-
-	/**
-		The child process is killed with `killSignal` (default: 'SIGTERM').
-	**/
-	@:optional var killSignal:String;
-
-	/**
 		The largest amount of data allowed on stdout or stderr.
 		If this value is exceeded then the child process is killed.
-		Default: 200*1024
+		Default: `1024 * 1024`
 	**/
 	@:optional var maxBuffer:Int;
 }
@@ -240,21 +269,31 @@ typedef ChildProcessForkOptions = {
 	> ChildProcessCommonOptions,
 
 	/**
-		Executable used to create the child process
+		Executable used to create the child process.
 	**/
 	@:optional var execPath:String;
 
 	/**
-		List of string arguments passed to the executable (Default: process.execArgv)
+		List of string arguments passed to the executable (Default: `process.execArgv`)
 	**/
 	@:optional var execArgv:Array<String>;
 
 	/**
 		If `true`, stdin, stdout, and stderr of the child will be piped to the parent,
-		otherwise they will be inherited from the parent, see the "pipe" and "inherit"
-		options for `ChildProcessSpawnOptions.stdio` for more details (default is `false`)
+		otherwise they will be inherited from the parent (default is `false`).
 	**/
 	@:optional var silent:Bool;
+
+	/**
+		See `ChildProcessSpawnOptions.stdio`. When provided, overrides `silent`.
+		Must contain exactly one `'ipc'` entry when using the array form.
+	**/
+	@:optional var stdio:ChildProcessSpawnOptionsStdio;
+
+	/**
+		Specify the kind of serialization used for sending messages between processes.
+	**/
+	@:optional var serialization:ChildProcessSerialization;
 }
 
 /**
@@ -263,7 +302,7 @@ typedef ChildProcessForkOptions = {
 @:native("Error")
 extern class ChildProcessExecError extends Error {
 	/**
-		the exit code of the child proces.
+		the exit code of the child process.
 	**/
 	var code(default, null):Int;
 
@@ -281,8 +320,8 @@ extern class ChildProcessExecError extends Error {
 	and `error.code` will be the exit code of the child process, and `error.signal` will be set
 	to the signal that terminated the process (see `ChildProcessExecError`).
 **/
-typedef ChildProcessExecCallback = #if (haxe_ver >= 4) (error:Null<ChildProcessExecError>, stdout:EitherType<Buffer, String>,
-		stderr:EitherType<Buffer, String>) -> Void; #else Null<ChildProcessExecError>->EitherType<Buffer, String>->EitherType<Buffer, String>->Void; #end
+typedef ChildProcessExecCallback = (error:Null<ChildProcessExecError>, stdout:EitherType<Buffer, String>,
+	stderr:EitherType<Buffer, String>) -> Void;
 
 /**
 	Object returned from the `spawnSync` method.
@@ -296,7 +335,7 @@ typedef ChildProcessSpawnSyncResult = {
 	/**
 		Array of results from stdio output
 	**/
-	var output:Array<EitherType<Buffer, String>>;
+	var output:Array<Null<EitherType<Buffer, String>>>;
 
 	/**
 		The contents of output[1]
@@ -311,12 +350,12 @@ typedef ChildProcessSpawnSyncResult = {
 	/**
 		The exit code of the child process
 	**/
-	var status:Int;
+	var status:Null<Int>;
 
 	/**
 		The signal used to kill the child process
 	**/
-	var signal:String;
+	var signal:Null<String>;
 
 	/**
 		The error object if the child process failed or timed out
@@ -324,19 +363,16 @@ typedef ChildProcessSpawnSyncResult = {
 	var error:Error;
 }
 
+/**
+	The `child_process` module enables spawning child processes.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/child_process.html
+**/
 @:jsRequire("child_process")
 extern class ChildProcess {
 	/**
 		Launches a new process with the given `command`, with command line arguments in `args`.
 		If omitted, `args` defaults to an empty `Array`.
-
-		The third argument is used to specify additional options, which defaults to:
-			{ cwd: null,
-			  env: process.env
-			}
-
-		Note that if spawn receives an empty options object, it will result in spawning the process with an empty
-		environment rather than using `process.env`. This due to backwards compatibility issues with a deprecated API.
 	**/
 	@:overload(function(command:String, ?options:ChildProcessSpawnOptions):ChildProcessObject {})
 	@:overload(function(command:String, args:Array<String>, ?options:ChildProcessSpawnOptions):ChildProcessObject {})
@@ -344,23 +380,12 @@ extern class ChildProcess {
 
 	/**
 		Runs a command in a shell and buffers the output.
-
-		`command` is the command to run, with space-separated arguments.
-
-		The default `options` are:
-			{ encoding: 'utf8',
-			  timeout: 0,
-			  maxBuffer: 200*1024,
-			  killSignal: 'SIGTERM',
-			  cwd: null,
-			  env: null }
 	**/
 	@:overload(function(command:String, options:ChildProcessExecOptions, callback:ChildProcessExecCallback):ChildProcessObject {})
 	static function exec(command:String, callback:ChildProcessExecCallback):ChildProcessObject;
 
 	/**
-		This is similar to `exec` except it does not execute a subshell but rather the specified file directly.
-		This makes it slightly leaner than `exec`
+		Similar to `exec` except it does not execute a subshell but rather the specified file directly.
 	**/
 	@:overload(function(file:String, args:Array<String>, options:ChildProcessExecFileOptions, ?callback:ChildProcessExecCallback):ChildProcessObject {})
 	@:overload(function(file:String, options:ChildProcessExecFileOptions, ?callback:ChildProcessExecCallback):ChildProcessObject {})
@@ -368,36 +393,21 @@ extern class ChildProcess {
 	static function execFile(file:String, ?callback:ChildProcessExecCallback):ChildProcessObject;
 
 	/**
-		This is a special case of the `spawn` functionality for spawning Node processes.
-		In addition to having all the methods in a normal `ChildProcess` instance,
-		the returned object has a communication channel built-in.
-		See `send` for details.
+		Special case of `spawn` for spawning Node.js processes with an IPC channel.
 	**/
-	@:overload(function(modulePath:String, args:Array<String>, options:ChildProcessForkOptions):ChildProcessObject {})
-	@:overload(function(modulePath:String, options:ChildProcessForkOptions):ChildProcessObject {})
-	static function fork(modulePath:String, ?args:Array<String>):ChildProcessObject;
+	@:overload(function(modulePath:EitherType<String, URL>, args:Array<String>, options:ChildProcessForkOptions):ChildProcessObject {})
+	@:overload(function(modulePath:EitherType<String, URL>, options:ChildProcessForkOptions):ChildProcessObject {})
+	static function fork(modulePath:EitherType<String, URL>, ?args:Array<String>):ChildProcessObject;
 
 	/**
 		Synchronous version of `spawn`.
-
-		`spawnSync` will not return until the child process has fully closed.
-		When a timeout has been encountered and `killSignal` is sent, the method won't return until the process
-		has completely exited. That is to say, if the process handles the SIGTERM signal and doesn't exit,
-		your process will wait until the child process has exited.
 	**/
 	@:overload(function(command:String, args:Array<String>, ?options:ChildProcessSpawnSyncOptions):ChildProcessSpawnSyncResult {})
 	static function spawnSync(command:String, ?options:ChildProcessSpawnSyncOptions):ChildProcessSpawnSyncResult;
 
 	/**
 		Synchronous version of `execFile`.
-
-		`execFileSync` will not return until the child process has fully closed.
-		When a timeout has been encountered and `killSignal` is sent, the method won't return until the process
-		has completely exited. That is to say, if the process handles the SIGTERM signal and doesn't exit,
-		your process will wait until the child process has exited.
-
 		If the process times out, or has a non-zero exit code, this method will throw.
-		The Error object will contain the entire result from `spawnSync`
 	**/
 	@:overload(function(command:String, ?options:ChildProcessSpawnSyncOptions):EitherType<String, Buffer> {})
 	@:overload(function(command:String, args:Array<String>, ?options:ChildProcessSpawnSyncOptions):EitherType<String, Buffer> {})
@@ -405,14 +415,7 @@ extern class ChildProcess {
 
 	/**
 		Synchronous version of `exec`.
-
-		`execSync` will not return until the child process has fully closed.
-		When a timeout has been encountered and `killSignal` is sent, the method won't return until the process
-		has completely exited. That is to say, if the process handles the SIGTERM signal and doesn't exit,
-		your process will wait until the child process has exited.
-
 		If the process times out, or has a non-zero exit code, this method will throw.
-		The Error object will contain the entire result from `spawnSync`
 	**/
 	static function execSync(command:String, ?options:ChildProcessSpawnSyncOptions):EitherType<String, Buffer>;
 }

--- a/src/js/node/Cluster.hx
+++ b/src/js/node/Cluster.hx
@@ -23,76 +23,54 @@
 package js.node;
 
 import haxe.DynamicAccess;
+import js.node.ChildProcess.ChildProcessSerialization;
+import js.node.ChildProcess.ChildProcessSpawnOptionsStdio;
 import js.node.cluster.Worker;
 import js.node.events.EventEmitter;
 
+/**
+	@see https://nodejs.org/docs/latest-v24.x/api/cluster.html
+**/
 enum abstract ClusterEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 	/**
 		When a new worker is forked the cluster module will emit a 'fork' event.
 		This can be used to log worker activity, and create your own timeout.
-
-		Listener arguments:
-			* worker:Worker
 	**/
 	var Fork:ClusterEvent<Worker->Void> = "fork";
 
 	/**
 		After forking a new worker, the worker should respond with an online message.
-		When the master receives an online message it will emit this event.
-
-		The difference between 'fork' and 'online' is that fork is emitted when the master forks a worker,
-		and 'online' is emitted when the worker is running.
-
-		Listener arguments:
-			* worker:Worker
+		When the primary receives an online message it will emit this event.
 	**/
 	var Online:ClusterEvent<Worker->Void> = "online";
 
 	/**
 		After calling `listen` from a worker, when the 'listening' event is emitted on the server,
-		a listening event will also be emitted on cluster in the master.
-
-		The event handler is executed with two arguments, the `worker` contains the worker object and
-		the `address` object contains the following connection properties: address, port and addressType.
-		This is very useful if the worker is listening on more than one address.
-
-		 		Listener arguments:
-			* worker:Worker
-			* address:ListeningEventAddress
+		a listening event will also be emitted on cluster in the primary.
 	**/
 	var Listening:ClusterEvent<Worker->ListeningEventAddress->Void> = "listening";
 
 	/**
 		Emitted after the worker IPC channel has disconnected.
-
-		This can occur when a worker exits gracefully, is killed,
-		or is disconnected manually (such as with `Worker.disconnect`).
-
-		There may be a delay between the 'disconnect' and 'exit' events.
-
-		These events can be used to detect if the process is stuck in a cleanup
-		or if there are long-living connections.
-
-		Listener arguments:
-			* worker:Worker
 	**/
 	var Disconnect:ClusterEvent<Worker->Void> = "disconnect";
 
 	/**
 		When any of the workers die the cluster module will emit the 'exit' event.
-		This can be used to restart the worker by calling `Cluster.fork` again.
-
-		Listener arguments:
-			* worker:Worker
-			* code:Int - the exit code, if it exited normally.
-			* signal:String - the name of the signal (eg. 'SIGHUP') that caused the process to be killed.
 	**/
 	var Exit:ClusterEvent<Worker->Int->String->Void> = "exit";
 
 	/**
-		Emitted the first time that `Cluster.setupMaster` is called.
+		Emitted every time `setupPrimary` is called.
 	**/
 	var Setup:ClusterEvent<ClusterSettings->Void> = "setup";
+
+	/**
+		Emitted when any worker receives a message.
+
+		// TODO(section-5): tighten message/handle typing beyond Dynamic
+	**/
+	var Message:ClusterEvent<Worker->Dynamic->Dynamic->Void> = "message";
 }
 
 /**
@@ -119,13 +97,9 @@ extern enum abstract ClusterSchedulingPolicy(Int) {
 }
 
 /**
-	A single instance of Node runs in a single thread.
-	To take advantage of multi-core systems the user will sometimes want to launch a cluster of Node processes to handle the load.
-	The cluster module allows you to easily create child processes that all share server ports.
+	The cluster module allows easy creation of child processes that all share server ports.
 
-	This feature was introduced recently, and may change in future versions. Please try it out and provide feedback.
-
-	Also note that, on Windows, it is not yet possible to set up a named pipe server in a worker.
+	@see https://nodejs.org/docs/latest-v24.x/api/cluster.html
 **/
 @:jsRequire("cluster")
 extern class Cluster extends EventEmitter<Cluster> {
@@ -139,108 +113,63 @@ extern class Cluster extends EventEmitter<Cluster> {
 	/**
 		The scheduling policy, either `SCHED_RR` for round-robin
 		or `SCHED_NONE` to leave it to the operating system.
-
-		This is a global setting and effectively frozen once you spawn the first worker
-		or call `setupMaster`, whatever comes first.
-
-		`SCHED_RR` is the default on all operating systems except Windows.
-		Windows will change to `SCHED_RR` once libuv is able to effectively distribute IOCP handles
-		without incurring a large performance hit.
-
-		`schedulingPolicy` can also be set through the NODE_CLUSTER_SCHED_POLICY environment variable.
-		Valid values are "rr" and "none".
 	**/
 	var schedulingPolicy:ClusterSchedulingPolicy;
 
 	/**
-		After calling `setupMaster` (or `fork`) this settings object will contain the settings, including the default values.
-
-		It is effectively frozen after being set, because `setupMaster` can only be called once.
-
-		This object is not supposed to be changed or set manually, by you.
+		After calling `setupPrimary` (or `fork`) this settings object will contain the settings,
+		including the default values.
 	**/
 	var settings(default, null):ClusterSettings;
 
 	/**
-		True if the process is a master.
-		This is determined by the process.env.NODE_UNIQUE_ID.
-		If process.env.NODE_UNIQUE_ID is undefined, then `isMaster` is true.
+		True if the process is a primary.
+		Deprecated alias for `isPrimary`.
 	**/
+	@:deprecated("Use isPrimary instead")
 	var isMaster(default, null):Bool;
 
 	/**
 		True if the process is a primary.
 		This is determined by the process.env.NODE_UNIQUE_ID.
 		If process.env.NODE_UNIQUE_ID is undefined, then `isPrimary` is true.
-
-		`isMaster` is a deprecated alias of `isPrimary`.
 	**/
 	var isPrimary(default, null):Bool;
 
 	/**
-		True if the process is not a master (it is the negation of `isMaster`).
+		True if the process is not a primary (it is the negation of `isPrimary`).
 	**/
 	var isWorker(default, null):Bool;
 
 	/**
-		`setupMaster` is used to change the default `fork` behavior.
-
-		Once called, the `settings` will be present in `settings`.
-
-		Note that:
-			Only the first call to `setupMaster` has any effect, subsequent calls are ignored
-
-			That because of the above, the only attribute of a worker that may be customized per-worker
-			is the `env` passed to `fork`
-
-			`fork` calls `setupMaster` internally to establish the defaults, so to have any effect,
-			`setupMaster` must be called before any calls to `fork`
+		Deprecated alias for `setupPrimary`.
 	**/
-	function setupMaster(?settings:{?exec:String, ?args:Array<String>, ?silent:Bool}):Void;
+	@:deprecated("Use setupPrimary instead")
+	function setupMaster(?settings:ClusterSettings):Void;
 
 	/**
 		Used to change the default `fork` behavior. Once called, the settings will be present in `settings`.
-
-		`setupMaster` is a deprecated alias of `setupPrimary`.
 	**/
-	function setupPrimary(?settings:{?exec:String, ?args:Array<String>, ?silent:Bool}):Void;
+	function setupPrimary(?settings:ClusterSettings):Void;
 
 	/**
-		Spawn a new worker process.
-
-		This can only be called from the master process.
+		Spawn a new worker process. This can only be called from the primary process.
 	**/
 	function fork(?env:DynamicAccess<String>):Worker;
 
 	/**
 		Calls `disconnect` on each worker in `workers`.
-
-		When they are disconnected all internal handles will be closed,
-		allowing the master process to die gracefully if no other event is waiting.
-
-		The method takes an optional `callback` argument which will be called when finished.
-
-		This can only be called from the master process.
 	**/
 	function disconnect(?callback:Void->Void):Void;
 
 	/**
-		A reference to the current worker object.
-
-		Not available in the master process.
+		A reference to the current worker object. Not available in the primary process.
 	**/
 	var worker(default, null):Worker;
 
 	/**
 		A hash that stores the active worker objects, keyed by `id` field.
-		Makes it easy to loop through all the workers.
-
-		It is only available in the master process.
-
-		A worker is removed from `workers` just before the 'disconnect' or 'exit' event is emitted.
-
-		Should you wish to reference a worker over a communication channel, using the worker's unique `id`
-		is the easiest way to find the worker.
+		It is only available in the primary process.
 	**/
 	var workers(default, null):DynamicAccess<Worker>;
 }
@@ -250,33 +179,62 @@ typedef ClusterSettings = {
 		list of string arguments passed to the node executable.
 		Default: process.execArgv
 	**/
-	@:optional var execArgv(default, null):Array<String>;
+	@:optional var execArgv:Array<String>;
 
 	/**
 		file path to worker file.
 		Default: process.argv[1]
 	**/
-	@:optional var exec(default, null):String;
+	@:optional var exec:String;
 
 	/**
 		string arguments passed to worker.
 		Default: process.argv.slice(2)
 	**/
-	@:optional var args(default, null):Array<String>;
+	@:optional var args:Array<String>;
+
+	/**
+		Current working directory of the worker process.
+		Default: `undefined` (inherits from parent process).
+	**/
+	@:optional var cwd:String;
+
+	/**
+		Specify the kind of serialization used for sending messages between processes.
+	**/
+	@:optional var serialization:ChildProcessSerialization;
 
 	/**
 		whether or not to send output to parent's stdio.
 		Default: false
 	**/
-	@:optional var silent(default, null):Bool;
+	@:optional var silent:Bool;
+
+	/**
+		Configures the stdio of forked processes.
+		Must contain an `'ipc'` entry. When provided, overrides `silent`.
+	**/
+	@:optional var stdio:ChildProcessSpawnOptionsStdio;
 
 	/**
 		Sets the user identity of the process.
 	**/
-	@:optional var uid(default, null):Int;
+	@:optional var uid:Int;
 
 	/**
 		Sets the group identity of the process.
 	**/
-	@:optional var gid(default, null):Int;
+	@:optional var gid:Int;
+
+	/**
+		Sets inspector port of worker. Can be a number, or a function that returns a number.
+	**/
+	// TODO(section-5): model inspectPort callback `() -> Int` without losing Int assignability
+	@:optional var inspectPort:haxe.extern.EitherType<Int, Void->Int>;
+
+	/**
+		Hide the forked processes console window that would normally be created on Windows.
+		Default: `false`.
+	**/
+	@:optional var windowsHide:Bool;
 }

--- a/src/js/node/Domain.hx
+++ b/src/js/node/Domain.hx
@@ -27,11 +27,15 @@ import js.node.domain.Domain as DomainObject;
 /**
 	Domains provide a way to handle multiple different IO operations as a single group.
 
+	Stability: 0 - Deprecated. Prefer `js.node.AsyncHooks` / `AsyncLocalStorage` for async context tracking.
+
 	If any of the event emitters or callbacks registered to a domain emit an error event, or throw an error,
 	then the domain object will be notified, rather than losing the context of the error in the process.on('uncaughtException') handler,
 	or causing the program to exit immediately with an error code.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/domain.html
 **/
-@:deprecated
+@:deprecated("The domain module is deprecated. Use AsyncLocalStorage / async_hooks instead.")
 @:jsRequire("domain")
 extern class Domain {
 	/**

--- a/src/js/node/Readline.hx
+++ b/src/js/node/Readline.hx
@@ -32,53 +32,41 @@ import js.node.web.AbortSignal;
 	The readline module provides an interface for reading data from a `Readable` stream (such as `process.stdin`) one
 	line at a time.
 
-	@see https://nodejs.org/api/readline.html#readline_readline
+	@see https://nodejs.org/docs/latest-v24.x/api/readline.html
 **/
 @:jsRequire("readline")
 extern class Readline {
 	/**
 		The `readline.clearLine()` method Clears current line of given `TTY` stream
 		in a specified direction identified by `dir`.
-
-		@see https://nodejs.org/api/readline.html#readline_readline_clearline_stream_dir_callback
 	**/
 	static function clearLine(stream:IWritable, dir:ClearLineDirection, ?callback:Void->Void):Bool;
 
 	/**
 		The `readline.clearScreenDown()` method clears the given `TTY` stream
 		from the current position of the cursor down.
-
-		@see https://nodejs.org/api/readline.html#readline_readline_clearscreendown_stream_callback
 	**/
 	static function clearScreenDown(stream:IWritable, ?callback:Void->Void):Bool;
 
 	/**
 		The `readline.createInterface()` method creates a new `readline.Interface` instance.
-
-		@see https://nodejs.org/api/readline.html#readline_readline_createinterface_options
 	**/
 	@:overload(function(input:IReadable, ?output:IWritable, ?completer:ReadlineCompleterCallback, ?terminal:Bool):Interface {})
 	static function createInterface(options:ReadlineOptions):Interface;
 
 	/**
 		The `readline.cursorTo()` method moves cursor to the specified position in a given `TTY` `stream`.
-
-		@see https://nodejs.org/api/readline.html#readline_readline_cursorto_stream_x_y_callback
 	**/
 	static function cursorTo(stream:IWritable, x:Int, ?y:Int, ?callback:Void->Void):Bool;
 
 	/**
 		The `readline.emitKeypressEvents()` method causes the given `Readable` stream to begin emitting `'keypress'`
 		events corresponding to received input.
-
-		@see https://nodejs.org/api/readline.html#readline_readline_emitkeypressevents_stream_interface
 	**/
 	static function emitKeypressEvents(stream:IReadable, ?iface:Interface):Void;
 
 	/**
 		The `readline.moveCursor()` method moves the cursor relative to its current position in a given `TTY` `stream`.
-
-		@see https://nodejs.org/api/readline.html#readline_readline_movecursor_stream_dx_dy_callback
 	**/
 	static function moveCursor(stream:IWritable, dx:Int, dy:Int, ?callback:Void->Void):Bool;
 }
@@ -86,7 +74,7 @@ extern class Readline {
 /**
 	Options object used by `Readline.createInterface`.
 
-	@see https://nodejs.org/api/readline.html#readline_readline_createinterface_options
+	@see https://nodejs.org/docs/latest-v24.x/api/readline.html#readlinecreateinterfaceoptions
 **/
 typedef ReadlineOptions = {
 	/**
@@ -101,77 +89,50 @@ typedef ReadlineOptions = {
 
 	/**
 		An optional function used for Tab autocompletion.
-
-		@see https://nodejs.org/api/readline.html#readline_use_of_the_completer_function
 	**/
 	@:optional var completer:ReadlineCompleterCallback;
 
 	/**
 		`true` if the `input` and `output` streams should be treated like a TTY, and have ANSI/VT100 escape codes
 		written to it.
-
-		Default: checking `isTTY` on the `output` stream upon instantiation.
 	**/
 	@:optional var terminal:Bool;
 
 	/**
 		Initial list of history lines.
-		This option makes sense only if `terminal` is set to `true` by the user or by an internal `output` check,
-		otherwise the history caching mechanism is not initialized at all.
-
-		Default: `[]`.
 	**/
 	@:optional var history:Array<String>;
 
 	/**
 		Maximum number of history lines retained.
 		To disable the history set this value to `0`.
-		This option makes sense only if `terminal` is set to `true` by the user or by an internal `output` check,
-		otherwise the history caching mechanism is not initialized at all.
-
-		Default: `30`.
 	**/
 	@:optional var historySize:Int;
 
 	/**
-		The prompt string to use.
-
-		Default: `'> '`.
+		The prompt string to use. Default: `'> '`.
 	**/
 	@:optional var prompt:String;
 
 	/**
 		If the delay between `\r` and `\n` exceeds `crlfDelay` milliseconds, both `\r` and `\n` will be treated as
 		separate end-of-line input.
-		`crlfDelay` will be coerced to a number no less than `100`.
-		It can be set to `Infinity`, in which case `\r` followed by `\n` will always be considered a single newline
-		(which may be reasonable for reading files with `\r\n` line delimiter).
-
-		Default: `100`.
 	**/
-	@:optional var crlfDelay:Int;
+	@:optional var crlfDelay:Float;
 
 	/**
 		If `true`, when a new input line added to the history list duplicates an older one, this removes the older line
 		from the list.
-
-		Default: `false`.
 	**/
 	@:optional var removeHistoryDuplicates:Bool;
 
 	/**
-		The duration `readline` will wait for a character (when reading an ambiguous key sequence in milliseconds one
-		that can both form a complete key sequence using the input read so far and can take additional input to complete
-		a longer key sequence).
-
-		Default: `500`.
+		The duration `readline` will wait for a character (when reading an ambiguous key sequence) in milliseconds.
 	**/
 	@:optional var escapeCodeTimeout:Int;
 
 	/**
-		The number of spaces a tab is equal to (minimum 1).
-
-		Default: `8`.
+		The number of spaces a tab is equal to (minimum 1). Default: `8`.
 	**/
 	@:optional var tabSize:Int;
 
@@ -182,16 +143,10 @@ typedef ReadlineOptions = {
 	@:optional var signal:AbortSignal;
 }
 
-#if haxe4
 typedef ReadlineCompleterCallback = (line:String) -> Array<EitherType<Array<String>, String>>;
-#else
-typedef ReadlineCompleterCallback = String->Array<EitherType<Array<String>, String>>;
-#end
 
 /**
 	Enumeration of possible directions for `Readline.clearLine`.
-
-	@see https://nodejs.org/api/readline.html#readline_readline_clearline_stream_dir_callback
 **/
 enum abstract ClearLineDirection(Int) from Int to Int {
 	/**

--- a/src/js/node/ReadlinePromises.hx
+++ b/src/js/node/ReadlinePromises.hx
@@ -23,15 +23,11 @@
 package js.node;
 
 import haxe.extern.EitherType;
+import js.lib.Promise;
 import js.node.readline.PromisesInterface;
 import js.node.stream.Readable.IReadable;
 import js.node.stream.Writable.IWritable;
 import js.node.web.AbortSignal;
-#if haxe4
-import js.lib.Promise;
-#else
-import js.Promise;
-#end
 
 /**
 	Completer result: matching entries, then the substring used for matching.
@@ -42,18 +38,14 @@ typedef ReadlinePromisesCompleterResult = Array<EitherType<Array<String>, String
 	Tab autocompletion for `readline/promises`.
 	Unlike the callback API, the completer may return a `Promise`.
 **/
-#if haxe4
 typedef ReadlinePromisesCompleterCallback = (line:String) -> EitherType<ReadlinePromisesCompleterResult, Promise<ReadlinePromisesCompleterResult>>;
-#else
-typedef ReadlinePromisesCompleterCallback = String->EitherType<ReadlinePromisesCompleterResult, Promise<ReadlinePromisesCompleterResult>>;
-#end
 
 /**
 	Options for `ReadlinePromises.createInterface`.
 
 	Same surface as `ReadlineOptions`, but `completer` may return a `Promise`.
 
-	@see https://nodejs.org/api/readline.html#readlinepromisescreateinterfaceoptions
+	@see https://nodejs.org/docs/latest-v24.x/api/readline.html#readlinepromisescreateinterfaceoptions
 **/
 typedef ReadlinePromisesOptions = {
 	/**
@@ -95,7 +87,7 @@ typedef ReadlinePromisesOptions = {
 	/**
 		Delay threshold for treating `\r\n` as a single newline.
 	**/
-	@:optional var crlfDelay:Int;
+	@:optional var crlfDelay:Float;
 
 	/**
 		If `true`, remove older duplicate history entries.
@@ -121,7 +113,7 @@ typedef ReadlinePromisesOptions = {
 /**
 	The `readline/promises` API provides an alternative set of interfaces that return promises.
 
-	@see https://nodejs.org/api/readline.html#promises-api
+	@see https://nodejs.org/docs/latest-v24.x/api/readline.html#promises-api
 **/
 @:jsRequire("readline/promises")
 extern class ReadlinePromises {

--- a/src/js/node/Repl.hx
+++ b/src/js/node/Repl.hx
@@ -23,132 +23,95 @@
 package js.node;
 
 import haxe.DynamicAccess;
+import js.lib.Error;
+import js.lib.Symbol;
 import js.node.repl.REPLServer;
 import js.node.stream.Readable.IReadable;
 import js.node.stream.Writable.IWritable;
-#if haxe4
-import js.lib.Error;
-import js.lib.Symbol;
-#else
-import js.Error;
-#end
 
 /**
 	The `repl` module provides a Read-Eval-Print-Loop (REPL) implementation that is available both as a standalone
 	program or includible in other applications.
 
-	@see https://nodejs.org/api/repl.html#repl_repl
+	@see https://nodejs.org/docs/latest-v24.x/api/repl.html
 **/
 @:jsRequire("repl")
 extern class Repl {
 	/**
 		The `repl.start()` method creates and starts a `repl.REPLServer` instance.
-
-		@see https://nodejs.org/api/repl.html#repl_repl_start_options
 	**/
 	@:overload(function(prompt:String):REPLServer {})
-	static function start(options:ReplOptions):REPLServer;
+	static function start(?options:ReplOptions):REPLServer;
 
 	/**
 		Evaluates expressions in sloppy mode.
-
-		@see https://nodejs.org/api/repl.html#repl_repl_start_options
 	**/
-	#if haxe4
 	static final REPL_MODE_SLOPPY:Symbol;
-	#else
-	static var REPL_MODE_SLOPPY(default, never):Dynamic;
-	#end
 
 	/**
 		Evaluates expressions in strict mode.
 		This is equivalent to prefacing every repl statement with `'use strict'`.
-
-		@see https://nodejs.org/api/repl.html#repl_repl_start_options
 	**/
-	#if haxe4
 	static final REPL_MODE_STRICT:Symbol;
-	#else
-	static var REPL_MODE_STRICT(default, never):Dynamic;
-	#end
 }
 
 /**
 	Options object used by `Repl.start`.
 
-	@see https://nodejs.org/api/repl.html#repl_repl_start_options
+	@see https://nodejs.org/docs/latest-v24.x/api/repl.html#replstartoptions
 **/
 typedef ReplOptions = {
 	/**
-		The input prompt to display.
-
-		Default: `'> '` (with a trailing space).
+		The input prompt to display. Default: `'> '` (with a trailing space).
 	**/
 	@:optional var prompt:String;
 
 	/**
-		The `Readable` stream from which REPL input will be read.
-
-		Default: `process.stdin`.
+		The `Readable` stream from which REPL input will be read. Default: `process.stdin`.
 	**/
 	@:optional var input:IReadable;
 
 	/**
-		The `Writable` stream to which REPL output will be written.
-
-		Default: `process.stdout`.
+		The `Writable` stream to which REPL output will be written. Default: `process.stdout`.
 	**/
 	@:optional var output:IWritable;
 
 	/**
 		If `true`, specifies that the `output` should be treated as a TTY terminal.
-
-		Default: checking the value of the `isTTY` property on the `output` stream upon instantiation.
 	**/
 	@:optional var terminal:Bool;
 
 	/**
 		The function to be used when evaluating each given line of input.
-
 		Default: an async wrapper for the JavaScript `eval()` function.
+
+		// TODO(section-5): replace DynamicAccess<Dynamic>/Dynamic result with a typed REPL context model
 	**/
-	#if haxe4
 	@:optional var eval:(code:String, context:DynamicAccess<Dynamic>, file:String, cb:(error:Null<Error>, ?result:Dynamic) -> Void) -> Void;
-	#else
-	@:optional var eval:String->DynamicAccess<Dynamic>->String->(Null<Error>->?Dynamic->Void)->Void;
-	#end
 
 	/**
 		If `true`, specifies that the default `writer` function should include ANSI color styling to REPL output.
-		If a custom `writer` function is provided then this has no effect.
-
-		Default: checking color support on the `output` stream if the REPL instance's `terminal` value is `true`.
 	**/
 	@:optional var useColors:Bool;
 
 	/**
-		If `true`, specifies that the default evaluation function will use the JavaScript `global` as the context as
-		opposed to creating a new separate context for the REPL instance.
-		The node CLI REPL sets this value to `true`.
-
-		Default: `false`.
+		If `true`, specifies that the default evaluation function will use the JavaScript `global` as the context.
 	**/
 	@:optional var useGlobal:Bool;
 
 	/**
 		If `true`, specifies that the default writer will not output the return value of a command if it evaluates to
 		`undefined`.
-
-		Default: `false`.
 	**/
 	@:optional var ignoreUndefined:Bool;
 
 	/**
 		The function to invoke to format the output of each command before writing to `output`.
-
 		Default: `util.inspect()`.
+
+		// TODO(section-5): type writer as (value:Dynamic) -> String
 	**/
-	@:optional var writer:Dynamic->Void;
+	@:optional var writer:Dynamic->Dynamic;
 
 	/**
 		An optional function used for custom Tab auto completion.
@@ -160,17 +123,16 @@ typedef ReplOptions = {
 		(sloppy) mode.
 		Acceptable values are `repl.REPL_MODE_SLOPPY` or `repl.REPL_MODE_STRICT`.
 	**/
-	#if haxe4
 	@:optional var replMode:Symbol;
-	#else
-	@:optional var replMode:Dynamic;
-	#end
 
 	/**
 		Stop evaluating the current piece of code when `SIGINT` is received, i.e. `Ctrl+C` is pressed.
 		This cannot be used together with a custom `eval` function.
-
-		Default: `false`.
 	**/
 	@:optional var breakEvalOnSigint:Bool;
+
+	/**
+		If `true`, show preview of the results when inputting. Default depends on Node version / terminal.
+	**/
+	@:optional var preview:Bool;
 }

--- a/src/js/node/V8.hx
+++ b/src/js/node/V8.hx
@@ -22,43 +22,137 @@
 
 package js.node;
 
+import haxe.Constraints.Function;
+import js.node.Buffer;
+import js.node.stream.Readable.IReadable;
+
 /**
 	The v8 module exposes APIs that are specific to the version of V8 built into the Node.js binary.
 
-	Note: The APIs and implementation are subject to change at any time.
+	@see https://nodejs.org/docs/latest-v24.x/api/v8.html
+
+	// TODO(section-5): expand Serializer/Deserializer/DefaultSerializer subclasses and CPU/Heap profile handles
 **/
 @:jsRequire("v8")
 extern class V8 {
+	/**
+		Returns an integer representing a version tag derived from the V8 version, command-line flags,
+		and detected CPU features. This is useful for determining whether a `vm.Script` `cachedData` buffer
+		is compatible with this instance of V8.
+	**/
+	static function cachedDataVersionTag():Int;
+
+	/**
+		Returns an object with statistics about the V8 heap spaces.
+	**/
 	static function getHeapStatistics():V8HeapStatistics;
 
 	/**
 		Returns statistics about the V8 heap spaces, i.e. the segments which make up the V8 heap.
-		Neither the ordering of heap spaces, nor the availability of a heap space can be guaranteed
-		as the statistics are provided via the V8 `GetHeapSpaceStatistics` function and may change
-		from one V8 version to the next.
 	**/
 	static function getHeapSpaceStatistics():Array<V8HeapSpaceStatistics>;
 
 	/**
-		This method can be used to programmatically set V8 command line flags. This method should be used with care.
-		Changing settings after the VM has started may result in unpredictable behavior, including crashes and data loss;
-		or it may simply do nothing.
+		Get statistics about code and its metadata in the heap, see V8 `GetHeapCodeAndMetadataStatistics`.
+	**/
+	static function getHeapCodeStatistics():V8HeapCodeStatistics;
 
-		The V8 options available for a version of Node.js may be determined by running `node --v8-options`.
+	/**
+		Generates a snapshot of the current V8 heap and returns a Readable stream that may be used to
+		read the JSON serialized representation.
+	**/
+	static function getHeapSnapshot(?options:V8HeapSnapshotOptions):IReadable;
+
+	/**
+		Generates a snapshot of the current V8 heap and writes it to a JSON file.
+		Returns the filename where the snapshot was saved.
+	**/
+	@:overload(function(?options:V8HeapSnapshotOptions):String {})
+	static function writeHeapSnapshot(?filename:String, ?options:V8HeapSnapshotOptions):String;
+
+	/**
+		This method can be used to programmatically set V8 command line flags.
 	**/
 	static function setFlagsFromString(string:String):Void;
+
+	/**
+		The `v8.stopCoverage()` method allows the user to stop collecting coverage, which was started by
+		`NODE_V8_COVERAGE`. While `NODE_V8_COVERAGE` can be used for collecting coverage for both
+		tests (via `node:test`) and application code, this method can be used to stop collecting coverage
+		on either side of that boundary.
+	**/
+	static function stopCoverage():Void;
+
+	/**
+		The `v8.takeCoverage()` method allows the user to write the coverage started by `NODE_V8_COVERAGE`
+		to disk on demand.
+	**/
+	static function takeCoverage():Void;
+
+	/**
+		This API sets a limit for near-heap-limit callback invocations.
+	**/
+	static function setHeapSnapshotNearHeapLimit(limit:Int):Void;
+
+	/**
+		Uses a `DefaultSerializer` to serialize `value` into a buffer.
+	**/
+	static function serialize(value:Dynamic):Buffer;
+
+	/**
+		Uses a `DefaultDeserializer` with default options to read a JS value from a buffer.
+	**/
+	static function deserialize(buffer:Buffer):Dynamic;
+
+	/**
+		This API will find all objects corresponding to the constructor `ctor`.
+	**/
+	static function queryObjects(ctor:Function, ?options:{format:String}):Dynamic;
+
+	/**
+		Tracks `Promise` lifecycle callbacks. Prefer `async_hooks` / `diagnostics_channel` for most apps.
+
+		// TODO(section-5): fully type promiseHooks createHook callbacks
+	**/
+	static var promiseHooks(default, null):V8PromiseHooks;
+
+	/**
+		Startup snapshot builder API (only meaningful when building a snapshot).
+	**/
+	static var startupSnapshot(default, null):V8StartupSnapshot;
+
+	/**
+		Starts a CPU profile and returns a handle that can be used to stop it.
+		// TODO(section-5): type CPUProfileHandle / SyncCPUProfileHandle / HeapProfileHandle
+	**/
+	static function startCpuProfile():V8CpuProfileHandle;
+
+	/**
+		Returns whether the string is stored in one-byte (Latin-1) representation in V8.
+	**/
+	static function isStringOneByteRepresentation(content:String):Bool;
 }
+
+// TODO(section-5): v8.Serializer / Deserializer / DefaultSerializer / DefaultDeserializer / GCProfiler / getCppHeapStatistics
 
 /**
 	Object returned by `V8.getHeapStatistics` method.
 **/
 typedef V8HeapStatistics = {
-	var total_heap_size:Int;
-	var total_heap_size_executable:Int;
-	var total_physical_size:Int;
-	var total_available_size:Int;
-	var used_heap_size:Int;
-	var heap_size_limit:Int;
+	var total_heap_size:Float;
+	var total_heap_size_executable:Float;
+	var total_physical_size:Float;
+	var total_available_size:Float;
+	var used_heap_size:Float;
+	var heap_size_limit:Float;
+	@:optional var malloced_memory:Float;
+	@:optional var peak_malloced_memory:Float;
+	@:optional var does_zap_garbage:Int;
+	@:optional var number_of_native_contexts:Float;
+	@:optional var number_of_detached_contexts:Float;
+	@:optional var total_global_handles_size:Float;
+	@:optional var used_global_handles_size:Float;
+	@:optional var external_memory:Float;
 }
 
 /**
@@ -66,8 +160,53 @@ typedef V8HeapStatistics = {
 **/
 typedef V8HeapSpaceStatistics = {
 	var space_name:String;
-	var space_size:Int;
-	var space_used_size:Int;
-	var space_available_size:Int;
-	var physical_space_size:Int;
+	var space_size:Float;
+	var space_used_size:Float;
+	var space_available_size:Float;
+	var physical_space_size:Float;
 }
+
+/**
+	Object returned by `V8.getHeapCodeStatistics` method.
+**/
+typedef V8HeapCodeStatistics = {
+	var code_and_metadata_size:Float;
+	var bytecode_and_metadata_size:Float;
+	var external_script_source_size:Float;
+	@:optional var cpu_profiler_metadata_size:Float;
+}
+
+typedef V8HeapSnapshotOptions = {
+	/**
+		If true, expose internals in the heap dump. Default: `false`.
+	**/
+	@:optional var exposeInternals:Bool;
+
+	/**
+		If true, expose numeric values in artificial fields. Default: `false`.
+	**/
+	@:optional var exposeNumericValues:Bool;
+}
+
+typedef V8PromiseHooks = {
+	function onInit(init:Function):Function;
+	function onSettled(settled:Function):Function;
+	function onBefore(before:Function):Function;
+	function onAfter(after:Function):Function;
+	function createHook(callbacks:{?init:Function, ?before:Function, ?after:Function, ?settled:Function}):Function;
+}
+
+typedef V8StartupSnapshot = {
+	function addSerializeCallback(callback:Function, ?data:Dynamic):Void;
+	function addDeserializeCallback(callback:Function, ?data:Dynamic):Void;
+	function setDeserializeMainFunction(callback:Function, ?data:Dynamic):Void;
+	function isBuildingSnapshot():Bool;
+}
+
+/**
+	Minimal handle returned by `V8.startCpuProfile`.
+**/
+typedef V8CpuProfileHandle = {
+	function stop():String;
+}
+

--- a/src/js/node/Vm.hx
+++ b/src/js/node/Vm.hx
@@ -22,10 +22,12 @@
 
 package js.node;
 
+import haxe.DynamicAccess;
+import haxe.extern.EitherType;
 import js.node.vm.Script;
 
 /**
-	Options object used by Vm.run* methods.
+	Options object used by `Vm.run*` methods.
 **/
 typedef VmRunOptions = {
 	> ScriptOptions,
@@ -33,8 +35,85 @@ typedef VmRunOptions = {
 }
 
 /**
-	Using this class JavaScript code can be compiled and
-	run immediately or compiled, saved, and run later.
+	Options for `Vm.createContext`.
+**/
+typedef VmCreateContextOptions = {
+	/**
+		Human-readable name of the newly created context. Default: `'VM Context i'`, where `i` is an ascending
+		numerical index of the created context.
+	**/
+	@:optional var name:String;
+
+	/**
+		Origin corresponding to the newly created context for display purposes. The origin should be formatted like a
+		URL, but with only scheme, host, and port (if necessary). Default: `''`.
+	**/
+	@:optional var origin:String;
+
+	/**
+		If set to `true` any wrappers corresponding to `contextObject` properties may be invoked. Default: `false`.
+	**/
+	@:optional var codeGeneration:VmCodeGenerationOptions;
+
+	/**
+		If set to `afterEvaluate`, microtasks will be run immediately after evaluating code on the context
+		(before returning from e.g. `runInContext`). Default: `undefined`.
+	**/
+	@:optional var microtaskMode:String;
+}
+
+typedef VmCodeGenerationOptions = {
+	/**
+		If set to `false` any calls to `eval` or function constructors (`Function`, `GeneratorFunction`, etc) will throw
+		an `EvalError`. Default: `true`.
+	**/
+	@:optional var strings:Bool;
+
+	/**
+		If set to `false` any attempt to compile a WebAssembly module will throw a `WebAssembly.CompileError`.
+		Default: `true`.
+	**/
+	@:optional var wasm:Bool;
+}
+
+/**
+	Options for `Vm.compileFunction`.
+**/
+typedef VmCompileFunctionOptions = {
+	> ScriptOptions,
+	/**
+		Provides an optional data with V8's code cache data for the supplied source.
+	**/
+	@:optional var parsingContext:VmContext<Dynamic>;
+
+	/**
+		An array containing context extension objects. Modules and wrappers used in `code` will be available as if
+		they were referenced from these objects.
+	**/
+	@:optional var contextExtensions:Array<DynamicAccess<Dynamic>>;
+}
+
+/**
+	Options for experimental `Vm.measureMemory`.
+**/
+typedef VmMeasureMemoryOptions = {
+	/**
+		`'summary'` or `'detailed'`. Default: `'summary'`.
+	**/
+	@:optional var mode:String;
+
+	/**
+		`'self'` or `'all'`. Default: `'self'`.
+	**/
+	@:optional var execution:String;
+}
+
+/**
+	The `vm` module enables compiling and running code within V8 Virtual Machine contexts.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/vm.html
+
+	// TODO(section-5): add vm.Module / SourceTextModule / SyntheticModule externs (large experimental surface)
 **/
 @:jsRequire("vm")
 extern class Vm {
@@ -42,51 +121,28 @@ extern class Vm {
 		Compiles `code`, runs it and returns the result.
 		Running code does not have access to local scope.
 
-		`filename` is optional, it's used only in stack traces.
-
-		In case of syntax error in `code` emits the syntax error to stderr and throws an exception.
+		// TODO(section-5): Dynamic is intentional for arbitrary JS eval results; refine per-call sites when possible
 	**/
-	static function runInThisContext(code:String, ?options:VmRunOptions):Dynamic;
+	static function runInThisContext(code:String, ?options:EitherType<String, VmRunOptions>):Dynamic;
 
 	/**
 		Compiles `code`, contextifies `sandbox` if passed or creates a new contextified sandbox if it's omitted,
 		and then runs the code with the sandbox as the global object and returns the result.
-
-		`runInNewContext` takes the same options as `runInThisContext`.
-
-		Note that running untrusted code is a tricky business requiring great care. `runInNewContext` is quite useful,
-		but safely running untrusted code requires a separate process.
 	**/
 	@:overload(function(code:String, ?sandbox:{}):Dynamic {})
 	static function runInNewContext(code:String, sandbox:{}, ?options:VmRunOptions):Dynamic;
 
 	/**
 		Compiles `code`, then runs it in `contextifiedSandbox` and returns the result.
-
-		Running code does not have access to local scope. The `contextifiedSandbox` object must have been previously
-		contextified via `createContext`; it will be used as the global object for code.
-
-		`runInContext` takes the same options as `runInThisContext`.
-
-		Note that running untrusted code is a tricky business requiring great care. `runInContext` is quite useful,
-		but safely running untrusted code requires a separate process.
 	**/
-	static function runInContext(code:String, contextifiedSandbox:VmContext<Dynamic>, ?options:VmRunOptions):Dynamic;
+	static function runInContext(code:String, contextifiedSandbox:VmContext<Dynamic>, ?options:EitherType<String, VmRunOptions>):Dynamic;
 
 	/**
-
-		If given a sandbox object, will "contextify" that sandbox so that it can be used in calls to `runInContext` or
-		`Script.runInContext`. Inside scripts run as such, sandbox will be the global object, retaining all its existing
-		properties but also having the built-in objects and functions any standard global object has. Outside of scripts
-		run by the vm module, sandbox will be unchanged.
-
-		If not given a sandbox object, returns a new, empty contextified sandbox object you can use.
-
-		This function is useful for creating a sandbox that can be used to run multiple scripts, e.g. if you were
-		emulating a web browser it could be used to create a single sandbox representing a window's global object,
-		then run all <script> tags together inside that sandbox.
+		If given a sandbox object, will "contextify" that sandbox so that it can be used in calls to `runInContext`
+		or `Script.runInContext`.
 	**/
-	static function createContext<T:{}>(?sandbox:T):VmContext<T>;
+	@:overload(function():VmContext<Dynamic> {})
+	static function createContext<T:{}>(sandbox:T, ?options:VmCreateContextOptions):VmContext<T>;
 
 	/**
 		Returns whether or not a sandbox object has been contextified by calling `createContext` on it.
@@ -94,16 +150,51 @@ extern class Vm {
 	static function isContext(sandbox:{}):Bool;
 
 	/**
-		Compiles and executes `code` inside the V8 debug context.
-		The primary use case is to get access to the V8 debug object:
-
-		Note that the debug context and object are intrinsically tied to V8's debugger implementation
-		and may change (or even get removed) without prior warning.
+		Compiles the given `code` into a function object that may use the provided `params` as formal parameters
+		and may use the objects in `options.contextExtensions` as its local scope.
 	**/
+	static function compileFunction(code:String, ?params:Array<String>, ?options:VmCompileFunctionOptions):haxe.Constraints.Function;
+
+	/**
+		Measure the known V8 heap memory attributed to this context / all contexts (experimental).
+
+		// TODO(section-5): type Promise result of measureMemory
+	**/
+	static function measureMemory(?options:VmMeasureMemoryOptions):js.lib.Promise<Dynamic>;
+
+	/**
+		Compiles and executes `code` inside the V8 debug context.
+		Removed from modern Node.js versions.
+	**/
+	@:deprecated("Removed from Node.js; do not use")
 	static function runInDebugContext(code:String):Dynamic;
 
 	@:deprecated("use new js.node.vm.Script(...) instead")
-	static function createScript(code:String, ?options:ScriptOptions):Script;
+	static function createScript(code:String, ?options:EitherType<String, ScriptOptions>):Script;
+
+	/**
+		Returns an object containing commonly used constants for VM operations.
+	**/
+	static var constants(default, null):VmConstants;
+}
+
+/**
+	Constants exported by `vm.constants`.
+**/
+typedef VmConstants = {
+	/**
+		A constant that can be used as the `importModuleDynamically` option to `vm.Script`
+		or `vm.compileFunction` so that Node.js uses the default ESM loader from the main context
+		to load the requested module.
+	**/
+	var USE_MAIN_CONTEXT_DEFAULT_LOADER:Dynamic;
+
+	/**
+		When passed as `contextObject` to `vm.createContext()`, this constant creates an empty context
+		with an object wrapper that allows code running in that context to see the outer context's Object
+		prototype methods, but also has its own independent Object/Array prototypes and builtins.
+	**/
+	var DONT_CONTEXTIFY:Dynamic;
 }
 
 /**

--- a/src/js/node/Wasi.hx
+++ b/src/js/node/Wasi.hx
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C)2014-2025 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node;
+
+import haxe.DynamicAccess;
+
+/**
+	WebAssembly System Interface (WASI) support.
+
+	Stability: 1 - Experimental
+
+	The Node.js module exports the `WASI` class. Following HOWTO naming (acronyms not uppercased),
+	the Haxe extern is `js.node.Wasi`.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/wasi.html
+**/
+@:jsRequire("wasi", "WASI")
+extern class Wasi {
+	function new(options:WasiOptions);
+
+	/**
+		Attempt to begin execution of `instance` as a WASI command by invoking its `_start()` export.
+		// TODO(section-5): WebAssembly.Instance typing
+	**/
+	function start(instance:Dynamic):Float;
+
+	/**
+		Attempt to initialize `instance` as a WASI reactor by invoking its `_initialize()` export.
+	**/
+	function initialize(instance:Dynamic):Void;
+
+	/**
+		Set up WASI host bindings to `instance` without calling `initialize()` or `start()`.
+		Added in: v24.4.0
+	**/
+	function finalizeBindings(instance:Dynamic, ?options:{?memory:Dynamic}):Void;
+
+	/**
+		Return an import object that can be passed to `WebAssembly.instantiate()`.
+		// TODO(section-5): WebAssembly.Imports typing
+	**/
+	function getImportObject():Dynamic;
+
+	/**
+		An object that implements the WASI system call API.
+		// TODO(section-5): WASI import object field typing
+	**/
+	var wasiImport(default, null):DynamicAccess<Dynamic>;
+}
+
+enum abstract WasiVersion(String) from String to String {
+	var Preview1 = "preview1";
+	var Unstable = "unstable";
+}
+
+typedef WasiOptions = {
+	/**
+		The version of WASI requested. Currently the only supported versions are `'unstable'` and `'preview1'`.
+		This option is mandatory.
+	**/
+	var version:WasiVersion;
+
+	@:optional var args:Array<String>;
+	@:optional var env:DynamicAccess<String>;
+	@:optional var preopens:DynamicAccess<String>;
+	@:optional var returnOnExit:Bool;
+	@:optional var stdin:Int;
+	@:optional var stdout:Int;
+	@:optional var stderr:Int;
+}

--- a/src/js/node/WorkerThreads.hx
+++ b/src/js/node/WorkerThreads.hx
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C)2014-2025 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node;
+
+import js.lib.Promise;
+import js.lib.Symbol;
+import js.node.Vm.VmContext;
+import js.node.worker_threads.MessagePort;
+import js.node.worker_threads.Worker;
+
+/**
+	The `node:worker_threads` module enables the use of threads that execute JavaScript in parallel.
+
+	Core surface for Node.js 24+. Transfer lists and posted values remain loosely typed
+	because structured clone accepts many object graphs.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/worker_threads.html
+**/
+@:jsRequire("worker_threads")
+extern class WorkerThreads {
+	static final parentPort:Null<MessagePort>;
+
+	/**
+		// TODO(section-5): workerData is application-defined; typed as Dynamic
+	**/
+	static final workerData:Dynamic;
+
+	static final isMainThread:Bool;
+	static final isInternalThread:Bool;
+	static final threadId:Int;
+	static final threadName:Null<String>;
+	static final SHARE_ENV:Symbol;
+	static final resourceLimits:WorkerResourceLimits;
+
+	/**
+		// TODO(section-5): environment data value typing is application-defined
+	**/
+	static function getEnvironmentData(key:Dynamic):Dynamic;
+
+	static function setEnvironmentData(key:Dynamic, ?value:Dynamic):Void;
+	static function markAsUntransferable(object:Dynamic):Void;
+	static function isMarkedAsUntransferable(object:Dynamic):Bool;
+	static function markAsUncloneable(object:Dynamic):Void;
+
+	/**
+		// TODO(section-5): transferList typing for structured clone
+	**/
+	static function postMessageToThread(threadId:Int, value:Dynamic, ?transferList:Array<Dynamic>, ?timeout:Int):Promise<Void>;
+
+	static function receiveMessageOnPort(port:MessagePort):Null<{message:Dynamic}>;
+	static function moveMessagePortToContext(port:MessagePort, contextifiedSandbox:VmContext<Dynamic>):MessagePort;
+}
+
+typedef WorkerResourceLimits = {
+	@:optional var maxOldGenerationSizeMb:Float;
+	@:optional var maxYoungGenerationSizeMb:Float;
+	@:optional var codeRangeSizeMb:Float;
+	@:optional var stackSizeMb:Float;
+}
+
+// TODO(section-5): BroadcastChannel / locks / Worker performance profiling APIs

--- a/src/js/node/async_hooks/AsyncHook.hx
+++ b/src/js/node/async_hooks/AsyncHook.hx
@@ -20,29 +20,19 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-package js.node.readline;
-
-import js.lib.Promise;
-import js.node.readline.Interface;
-import js.node.web.AbortSignal;
+package js.node.async_hooks;
 
 /**
-	Instances of `readlinePromises.Interface` are constructed using
-	`ReadlinePromises.createInterface()`.
-
-	Differs from `readline.Interface` mainly in that `question` returns a `Promise`.
-
-	@see https://nodejs.org/docs/latest-v24.x/api/readline.html#class-readlinepromisesinterface
+	The callbacks registered via `AsyncHooks.createHook` return an `AsyncHook` instance.
 **/
-@:jsRequire("readline/promises", "Interface")
-extern class PromisesInterface extends Interface {
+extern class AsyncHook {
 	/**
-		Displays `query` by writing it to `output`, waits for user input on `input`,
-		then fulfills with the provided input.
-
-		When called, resumes the `input` stream if it has been paused.
-		If called after `close()`, returns a rejected promise.
+		Enable the callbacks for a given `AsyncHook` instance.
 	**/
-	@:overload(function(query:String):Promise<String> {})
-	function question(query:String, options:{?signal:AbortSignal}):Promise<String>;
+	function enable():AsyncHook;
+
+	/**
+		Disable the callbacks for a given `AsyncHook` instance.
+	**/
+	function disable():AsyncHook;
 }

--- a/src/js/node/async_hooks/AsyncLocalStorage.hx
+++ b/src/js/node/async_hooks/AsyncLocalStorage.hx
@@ -20,29 +20,34 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-package js.node.readline;
+package js.node.async_hooks;
 
-import js.lib.Promise;
-import js.node.readline.Interface;
-import js.node.web.AbortSignal;
+import haxe.Constraints.Function;
 
 /**
-	Instances of `readlinePromises.Interface` are constructed using
-	`ReadlinePromises.createInterface()`.
+	Async local storage stores shared context across callbacks / promise chains.
 
-	Differs from `readline.Interface` mainly in that `question` returns a `Promise`.
-
-	@see https://nodejs.org/docs/latest-v24.x/api/readline.html#class-readlinepromisesinterface
+	@see https://nodejs.org/docs/latest-v24.x/api/async_hooks.html#class-asynclocalstorage
 **/
-@:jsRequire("readline/promises", "Interface")
-extern class PromisesInterface extends Interface {
-	/**
-		Displays `query` by writing it to `output`, waits for user input on `input`,
-		then fulfills with the provided input.
+@:jsRequire("async_hooks", "AsyncLocalStorage")
+extern class AsyncLocalStorage<T> {
+	function new():Void;
 
-		When called, resumes the `input` stream if it has been paused.
-		If called after `close()`, returns a rejected promise.
+	/**
+		Runs a function synchronously within a context and returns its return value.
+		// TODO(section-5): model variadic args without Rest for broader Haxe 4.0.x coverage
 	**/
-	@:overload(function(query:String):Promise<String> {})
-	function question(query:String, options:{?signal:AbortSignal}):Promise<String>;
+	function run<R>(store:T, callback:Function, ?args:Array<Dynamic>):R;
+
+	function enterWith(store:T):Void;
+
+	function exit<R>(callback:Function, ?args:Array<Dynamic>):R;
+
+	function getStore():Null<T>;
+
+	function disable():Void;
+
+	static function bind<F:Function>(fn:F):F;
+
+	static function snapshot():Function;
 }

--- a/src/js/node/async_hooks/AsyncResource.hx
+++ b/src/js/node/async_hooks/AsyncResource.hx
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.async_hooks;
+
+import haxe.Constraints.Function;
+import haxe.extern.EitherType;
+
+/**
+	The class `AsyncResource` is designed to be extended by the embedder's async resources.
+	Using this, users can easily trigger the lifetime events of their own resources.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/async_hooks.html#class-asyncresource
+**/
+@:jsRequire("async_hooks", "AsyncResource")
+extern class AsyncResource {
+	/**
+		Create a new `AsyncResource` object.
+	**/
+	function new(type:String, ?options:EitherType<Float, AsyncResourceOptions>);
+
+	/**
+		Call the provided function with the provided arguments in the execution context of the async resource.
+		// TODO(section-5): type Rest args more precisely when binding helpers are standardized
+	**/
+	function runInAsyncScope(fn:Function, ?thisArg:Dynamic, ?args:Array<Dynamic>):Dynamic;
+
+	/**
+		Call `AsyncHooks.emitDestroy()` after binding / pending work is finished.
+	**/
+	function emitDestroy():AsyncResource;
+
+	/**
+		Returns the unique `asyncId` assigned to the resource.
+	**/
+	function asyncId():Float;
+
+	/**
+		Returns the trigger `asyncId` of the resource.
+	**/
+	function triggerAsyncId():Float;
+
+	/**
+		Binds the given function to execute within this async resource's stack.
+	**/
+	function bind(fn:Function, ?thisArg:Dynamic):Function;
+
+	/**
+		Binds the given function to execute within a given execution context of an async resource.
+	**/
+	@:native("bind")
+	static function bindStatic(fn:Function, type:EitherType<String, AsyncResource>, ?thisArg:Dynamic):Function;
+}
+
+typedef AsyncResourceOptions = {
+	/**
+		The ID of the execution context that created this async event. Default: `executionAsyncId()`.
+	**/
+	@:optional var triggerAsyncId:Float;
+
+	/**
+		Disables automatic `emitDestroy` when the object is garbage collected.
+		This usually means the resource has to manually call `emitDestroy()`. Default: `false`.
+	**/
+	@:optional var requireManualDestroy:Bool;
+}

--- a/src/js/node/child_process/ChildProcess.hx
+++ b/src/js/node/child_process/ChildProcess.hx
@@ -22,15 +22,12 @@
 
 package js.node.child_process;
 
+import haxe.extern.EitherType;
+import js.lib.Error;
 import js.node.Stream;
 import js.node.events.EventEmitter;
 import js.node.stream.Readable;
 import js.node.stream.Writable;
-#if haxe4
-import js.lib.Error;
-#else
-import js.Error;
-#end
 
 /**
 	Enumeration of events emitted by `ChildProcess` objects.
@@ -42,7 +39,7 @@ enum abstract ChildProcessEvent<T:haxe.Constraints.Function>(Event<T>) to Event<
 			2. The process could not be killed, or
 			3. Sending a message to the child process failed for whatever reason.
 
-		Note that the exit-event may or may not fire after an error has occured.
+		Note that the exit-event may or may not fire after an error has occurred.
 		If you are listening on both events to fire a function, remember to guard against calling your function twice.
 
 		See also `ChildProcess.kill` and `ChildProcess.send`.
@@ -55,27 +52,14 @@ enum abstract ChildProcessEvent<T:haxe.Constraints.Function>(Event<T>) to Event<
 		Listener arguments:
 			code - the exit code, if it exited normally.
 			signal - the signal passed to kill the child process, if it was killed by the parent.
-
-		If the process terminated normally, `code` is the final exit code of the process, otherwise null.
-		If the process terminated due to receipt of a signal, `signal` is the string name of the signal, otherwise null.
-
-		Note that the child process stdio streams might still be open.
-
-		Also, note that node establishes signal handlers for 'SIGINT' and 'SIGTERM',
-		so it will not terminate due to receipt of those signals, it will exit.
-		See waitpid(2).
 	**/
-	var Exit:ChildProcessEvent<Int->String->Void> = "exit";
+	var Exit:ChildProcessEvent<Null<Int>->Null<String>->Void> = "exit";
 
 	/**
 		This event is emitted when the stdio streams of a child process have all terminated.
 		This is distinct from `Exit`, since multiple processes might share the same stdio streams.
-
-		Listener arguments:
-			code - the exit code, if it exited normally.
-			signal - the signal passed to kill the child process, if it was killed by the parent.
 	**/
-	var Close:ChildProcessEvent<Int->String->Void> = "close";
+	var Close:ChildProcessEvent<Null<Int>->Null<String>->Void> = "close";
 
 	/**
 		This event is emitted after calling the `disconnect` method in the parent or in the child.
@@ -86,13 +70,20 @@ enum abstract ChildProcessEvent<T:haxe.Constraints.Function>(Event<T>) to Event<
 	/**
 		Messages send by `send` are obtained using the message event.
 
-		This event can also be listened on the `process` object to receive messages from the parent.
-
 		Listener arguments:
 			message - a parsed JSON object or primitive value
 			sendHandle - a Socket or Server object
+
+		// TODO(section-5): tighten message/sendHandle typing beyond Dynamic once IPC handle unions are modeled
 	**/
 	var Message:ChildProcessEvent<Dynamic->Dynamic->Void> = "message";
+
+	/**
+		The `'spawn'` event is emitted once the child process has spawned successfully.
+		If the child process does not spawn successfully, the `'spawn'` event is not emitted
+		and the `'error'` event is emitted instead.
+	**/
+	var Spawn:ChildProcessEvent<Void->Void> = "spawn";
 }
 
 typedef ChildProcessSendOptions = {
@@ -111,6 +102,8 @@ typedef ChildProcessSendOptions = {
 
 	The `ChildProcess` class is not intended to be used directly. Use the spawn() or fork() module methods
 	to create a `ChildProcess` instance.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/child_process.html#class-childprocess
 **/
 extern class ChildProcess extends EventEmitter<ChildProcess> {
 	/**
@@ -119,102 +112,116 @@ extern class ChildProcess extends EventEmitter<ChildProcess> {
 
 		If the child stdio streams are shared with the parent, then this will not be set.
 	**/
-	var stdin(default, null):IWritable;
+	var stdin(default, null):Null<IWritable>;
 
 	/**
 		A Readable Stream that represents the child process's stdout.
 
 		If the child stdio streams are shared with the parent, then this will not be set.
 	**/
-	var stdout(default, null):IReadable;
+	var stdout(default, null):Null<IReadable>;
 
 	/**
 		A Readable Stream that represents the child process's stderr.
 
 		If the child stdio streams are shared with the parent, then this will not be set.
 	**/
-	var stderr(default, null):IReadable;
+	var stderr(default, null):Null<IReadable>;
 
 	/**
-		The parent end of the stdio pipes.
+		A sparse array of pipes to the child process, corresponding with positions
+		in the `stdio` option that have been set to the value `'pipe'`.
 	**/
-	var stdio(default, null):Array<IStream>;
+	var stdio(default, null):Array<Null<IStream>>;
 
 	/**
 		The PID of the child process.
+
+		If the child process could not be spawned successfully, then the value is `undefined`.
 	**/
-	var pid(default, null):Int;
+	var pid(default, null):Null<Int>;
 
 	/**
-		Set to false after `disconnect' is called
+		Set to false after `disconnect` is called.
 		If `connected` is false, it is no longer possible to send messages.
 	**/
 	var connected(default, null):Bool;
 
 	/**
-		Send a signal to the child process.
-
-		If no argument is given, the process will be sent 'SIGTERM'.
-		See signal(7) for a list of available signals.
-
-		May emit an 'error' event when the signal cannot be delivered.
-
-		Sending a signal to a child process that has already exited is not an error
-		but may have unforeseen consequences: if the PID (the process ID) has been reassigned to another process,
-		the signal will be delivered to that process instead. What happens next is anyone's guess.
-
-		Note that while the function is called `kill`, the signal delivered to the child process may not actually kill it.
-		`kill` really just sends a signal to a process. See kill(2)
+		The `subprocess.killed` property indicates whether the child process successfully received
+		a signal from `subprocess.kill()`. The `killed` property does not indicate that the child process
+		has been terminated.
 	**/
-	function kill(?signal:String):Void;
+	var killed(default, null):Bool;
 
 	/**
-		When using `fork` you can write to the child using `send` and messages are received by a 'message' event on the child.
-
-		In the child the `Process` object will have a `send` method, and process will emit objects each time it receives
-		a message on its channel.
-
-		Please note that the `send` method on both the parent and child are synchronous - sending large chunks of data is
-		not advised (pipes can be used instead, see `spawn`).
-
-		There is a special case when sending a {cmd: 'NODE_foo'} `message`. All messages containing a `NODE_` prefix in
-		its cmd property will not be emitted in the 'message' event, since they are internal messages used by node core.
-		Messages containing the prefix are emitted in the 'internalMessage' event, you should by all means avoid using
-		this feature, it is subject to change without notice.
-
-		The `sendHandle` option is for sending a TCP server or socket object to another process.
-		The child will receive the object as its second argument to the message event.
-
-		The `callback` option is a function that is invoked after the message is sent but before the target may have received it.
-		It is called with a single argument: null on success, or an `Error` object on failure.
-
-		Emits an 'error' event if the message cannot be sent, for example because the child process has already exited.
-
-		Returns true under normal circumstances or false when the backlog of unsent messages exceeds a threshold that
-		makes it unwise to send more. Use the callback mechanism to implement flow control.
+		The `subprocess.exitCode` property indicates the exit code of the child process.
+		If the child process is still running, the field will be `null`.
 	**/
-	@:overload(function(message:Dynamic, sendHandle:Dynamic, options:ChildProcessSendOptions, ?callback:Error->Void):Bool {})
-	@:overload(function(message:Dynamic, sendHandle:Dynamic, ?callback:Error->Void):Bool {})
-	function send(message:Dynamic, ?callback:Error->Void):Bool;
+	var exitCode(default, null):Null<Int>;
+
+	/**
+		The `subprocess.signalCode` property indicates the signal that caused the child process to terminate,
+		or `null` if it terminated normally.
+	**/
+	var signalCode(default, null):Null<String>;
+
+	/**
+		The executable file name of the child process that is launched.
+
+		For example, on Linux this would be `'bin/bash'` when spawning bash. For `fork()`, it would be the path
+		to the `node` binary.
+	**/
+	var spawnfile(default, null):String;
+
+	/**
+		The command-line arguments of the child process.
+	**/
+	var spawnargs(default, null):Array<String>;
+
+	/**
+		While the IPC channel established by `fork` is open, this is a reference to that channel.
+		Otherwise `null`.
+	**/
+	// TODO(section-5): type IPC channel pipe more precisely than Null<Dynamic>
+	var channel(default, null):Null<Dynamic>;
+
+	/**
+		Send a signal to the child process.
+
+		If no argument is given, the process will be sent `'SIGTERM'`.
+		See signal(7) for a list of available signals.
+
+		Returns `true` if `kill()` succeeded, else `false`.
+	**/
+	function kill(?signal:EitherType<String, Int>):Bool;
+
+	/**
+		When using `fork` you can write to the child using `send`
+		and messages are received by a `'message'` event on the child.
+
+		// TODO(section-5): replace Dynamic message/sendHandle with structured IPC types
+	**/
+	@:overload(function(message:Dynamic, sendHandle:Dynamic, options:ChildProcessSendOptions, ?callback:Null<Error>->Void):Bool {})
+	@:overload(function(message:Dynamic, sendHandle:Dynamic, ?callback:Null<Error>->Void):Bool {})
+	function send(message:Dynamic, ?callback:Null<Error>->Void):Bool;
 
 	/**
 		Close the IPC channel between parent and child, allowing the child to exit gracefully once there are no other
 		connections keeping it alive.
-
-		After calling this method the `connected` flag will be set to false in both the parent and child,
-		and it is no longer possible to send messages.
-
-		The 'disconnect' event will be emitted when there are no messages in the process of being received,
-		most likely immediately.
-
-		Note that you can also call `process.disconnect` in the child process.
 	**/
 	function disconnect():Void;
 
 	/**
 		By default, the parent will wait for the detached child to exit.
-		To prevent the parent from waiting for a given child, use the `unref` method,
-		and the parent's event loop will not include the child in its reference count.
+		To prevent the parent from waiting for a given child, use the `unref` method.
 	**/
 	function unref():Void;
+
+	/**
+		Opposite of `unref()`. Calls reference the child from the parent's event loop so that
+		the parent will wait for the child to exit before exiting itself
+		(unless there are other references keeping the parent alive).
+	**/
+	function ref():Void;
 }

--- a/src/js/node/cluster/Worker.hx
+++ b/src/js/node/cluster/Worker.hx
@@ -22,16 +22,16 @@
 
 package js.node.cluster;
 
+import js.lib.Error;
 import js.node.Cluster.ListeningEventAddress;
 import js.node.child_process.ChildProcess;
 import js.node.events.EventEmitter;
-#if haxe4
-import js.lib.Error;
-#else
-import js.Error;
-#end
 
+/**
+	@see https://nodejs.org/docs/latest-v24.x/api/cluster.html#class-worker
+**/
 enum abstract WorkerEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
+	// TODO(section-5): tighten message/handle typing beyond Dynamic
 	var Message:WorkerEvent<Dynamic->Dynamic->Void> = "message";
 	var Online:WorkerEvent<Void->Void> = "online";
 	var Listening:WorkerEvent<ListeningEventAddress->Void> = "listening";
@@ -42,7 +42,7 @@ enum abstract WorkerEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 
 /**
 	A Worker object contains all public information and method about a worker.
-	In the master it can be obtained using `Cluster.workers`.
+	In the primary it can be obtained using `Cluster.workers`.
 	In a worker it can be obtained using `Cluster.worker`.
 **/
 extern class Worker extends EventEmitter<Worker> {
@@ -51,50 +51,41 @@ extern class Worker extends EventEmitter<Worker> {
 
 		While a worker is alive, this is the key that indexes it in `Cluster.workers`
 	**/
-	var id(default, null):String;
+	var id(default, null):Int;
 
 	/**
 		All workers are created using `ChildProcess.fork`, the returned object from this function is stored as `process`.
 		In a worker, the global process is stored.
-
-		Note that workers will call `process.exit(0)` if the 'disconnect' event occurs on process
-		and `suicide` is not true. This protects against accidental disconnection.
 	**/
 	var process:ChildProcess;
 
 	/**
-		Set by calling `kill` or `disconnect`, until then it is undefined.
-
-		Lets you distinguish between voluntary and accidental exit, the master may choose
-		not to respawn a worker based on this value.
-
-		(an alias to `exitedAfterDisconnect` in newer node.js versions)
+		Deprecated alias for `exitedAfterDisconnect`.
 	**/
+	@:deprecated("Use exitedAfterDisconnect instead")
 	var suicide:Null<Bool>;
 
 	/**
-		Set by calling `kill` or `disconnect`. Until then, it is undefined.
+		Set by calling `kill` or `disconnect`. Until then, it is `undefined`.
 
-		Lets you distinguish between voluntary and accidental exit, the master may choose
+		Lets you distinguish between voluntary and accidental exit, the primary may choose
 		not to respawn a worker based on this value.
 	**/
 	var exitedAfterDisconnect:Null<Bool>;
 
 	/**
 		This function is equal to the `send` methods provided by `ChildProcess.fork`.
-		In the master you should use this function to send a `message` to a specific worker.
+		In the primary you should use this function to send a `message` to a specific worker.
 
-		In a worker you can also use `process.send`, it is the same function.
+		// TODO(section-5): replace Dynamic message/sendHandle with structured IPC types
 	**/
-	@:overload(function(message:Dynamic, sendHandle:Dynamic, ?callback:Error->Void):Bool {})
-	function send(message:Dynamic, ?callback:Error->Void):Bool;
+	@:overload(function(message:Dynamic, sendHandle:Dynamic, ?callback:Null<Error>->Void):Bool {})
+	function send(message:Dynamic, ?callback:Null<Error>->Void):Bool;
 
 	/**
-		This function will kill the worker. In the master, it does this by disconnecting the `worker.process`,
+		This function will kill the worker. In the primary, it does this by disconnecting the `worker.process`,
 		and once disconnected, killing with `signal`. In the worker, it does it by disconnecting the channel,
 		and then exiting with code 0.
-
-		Causes `suicide` to be set.
 	**/
 	function kill(?signal:String):Void;
 
@@ -102,17 +93,12 @@ extern class Worker extends EventEmitter<Worker> {
 		In a worker, this function will close all servers, wait for the 'close' event on those servers,
 		and then disconnect the IPC channel.
 
-		In the master, an internal message is sent to the worker causing it to call `disconnect` on itself.
-
-		Causes `suicide` to be set.
+		Returns a reference to `worker`.
 	**/
-	function disconnect():Void;
+	function disconnect():Worker;
 
 	/**
-		This function returns true if the worker is connected to its master via its IPC channel, false otherwise
-
-		A worker is connected to its master after it's been created.
-		It is disconnected after the 'disconnect' event is emitted.
+		This function returns true if the worker is connected to its primary via its IPC channel, false otherwise.
 	**/
 	function isConnected():Bool;
 

--- a/src/js/node/domain/Domain.hx
+++ b/src/js/node/domain/Domain.hx
@@ -29,7 +29,7 @@ import js.node.events.EventEmitter;
 /**
 	Enumeration of events emitted by `Domain` objects.
 **/
-@:deprecated
+@:deprecated("The domain module is deprecated. Use AsyncLocalStorage / async_hooks instead.")
 enum abstract DomainEvent<T:Function>(Event<T>) to Event<T> {
 	var Error:DomainEvent<DomainError->Void> = "error";
 	var Dispose:DomainEvent<Void->Void> = "dispose";
@@ -38,7 +38,7 @@ enum abstract DomainEvent<T:Function>(Event<T>) to Event<T> {
 /**
 	Any time an Error object is routed through a domain, a few extra fields are added to it.
 **/
-@:deprecated
+@:deprecated("The domain module is deprecated. Use AsyncLocalStorage / async_hooks instead.")
 typedef DomainError = {
 	/**
 		The domain that first handled the error.
@@ -65,7 +65,7 @@ typedef DomainError = {
 	The Domain class encapsulates the functionality of routing errors
 	and uncaught exceptions to the active Domain object.
 **/
-@:deprecated
+@:deprecated("The domain module is deprecated. Use AsyncLocalStorage / async_hooks instead.")
 extern class Domain extends EventEmitter<Domain> {
 	/**
 		Run the supplied function in the context of the domain, implicitly binding all event emitters, timers,

--- a/src/js/node/readline/Interface.hx
+++ b/src/js/node/readline/Interface.hx
@@ -24,60 +24,52 @@ package js.node.readline;
 
 import js.node.Buffer;
 import js.node.events.EventEmitter;
+import js.node.web.AbortSignal;
 
 /**
 	Enumeration of events emitted by the `Interface` objects.
 **/
 enum abstract InterfaceEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 	/**
-		The `'close'` event is emitted when one of the following occur:
-
-		@see https://nodejs.org/api/readline.html#readline_event_close
+		The `'close'` event is emitted when one of the following occur.
 	**/
 	var Close:InterfaceEvent<Void->Void> = "close";
 
 	/**
 		The `'line'` event is emitted whenever the `input` stream receives an end-of-line input (`\n`, `\r`, or `\r\n`).
-
-		@see https://nodejs.org/api/readline.html#readline_event_line
 	**/
 	var Line:InterfaceEvent<String->Void> = "line";
 
 	/**
-		The `'pause'` event is emitted when one of the following occur:
+		The `'history'` event is emitted when the history array has changed.
+	**/
+	var History:InterfaceEvent<Array<String>->Void> = "history";
 
-		@see https://nodejs.org/api/readline.html#readline_event_pause
+	/**
+		The `'pause'` event is emitted when one of the following occur.
 	**/
 	var Pause:InterfaceEvent<Void->Void> = "pause";
 
 	/**
 		The `'resume'` event is emitted whenever the `input` stream is resumed.
-
-		@see https://nodejs.org/api/readline.html#readline_event_resume
 	**/
 	var Resume:InterfaceEvent<Void->Void> = "resume";
 
 	/**
 		The `'SIGCONT'` event is emitted when a Node.js process previously moved into the background using `<ctrl>-Z`
 		(i.e. `SIGTSTP`) is then brought back to the foreground using `fg(1p)`.
-
-		@see https://nodejs.org/api/readline.html#readline_event_sigcont
 	**/
 	var SIGCONT:InterfaceEvent<Void->Void> = "SIGCONT";
 
 	/**
 		The `'SIGINT'` event is emitted whenever the `input` stream receives a `<ctrl>-C` input, known typically as
 		`SIGINT`.
-
-		@see https://nodejs.org/api/readline.html#readline_event_sigint
 	**/
 	var SIGINT:InterfaceEvent<Void->Void> = "SIGINT";
 
 	/**
 		The `'SIGTSTP'` event is emitted when the `input` stream receives a `<ctrl>-Z` input, typically known as
 		`SIGTSTP`.
-
-		@see https://nodejs.org/api/readline.html#readline_event_sigtstp
 	**/
 	var SIGTSTP:InterfaceEvent<Void->Void> = "SIGTSTP";
 }
@@ -85,67 +77,80 @@ enum abstract InterfaceEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> 
 /**
 	Instances of the `readline.Interface` class are constructed using the `readline.createInterface()` method.
 
-	@see https://nodejs.org/api/readline.html#readline_class_interface
+	@see https://nodejs.org/docs/latest-v24.x/api/readline.html#class-interfaceconstructor
 **/
 extern class Interface extends EventEmitter<Interface> {
 	/**
+		The current input line buffered by `readline` (without a trailing newline).
+	**/
+	var line(default, null):String;
+
+	/**
+		The current cursor position relative to `line`.
+	**/
+	var cursor(default, null):Int;
+
+	/**
 		The `rl.close()` method closes the `readline.Interface` instance and relinquishes control over the `input` and
 		`output` streams.
-
-		@see https://nodejs.org/api/readline.html#readline_rl_close
 	**/
 	function close():Void;
 
 	/**
 		The `rl.pause()` method pauses the `input` stream, allowing it to be resumed later if necessary.
-
-		@see https://nodejs.org/api/readline.html#readline_rl_pause
 	**/
 	function pause():Void;
 
 	/**
 		The `rl.prompt()` method writes the `readline.Interface` instances configured `prompt` to a new line in `output`
 		in order to provide a user with a new location at which to provide input.
-
-		@see https://nodejs.org/api/readline.html#readline_rl_prompt_preservecursor
 	**/
 	function prompt(?preserveCursor:Bool):Void;
 
 	/**
 		The `rl.question()` method displays the `query` by writing it to the `output`, waits for user `input` to be
 		provided on input, then invokes the `callback` function passing the provided input as the first argument.
-
-		@see https://nodejs.org/api/readline.html#readline_rl_question_query_callback
 	**/
-	function question(query:String, callback:String->Void):Void;
+	@:overload(function(query:String, callback:String->Void):Void {})
+	function question(query:String, options:{?signal:AbortSignal}, callback:String->Void):Void;
 
 	/**
 		The `rl.resume()` method resumes the `input` stream if it has been paused.
-
-		@see https://nodejs.org/api/readline.html#readline_rl_resume
 	**/
 	function resume():Void;
 
 	/**
 		The `rl.setPrompt()` method sets the prompt that will be written to `output` whenever `rl.prompt()` is called.
-
-		@see https://nodejs.org/api/readline.html#readline_rl_setprompt_prompt
 	**/
 	function setPrompt(prompt:String):Void;
 
 	/**
-		The `rl.write()` method write either `data` or a key sequence identified by `key` to the `output`.
+		Returns the current prompt used by `rl.prompt()`.
+	**/
+	function getPrompt():String;
 
-		@see https://nodejs.org/api/readline.html#readline_rl_write_data_key
+	/**
+		Returns the real position of the cursor relative to the input prompt + string.
+	**/
+	function getCursorPos():InterfaceCursorPos;
+
+	/**
+		The `rl.write()` method write either `data` or a key sequence identified by `key` to the `output`.
 	**/
 	@:overload(function(data:Buffer, ?key:InterfaceWriteKey):Void {})
-	function write(data:String, ?key:InterfaceWriteKey):Void;
+	function write(data:Null<String>, ?key:InterfaceWriteKey):Void;
+}
+
+/**
+	Cursor position returned by `Interface.getCursorPos`.
+**/
+typedef InterfaceCursorPos = {
+	var rows:Int;
+	var cols:Int;
 }
 
 /**
 	Key sequence passed as the `key` argument to `Interface.write`.
-
-	@see https://nodejs.org/api/readline.html#readline_rl_write_data_key
 **/
 typedef InterfaceWriteKey = {
 	/**
@@ -155,7 +160,7 @@ typedef InterfaceWriteKey = {
 
 	/**
 		`true` to indicate the <Meta> key.
-	 */
+	**/
 	@:optional var meta:Bool;
 
 	/**

--- a/src/js/node/readline/PromisesReadline.hx
+++ b/src/js/node/readline/PromisesReadline.hx
@@ -22,13 +22,9 @@
 
 package js.node.readline;
 
+import js.lib.Promise;
 import js.node.Readline.ClearLineDirection;
 import js.node.stream.Writable.IWritable;
-#if haxe4
-import js.lib.Promise;
-#else
-import js.Promise;
-#end
 
 /**
 	Options for constructing a `PromisesReadline`.
@@ -44,7 +40,7 @@ typedef PromisesReadlineOptions = {
 	The `readlinePromises.Readline` class provides an abstraction for collecting
 	pending actions on a TTY stream and applying them with `commit()`.
 
-	@see https://nodejs.org/api/readline.html#class-readlinepromisesreadline
+	@see https://nodejs.org/docs/latest-v24.x/api/readline.html#class-readlinepromisesreadline
 **/
 @:jsRequire("readline/promises", "Readline")
 extern class PromisesReadline {

--- a/src/js/node/repl/REPLServer.hx
+++ b/src/js/node/repl/REPLServer.hx
@@ -23,12 +23,8 @@
 package js.node.repl;
 
 import haxe.DynamicAccess;
-import js.node.events.EventEmitter;
-#if haxe4
 import js.lib.Error;
-#else
-import js.Error;
-#end
+import js.node.events.EventEmitter;
 
 /**
 	Enumeration of events emitted by the `REPLServer` objects.
@@ -37,32 +33,22 @@ enum abstract REPLServerEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T>
 	/**
 		The `'exit'` event is emitted when the REPL is exited either by receiving the `.exit` command as input,
 		the user pressing `<ctrl>-C` twice to signal `SIGINT`, or by pressing `<ctrl>-D` to signal 'end' on the input stream.
-		The listener callback is invoked without any arguments.
-
-		@see https://nodejs.org/api/repl.html#repl_event_exit
 	**/
 	var Exit:REPLServerEvent<Void->Void> = "exit";
 
 	/**
 		The `'reset'` event is emitted when the REPL's context is reset.
-		This occurs whenever the `.clear` command is received as input unless the REPL is using the default evaluator
-		and the `repl.REPLServer` instance was created with the `useGlobal` option set to `true`.
-		The listener callback will be called with a reference to the `context` object as the only argument.
 
-		@see https://nodejs.org/api/repl.html#repl_event_reset
+		// TODO(section-5): type context beyond DynamicAccess<Dynamic>
 	**/
-	#if haxe4
 	var Reset:REPLServerEvent<(context:DynamicAccess<Dynamic>) -> Void> = "reset";
-	#else
-	var Reset:REPLServerEvent<DynamicAccess<Dynamic>->Void> = "reset";
-	#end
 }
 
 /**
 	Instances of `repl.REPLServer` are created using the `repl.start()` method and should not be created directly using
 	the JavaScript `new` keyword.
 
-	@see https://nodejs.org/api/repl.html#repl_class_replserver
+	@see https://nodejs.org/docs/latest-v24.x/api/repl.html#class-replserver
 **/
 @:jsRequire("repl", "REPLServer")
 extern class REPLServer extends EventEmitter<REPLServer> {
@@ -70,53 +56,34 @@ extern class REPLServer extends EventEmitter<REPLServer> {
 		It is possible to expose a variable to the REPL explicitly by assigning it to the `context` object associated
 		with each `REPLServer`.
 
-		@see https://nodejs.org/api/repl.html#repl_global_and_local_scope
+		// TODO(section-5): type context beyond DynamicAccess<Dynamic>
 	**/
 	var context(default, null):DynamicAccess<Dynamic>;
 
 	/**
 		The `replServer.defineCommand()` method is used to add new `.`-prefixed commands to the REPL instance.
-
-		@see https://nodejs.org/api/repl.html#repl_replserver_definecommand_keyword_cmd
 	**/
-	#if haxe4
 	@:overload(function(keyword:String, cmd:(rest:String) -> Void):Void {})
-	#else
-	@:overload(function(keyword:String, cmd:String->Void):Void {})
-	#end
 	function defineCommand(keyword:String, cmd:REPLServerOptions):Void;
 
 	/**
-		The `replServer.displayPrompt()` method readies the REPL instance for input from the user, printing the
-		configured `prompt` to a new line in the `output` and resuming the `input` to accept new input.
-
-		@see https://nodejs.org/api/repl.html#repl_replserver_displayprompt_preservecursor
+		The `replServer.displayPrompt()` method readies the REPL instance for input from the user.
 	**/
 	function displayPrompt(?preserveCursor:Bool):Void;
 
 	/**
 		The `replServer.clearBufferedCommand()` method clears any command that has been buffered but not yet executed.
-
-		@see https://nodejs.org/api/repl.html#repl_replserver_clearbufferedcommand
 	**/
 	function clearBufferedCommand():Void;
 
 	/**
 		Initializes a history log file for the REPL instance.
-
-		@see https://nodejs.org/api/repl.html#repl_replserver_setuphistory_historypath_callback
 	**/
-	#if haxe4
 	function setupHistory(historyPath:String, callback:(err:Null<Error>, repl:Null<REPLServer>) -> Void):Void;
-	#else
-	function setupHistory(historyPath:String, callback:Null<Error>->Null<REPLServer>->Void):Void;
-	#end
 }
 
 /**
 	Options object used by `REPLServer.defineCommand`.
-
-	@see https://nodejs.org/api/repl.html#repl_class_replserver
 **/
 typedef REPLServerOptions = {
 	/**
@@ -127,9 +94,5 @@ typedef REPLServerOptions = {
 	/**
 		The function to execute.
 	**/
-	#if haxe4
 	var action:(rest:String) -> Void;
-	#else
-	var action:String->Void;
-	#end
 }

--- a/src/js/node/vm/Script.hx
+++ b/src/js/node/vm/Script.hx
@@ -22,33 +22,58 @@
 
 package js.node.vm;
 
+import haxe.extern.EitherType;
+import js.node.Buffer;
 import js.node.Vm.VmContext;
 
 typedef ScriptOptions = {
 	/**
-		The filename that shows up in any stack traces produced.
+		Specifies the filename used in stack traces produced by this script.
 	**/
 	@:optional var filename:String;
 
 	/**
+		Specifies the line number offset that is displayed in stack traces produced by this script.
+	**/
+	@:optional var lineOffset:Int;
+
+	/**
+		Specifies the column number offset that is displayed in stack traces produced by this script.
+	**/
+	@:optional var columnOffset:Int;
+
+	/**
 		Whether or not to print any errors to stderr, with the line of code that caused them highlighted,
 		before throwing an exception.
-
-		Will capture both syntax errors from compiling code and runtime errors thrown by executing the compiled code.
-
-		Defaults to true.
+		Deprecated alias kept for older Node docs; prefer omitting and relying on engine defaults.
 	**/
 	@:optional var displayErrors:Bool;
+
+	/**
+		Provides an optional data with V8's code cache data for the supplied source.
+	**/
+	@:optional var cachedData:Buffer;
+
+	/**
+		V8-specific option; when `true`, produces cached data used for faster compilation next time.
+		Deprecated in favor of `createCachedData()`.
+	**/
+	@:deprecated("Use createCachedData() instead")
+	@:optional var produceCachedData:Bool;
+
+	/**
+		Used to specify how the modules should be loaded during evaluation.
+		Passed to the experimental `importModuleDynamically` hook.
+
+		// TODO(section-5): type importModuleDynamically callback
+	**/
+	@:optional var importModuleDynamically:Dynamic;
 }
 
 typedef ScriptRunOptions = {
 	/**
 		Whether or not to print any errors to stderr, with the line of code that caused them highlighted,
 		before throwing an exception.
-
-		Will capture both syntax errors from compiling code and runtime errors thrown by executing the compiled code.
-
-		Defaults to true.
 	**/
 	@:optional var displayErrors:Bool;
 
@@ -57,42 +82,64 @@ typedef ScriptRunOptions = {
 		If execution is terminated, an Error will be thrown.
 	**/
 	@:optional var timeout:Int;
+
+	/**
+		If `true`, the execution will be terminated when `SIGINT` (`Ctrl+C`) is received.
+		Existing handlers for the event that have been attached via `process.on('SIGINT')` will be disabled during
+		script execution, but will continue to work after that. Default: `false`.
+	**/
+	@:optional var breakOnSigint:Bool;
 }
 
 /**
 	A class for holding precompiled scripts, and running them in specific sandboxes.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/vm.html#class-vmscript
 **/
 @:jsRequire("vm", "Script")
 extern class Script {
 	/**
 		Creating a new `Script` compiles `code` but does not run it. Instead, the created `Script` object
 		represents this compiled code.
-
-		This script can be run later many times using methods below.
-
-		The returned script is not bound to any global object. It is bound before each run, just for that run.
 	**/
-	function new(code:String, ?options:ScriptOptions);
+	function new(code:String, ?options:EitherType<String, ScriptOptions>);
+
+	/**
+		When producing cached data with `--produce_cached_data`, this value becomes `true` if the produced
+		cached data was rejected by V8.
+	**/
+	var cachedDataRejected(default, null):Null<Bool>;
+
+	/**
+		When the script is compiled using `cachedData` this value will be `true` if the data was accepted by V8.
+	**/
+	var cachedDataProduced(default, null):Null<Bool>;
+
+	/**
+		When `cachedData` is supplied, the rejected or produced status is reflected here.
+	**/
+	var cachedData(default, null):Null<Buffer>;
+
+	/**
+		Creates a code cache that can be used with `Script` constructor's `cachedData` option
+		to avoid recompilation next time.
+	**/
+	function createCachedData():Buffer;
 
 	/**
 		Similar to `Vm.runInThisContext` but a method of a precompiled `Script` object.
-		`runInThisContext` runs the code of script and returns the result.
-		Running code does not have access to local scope, but does have access to the current global object.
+
+		// TODO(section-5): Dynamic is intentional for arbitrary JS eval results
 	**/
 	function runInThisContext(?options:ScriptRunOptions):Dynamic;
 
 	/**
 		Similar to `Vm.runInContext` but a method of a precompiled `Script` object.
-		`runInContext` runs script's compiled code in `contextifiedSandbox` and returns the result.
-		Running code does not have access to local scope.
 	**/
 	function runInContext(contextifiedSandbox:VmContext<Dynamic>, ?options:ScriptRunOptions):Dynamic;
 
 	/**
 		Similar to `Vm.runInNewContext` but a method of a precompiled `Script` object.
-		`runInNewContext` contextifies sandbox if passed or creates a new contextified sandbox if it's omitted,
-		and then runs script's compiled code with the sandbox as the global object and returns the result.
-		Running code does not have access to local scope.
 	**/
 	@:overload(function(sandbox:{}, ?options:ScriptRunOptions):Dynamic {})
 	function runInNewContext(?sandbox:{}):Dynamic;

--- a/src/js/node/worker_threads/MessageChannel.hx
+++ b/src/js/node/worker_threads/MessageChannel.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2025 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -20,29 +20,16 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-package js.node.readline;
-
-import js.lib.Promise;
-import js.node.readline.Interface;
-import js.node.web.AbortSignal;
+package js.node.worker_threads;
 
 /**
-	Instances of `readlinePromises.Interface` are constructed using
-	`ReadlinePromises.createInterface()`.
+	Instances of `MessageChannel` represent an asynchronous two-way communications channel.
 
-	Differs from `readline.Interface` mainly in that `question` returns a `Promise`.
-
-	@see https://nodejs.org/docs/latest-v24.x/api/readline.html#class-readlinepromisesinterface
+	@see https://nodejs.org/docs/latest-v24.x/api/worker_threads.html#class-messagechannel
 **/
-@:jsRequire("readline/promises", "Interface")
-extern class PromisesInterface extends Interface {
-	/**
-		Displays `query` by writing it to `output`, waits for user input on `input`,
-		then fulfills with the provided input.
-
-		When called, resumes the `input` stream if it has been paused.
-		If called after `close()`, returns a rejected promise.
-	**/
-	@:overload(function(query:String):Promise<String> {})
-	function question(query:String, options:{?signal:AbortSignal}):Promise<String>;
+@:jsRequire("worker_threads", "MessageChannel")
+extern class MessageChannel {
+	function new():Void;
+	var port1(default, null):MessagePort;
+	var port2(default, null):MessagePort;
 }

--- a/src/js/node/worker_threads/MessagePort.hx
+++ b/src/js/node/worker_threads/MessagePort.hx
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C)2014-2025 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.worker_threads;
+
+import js.lib.Error;
+import js.node.events.EventEmitter;
+
+/**
+	Events emitted by `MessagePort`.
+**/
+enum abstract MessagePortEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
+	var Close:MessagePortEvent<Void->Void> = "close";
+	// TODO(section-5): message value is structured-clone Dynamic
+	var Message:MessagePortEvent<Dynamic->Void> = "message";
+	var MessageError:MessagePortEvent<Error->Void> = "messageerror";
+}
+
+/**
+	Instances of `MessagePort` represent one end of an asynchronous two-way communication channel.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/worker_threads.html#class-messageport
+**/
+@:jsRequire("worker_threads", "MessagePort")
+extern class MessagePort extends EventEmitter<MessagePort> {
+	/**
+		Sends a JavaScript value to the receiving end of the channel.
+		// TODO(section-5): transferList / value typing for structured clone
+	**/
+	function postMessage(value:Dynamic, ?transferList:Array<Dynamic>):Void;
+
+	/**
+		Disables further sending of messages from either port. Once done, no further messages can be received.
+	**/
+	function close():Void;
+
+	/**
+		Starts receiving messages. Automatically called if a listener for `'message'` is attached.
+	**/
+	function start():Void;
+
+	/**
+		Opposite of `unref()`. Increases active handle count.
+	**/
+	function ref():Void;
+
+	/**
+		Decreases the reference count. Allows the thread to exit if this is the only active handle.
+	**/
+	function unref():Void;
+
+	/**
+		If true, the MessagePort will keep the event loop of the thread alive.
+	**/
+	function hasRef():Bool;
+}

--- a/src/js/node/worker_threads/Worker.hx
+++ b/src/js/node/worker_threads/Worker.hx
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C)2014-2025 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.worker_threads;
+
+import haxe.extern.EitherType;
+import js.lib.Error;
+import js.lib.Promise;
+import js.node.WorkerThreads.WorkerResourceLimits;
+import js.node.events.EventEmitter;
+import js.node.stream.Readable.IReadable;
+import js.node.stream.Writable.IWritable;
+import js.node.url.URL;
+
+/**
+	Events emitted by `Worker`.
+**/
+enum abstract WorkerEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
+	var Error:WorkerEvent<Error->Void> = "error";
+	var Exit:WorkerEvent<Int->Void> = "exit";
+	// TODO(section-5): message value is structured-clone Dynamic
+	var Message:WorkerEvent<Dynamic->Void> = "message";
+	var MessageError:WorkerEvent<Error->Void> = "messageerror";
+	var Online:WorkerEvent<Void->Void> = "online";
+}
+
+/**
+	The `Worker` class represents an independent JavaScript execution thread.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/worker_threads.html#class-worker
+**/
+@:jsRequire("worker_threads", "Worker")
+extern class Worker extends EventEmitter<Worker> {
+	/**
+		@see https://nodejs.org/docs/latest-v24.x/api/worker_threads.html#new-workerfilename-options
+	**/
+	function new(filename:EitherType<String, URL>, ?options:WorkerOptions);
+
+	/**
+		Send a message to the worker that will be received via `require('worker_threads').parentPort.on('message')`.
+		// TODO(section-5): transferList / value typing for structured clone
+	**/
+	function postMessage(value:Dynamic, ?transferList:Array<Dynamic>):Void;
+
+	/**
+		Opposite of `unref()`. Calls will take effect if the Worker previously was `unref`ed.
+	**/
+	function ref():Void;
+
+	/**
+		Calling `unref` on a worker allows the thread to exit if this is the only active handle in the event system.
+	**/
+	function unref():Void;
+
+	/**
+		Stop all JavaScript execution in the worker thread as soon as possible.
+		Returns a Promise for the exit code.
+	**/
+	function terminate():Promise<Int>;
+
+	/**
+		Returns a readable stream for a V8 snapshot of the current state of the Worker.
+	**/
+	function getHeapSnapshot():Promise<IReadable>;
+
+	/**
+		Returns statistics about the worker's V8 heap.
+		// TODO(section-5): align with V8HeapStatistics once shared typing is practical
+	**/
+	function getHeapStatistics():Promise<Dynamic>;
+
+	/**
+		An integer identifier for the referenced thread. Identical to `threadId` inside the worker.
+	**/
+	var threadId(default, null):Int;
+
+	/**
+		Optional name assigned when creating the worker.
+	**/
+	var threadName(default, null):Null<String>;
+
+	/**
+		If `stdin: true` was passed to the constructor, this is a writable stream connected to worker's `process.stdin`.
+	**/
+	var stdin(default, null):Null<IWritable>;
+
+	/**
+		A readable stream connected to worker's `process.stdout`.
+	**/
+	var stdout(default, null):IReadable;
+
+	/**
+		A readable stream connected to worker's `process.stderr`.
+	**/
+	var stderr(default, null):IReadable;
+
+	/**
+		An object containing information about the resource limits of the Worker.
+	**/
+	var resourceLimits(default, null):Null<WorkerResourceLimits>;
+}
+
+typedef WorkerOptions = {
+	/**
+		Additional data to send in parallel.
+		// TODO(section-5): workerData typing is application-defined
+	**/
+	@:optional var workerData:Dynamic;
+
+	/**
+		List of transferable objects to pass alongside `workerData`.
+	**/
+	@:optional var transferList:Array<Dynamic>;
+
+	@:optional var stdin:Bool;
+	@:optional var stdout:Bool;
+	@:optional var stderr:Bool;
+
+	/**
+		Executable used to create the worker.
+	**/
+	@:optional var execArgv:Array<String>;
+
+	/**
+		An optional environment object keyed like `process.env`.
+		Use `WorkerThreads.SHARE_ENV` to share the env.
+	**/
+	@:optional var env:EitherType<haxe.DynamicAccess<String>, js.lib.Symbol>;
+
+	@:optional var resourceLimits:WorkerResourceLimits;
+	@:optional var name:String;
+
+	/**
+		If `true`, track unmanaged resources managed by the worker.
+	**/
+	@:optional var trackUnmanagedFds:Bool;
+}


### PR DESCRIPTION
## Summary
- Align section-5 externs (`child_process`, `cluster`, `readline`/`readline/promises`, `repl`, `vm`, `v8`, `domain`) with Node.js 24 APIs and drop remaining Haxe 3 conditionals.
- Add core affinity stubs for `async_hooks`, `worker_threads`, and `wasi` (preferring practical surface over totality).
- Leave intentional `Dynamic` IPC/eval/structured-clone seams tagged with `TODO(section-5)` for follow-up typing.

## Test plan
- [x] `haxe -js dummy -cp src --macro 'ImportAll.run("src")' --macro '_internal.SuppressDeprecated.run()' --no-output` under Haxe 4.0.5
- [x] Same ImportAll check under Haxe 5.0.0-preview.1
- [ ] Spot-check new options (`signal`/`serialization`/`windowsHide`, cluster `setupPrimary`, readline `line`/`getCursorPos`, vm `compileFunction`, v8 heap/snapshot helpers) against Node 24 docs
- [ ] Smoke-use `AsyncLocalStorage`, `worker_threads.Worker`, and `Wasi` constructors in a small sample if desired


Made with [Cursor](https://cursor.com)