### PR TITLE
Audit crypto/util/assert/url for Node 24 + Haxe 4

### DIFF
--- a/examples/AssertThrows.hx
+++ b/examples/AssertThrows.hx
@@ -1,16 +1,17 @@
-#if haxe4
 import js.lib.Error;
 import js.lib.RegExp;
-#else
-import js.Error;
-import js.RegExp;
-#end
 import js.node.Assert;
 
 class AssertThrows {
 	static function main() {
 		Assert.throws(function() throw new Error("Wrong value"), Error);
 		Assert.throws(function() throw new Error("Wrong value"), new RegExp("value"));
-		Assert.throws(function() throw new Error("Wrong value"), function(err) return (Std.is(err, Error) && ~/value/.match(err.message)), "unexpected error");
+		Assert.throws(function() throw new Error("Wrong value"), function(err)
+			return switch Std.downcast(cast err, Error) {
+				case null: false;
+				case e: ~/value/.match(e.message);
+			},
+			"unexpected error"
+		);
 	}
 }

--- a/src/js/node/Assert.hx
+++ b/src/js/node/Assert.hx
@@ -22,15 +22,10 @@
 
 package js.node;
 
-#if haxe4
+import haxe.Constraints.Function;
 import js.lib.Error;
 import js.lib.Promise;
 import js.lib.RegExp;
-#else
-import js.Error;
-import js.Promise;
-import js.RegExp;
-#end
 
 /**
 	The `assert module` provides a set of assertion functions for verifying invariants.
@@ -54,8 +49,8 @@ extern class Assert {
 		@see https://nodejs.org/api/assert.html#assert_assert_value_message
 	**/
 	@:selfCall
-	@:overload(function(value:Dynamic, ?message:Error):Void {})
-	static function assert(value:Dynamic, ?message:String):Void;
+	@:overload(function(value:Any, ?message:Error):Void {})
+	static function assert(value:Any, ?message:String):Void;
 
 	/**
 		An alias of `Assert.deepStrictEqual()`.
@@ -91,12 +86,12 @@ extern class Assert {
 
 		@see https://nodejs.org/api/assert.html#assert_assert_doesnotreject_asyncfn_error_message
 	**/
-	@:overload(function(asyncFn:Void->Promise<Dynamic>, ?error:Class<Dynamic>, ?message:String):Void {})
-	@:overload(function(asyncFn:Void->Promise<Dynamic>, ?error:RegExp, ?message:String):Void {})
-	@:overload(function(asyncFn:Void->Promise<Dynamic>, ?error:Dynamic->Bool, ?message:String):Void {})
-	@:overload(function(asyncFn:Promise<Dynamic>, ?error:Class<Dynamic>, ?message:String):Void {})
-	@:overload(function(asyncFn:Promise<Dynamic>, ?error:RegExp, ?message:String):Void {})
-	static function doesNotReject(asyncFn:Promise<Dynamic>, ?error:Dynamic->Bool, ?message:String):Void;
+	@:overload(function(asyncFn:Void->Promise<Any>, ?error:Class<Any>, ?message:String):Void {})
+	@:overload(function(asyncFn:Void->Promise<Any>, ?error:RegExp, ?message:String):Void {})
+	@:overload(function(asyncFn:Void->Promise<Any>, ?error:Any->Bool, ?message:String):Void {})
+	@:overload(function(asyncFn:Promise<Any>, ?error:Class<Any>, ?message:String):Void {})
+	@:overload(function(asyncFn:Promise<Any>, ?error:RegExp, ?message:String):Void {})
+	static function doesNotReject(asyncFn:Promise<Any>, ?error:Any->Bool, ?message:String):Void;
 
 	/**
 		Asserts that the function `fn` does not throw an error.
@@ -108,9 +103,9 @@ extern class Assert {
 
 		@see https://nodejs.org/api/assert.html#assert_assert_doesnotthrow_fn_error_message
 	**/
-	@:overload(function(fn:Void->Void, ?error:Class<Dynamic>, ?message:String):Void {})
+	@:overload(function(fn:Void->Void, ?error:Class<Any>, ?message:String):Void {})
 	@:overload(function(fn:Void->Void, ?error:RegExp, ?message:String):Void {})
-	static function doesNotThrow(fn:Void->Void, ?error:Dynamic->Bool, ?message:String):Void;
+	static function doesNotThrow(fn:Void->Void, ?error:Any->Bool, ?message:String):Void;
 
 	/**
 		An alias of `strictEqual`.
@@ -138,8 +133,8 @@ extern class Assert {
 	**/
 	@:deprecated
 	@:native("fail")
-	@:overload(function<T>(actual:T, expected:T, ?message:String, ?operator_:String, ?stackStartFn:haxe.Constraints.Function):Void {})
-	static function fail_<T>(actual:T, expected:T, ?message:Error, ?operator_:String, ?stackStartFn:haxe.Constraints.Function):Void;
+	@:overload(function<T>(actual:T, expected:T, ?message:String, ?operator_:String, ?stackStartFn:Function):Void {})
+	static function fail_<T>(actual:T, expected:T, ?message:Error, ?operator_:String, ?stackStartFn:Function):Void;
 
 	/**
 		Throws `value` if `value` is not `undefined` or `null`.
@@ -148,7 +143,7 @@ extern class Assert {
 
 		@see https://nodejs.org/api/assert.html#assert_assert_iferror_value
 	**/
-	static function ifError(value:Dynamic):Void;
+	static function ifError(value:Any):Void;
 
 	/**
 		Expects the `string` input to match the regular expression.
@@ -198,8 +193,8 @@ extern class Assert {
 
 		@see https://nodejs.org/api/assert.html#assert_assert_ok_value_message
 	**/
-	@:overload(function(value:Dynamic, ?message:Error):Void {})
-	static function ok(value:Dynamic, ?message:String):Void;
+	@:overload(function(value:Any, ?message:Error):Void {})
+	static function ok(value:Any, ?message:String):Void;
 
 	/**
 		Tests for partial deep equality between the `actual` and `expected` parameters.
@@ -218,16 +213,16 @@ extern class Assert {
 
 		@see https://nodejs.org/api/assert.html#assert_assert_rejects_asyncfn_error_message
 	**/
-	@:overload(function(asyncFn:Void->Promise<Dynamic>, ?error:Class<Dynamic>, ?message:String):Void {})
-	@:overload(function(asyncFn:Void->Promise<Dynamic>, ?error:RegExp, ?message:String):Void {})
-	@:overload(function(asyncFn:Void->Promise<Dynamic>, ?error:Dynamic->Bool, ?message:String):Void {})
-	@:overload(function(asyncFn:Void->Promise<Dynamic>, ?error:Dynamic, ?message:String):Void {})
-	@:overload(function(asyncFn:Void->Promise<Dynamic>, ?error:Error, ?message:String):Void {})
-	@:overload(function(asyncFn:Promise<Dynamic>, ?error:Class<Dynamic>, ?message:String):Void {})
-	@:overload(function(asyncFn:Promise<Dynamic>, ?error:RegExp, ?message:String):Void {})
-	@:overload(function(asyncFn:Promise<Dynamic>, ?error:Dynamic->Bool, ?message:String):Void {})
-	@:overload(function(asyncFn:Promise<Dynamic>, ?error:Dynamic, ?message:String):Void {})
-	static function rejects(asyncFn:Promise<Dynamic>, ?error:Error, ?message:String):Void;
+	@:overload(function(asyncFn:Void->Promise<Any>, ?error:Class<Any>, ?message:String):Void {})
+	@:overload(function(asyncFn:Void->Promise<Any>, ?error:RegExp, ?message:String):Void {})
+	@:overload(function(asyncFn:Void->Promise<Any>, ?error:Any->Bool, ?message:String):Void {})
+	@:overload(function(asyncFn:Void->Promise<Any>, ?error:Any, ?message:String):Void {})
+	@:overload(function(asyncFn:Void->Promise<Any>, ?error:Error, ?message:String):Void {})
+	@:overload(function(asyncFn:Promise<Any>, ?error:Class<Any>, ?message:String):Void {})
+	@:overload(function(asyncFn:Promise<Any>, ?error:RegExp, ?message:String):Void {})
+	@:overload(function(asyncFn:Promise<Any>, ?error:Any->Bool, ?message:String):Void {})
+	@:overload(function(asyncFn:Promise<Any>, ?error:Any, ?message:String):Void {})
+	static function rejects(asyncFn:Promise<Any>, ?error:Error, ?message:String):Void;
 
 	/**
 		Tests strict equality between the `actual` and `expected` parameter as
@@ -244,7 +239,7 @@ extern class Assert {
 		@see https://nodejs.org/api/assert.html#assert_assert_throws_fn_error_message
 	**/
 	@:overload(function(fn:Void->Void, ?error:RegExp, ?message:String):Void {})
-	@:overload(function(fn:Void->Void, ?error:Dynamic->Bool, ?message:String):Void {})
-	@:overload(function(fn:Void->Void, ?error:Dynamic, ?message:String):Void {})
+	@:overload(function(fn:Void->Void, ?error:Any->Bool, ?message:String):Void {})
+	@:overload(function(fn:Void->Void, ?error:Any, ?message:String):Void {})
 	static function throws(fn:Void->Void, ?error:Error, ?message:String):Void;
 }

--- a/src/js/node/Crypto.hx
+++ b/src/js/node/Crypto.hx
@@ -22,20 +22,16 @@
 
 package js.node;
 
+import haxe.DynamicAccess;
 import haxe.extern.EitherType;
+import js.html.SubtleCrypto;
+import js.lib.ArrayBuffer;
+import js.lib.ArrayBufferView;
+import js.lib.Error;
 import js.node.Buffer;
 import js.node.crypto.*;
 import js.node.crypto.DiffieHellman.IDiffieHellman;
 import js.node.tls.SecureContext;
-#if haxe4
-import js.lib.ArrayBuffer;
-import js.lib.ArrayBufferView;
-import js.lib.Error;
-#else
-import js.html.ArrayBuffer;
-import js.html.ArrayBufferView;
-import js.Error;
-#end
 
 /**
 	Enumerations of crypto algorighms to be used.
@@ -98,6 +94,27 @@ extern class Crypto {
 	**/
 	@:deprecated
 	static var fips:Bool;
+
+	/**
+		OpenSSL crypto constants (padding modes, DH check codes, engine methods, etc.).
+	**/
+	static var constants(default, never):DynamicAccess<Int>;
+
+	/**
+		A convenient alias for `Crypto.webcrypto.subtle`.
+	**/
+	static var subtle(default, never):SubtleCrypto;
+
+	/**
+		Node.js Web Crypto API implementation (`crypto.webcrypto`).
+
+		Typed as the Haxe std `js.html.Crypto` surface. Node-specific Web Crypto
+		extensions beyond that DOM typedef are not duplicated here — no separate
+		`js.node.webcrypto` package.
+
+		// TODO(section-4): audit Node-only Web Crypto additions vs `js.html.Crypto`
+	**/
+	static var webcrypto(default, never):js.html.Crypto;
 
 	/**
 		Returns `1` if and only if a FIPS compliant crypto provider is currently in use, `0` otherwise.
@@ -182,6 +199,7 @@ extern class Crypto {
 
 		`key` and `iv` must be 'binary' encoded strings or buffers.
 	**/
+	@:overload(function(algorithm:String, key:EitherType<EitherType<String, Buffer>, KeyObject>, iv:Null<EitherType<String, Buffer>>):Cipher {})
 	static function createCipheriv(algorithm:String, key:EitherType<String, Buffer>, iv:EitherType<String, Buffer>):Cipher;
 
 	/**
@@ -194,6 +212,7 @@ extern class Crypto {
 		Creates and returns a decipher object, with the given algorithm, key and iv.
 		This is the mirror of the `createCipheriv` above.
 	**/
+	@:overload(function(algorithm:String, key:EitherType<EitherType<String, Buffer>, KeyObject>, iv:Null<EitherType<String, Buffer>>):Decipher {})
 	static function createDecipheriv(algorithm:String, key:EitherType<String, Buffer>, iv:EitherType<String, Buffer>):Decipher;
 
 	/**
@@ -230,12 +249,33 @@ extern class Crypto {
 	static function getDiffieHellman(group_name:DiffieHellmanGroupName):IDiffieHellman;
 
 	/**
+		An alias for `getDiffieHellman`.
+	**/
+	static function createDiffieHellmanGroup(name:DiffieHellmanGroupName):IDiffieHellman;
+
+	/**
 		Creates an Elliptic Curve (EC) Diffie-Hellman key exchange object using a predefined curve
 		specified by the `curve_name` string. Use `getCurves` to obtain a list of available curve names.
 		On recent releases, openssl ecparam -list_curves will also display the name
 		and description of each available elliptic curve.
 	**/
 	static function createECDH(curve_name:String):ECDH;
+
+	/**
+		Creates and returns a new key object containing a private key.
+	**/
+	static function createPrivateKey(key:EitherType<String, EitherType<Buffer, CryptoKeyInput>>):KeyObject;
+
+	/**
+		Creates and returns a new key object containing a public key.
+	**/
+	static function createPublicKey(key:EitherType<String, EitherType<Buffer, EitherType<KeyObject, CryptoKeyInput>>>):KeyObject;
+
+	/**
+		Creates and returns a new key object containing a secret key for symmetric encryption or `Hmac`.
+	**/
+	@:overload(function(key:String, encoding:String):KeyObject {})
+	static function createSecretKey(key:EitherType<String, EitherType<Buffer, ArrayBufferView>>):KeyObject;
 
 	/**
 		Asynchronous PBKDF2 applies pseudorandom function HMAC-SHA1 to derive a key of given length
@@ -403,6 +443,111 @@ extern class Crypto {
 	**/
 	@:overload(function(public_key:CryptoKeyOptions, buffer:Buffer):Buffer {})
 	static function publicEncrypt(public_key:String, buffer:Buffer):Buffer;
+
+	/**
+		Asynchronously generates a new random secret key of the given `length`.
+		`type` is currently `'hmac'` or `'aes'`.
+	**/
+	static function generateKey(type:String, options:GenerateKeyOptions, callback:Error->KeyObject->Void):Void;
+
+	/**
+		Synchronously generates a new random secret key of the given `length`.
+		`type` is currently `'hmac'` or `'aes'`.
+	**/
+	static function generateKeySync(type:String, options:GenerateKeyOptions):KeyObject;
+
+	/**
+		Generates a new asymmetric key pair of the given `type`.
+
+		// TODO(section-4): finer-grained overloads per key type / encoding (RSA, EC, Ed25519, …)
+	**/
+	@:overload(function(type:String, options:Any, callback:Error->EitherType<String, KeyObject>->EitherType<String, KeyObject>->Void):Void {})
+	@:overload(function(type:String, callback:Error->KeyObject->KeyObject->Void):Void {})
+	static function generateKeyPair(type:String, options:Any, callback:Error->KeyObject->KeyObject->Void):Void;
+
+	/**
+		Synchronously generates a new asymmetric key pair of the given `type`.
+
+		// TODO(section-4): finer-grained return encodings per key type
+	**/
+	@:overload(function(type:String):KeyPairKeyObjectResult {})
+	static function generateKeyPairSync(type:String, ?options:Any):EitherType<KeyPairKeyObjectResult, KeyPairEncodedResult>;
+
+	/**
+		Generates a pseudorandom prime of `size` bits.
+	**/
+	@:overload(function(size:Int, options:GeneratePrimeOptions, callback:Error->EitherType<ArrayBuffer, Any>->Void):Void {})
+	static function generatePrime(size:Int, callback:Error->ArrayBuffer->Void):Void;
+
+	/**
+		Generates a pseudorandom prime of `size` bits (synchronous).
+	**/
+	static function generatePrimeSync(size:Int, ?options:GeneratePrimeOptions):EitherType<ArrayBuffer, Any>;
+
+	/**
+		One-shot hashing. Returns a digest for `data` using `algorithm`.
+	**/
+	@:overload(function(algorithm:String, data:EitherType<String, EitherType<Buffer, ArrayBufferView>>, options:HashOptions):EitherType<String, Buffer> {})
+	static function hash(algorithm:String, data:EitherType<String, EitherType<Buffer, ArrayBufferView>>, ?encoding:String):EitherType<String, Buffer>;
+
+	/**
+		Calculates and returns the signature for `data` using the given private key and algorithm.
+	**/
+	@:overload(function(algorithm:Null<String>, data:EitherType<Buffer, ArrayBufferView>, key:EitherType<String, EitherType<Buffer, KeyObject>>,
+		callback:Error->Buffer->Void):Void {})
+	static function sign(algorithm:Null<String>, data:EitherType<Buffer, ArrayBufferView>,
+		key:EitherType<String, EitherType<Buffer, EitherType<KeyObject, CryptoKeyInput>>>):Buffer;
+
+	/**
+		Verifies the given signature for `data` using the given key and algorithm.
+	**/
+	@:overload(function(algorithm:Null<String>, data:EitherType<Buffer, ArrayBufferView>,
+		key:EitherType<String, EitherType<Buffer, EitherType<KeyObject, CryptoKeyInput>>>, signature:EitherType<Buffer, ArrayBufferView>,
+		callback:Error->Bool->Void):Void {})
+	static function verify(algorithm:Null<String>, data:EitherType<Buffer, ArrayBufferView>,
+		key:EitherType<String, EitherType<Buffer, EitherType<KeyObject, CryptoKeyInput>>>,
+		signature:EitherType<Buffer, ArrayBufferView>):Bool;
+
+	/**
+		Computes the Diffie-Hellman shared secret based on a `privateKey` and a `publicKey`.
+	**/
+	@:overload(function(options:DiffieHellmanOptions, callback:Error->Buffer->Void):Void {})
+	static function diffieHellman(options:DiffieHellmanOptions):Buffer;
+
+	/**
+		A Web Crypto-compatible implementation of `getRandomValues`.
+	**/
+	static function getRandomValues<T:ArrayBufferView>(typedArray:T):T;
+
+	/**
+		Returns information about the secure heap usage used by OpenSSL.
+	**/
+	static function secureHeapUsed():SecureHeapUsage;
+
+	/**
+		Key encapsulation (KEM) using a public key.
+	**/
+	@:overload(function(key:EitherType<String, EitherType<Buffer, EitherType<KeyObject, CryptoKeyInput>>>,
+		callback:Error->EncapsulateResult->Void):Void {})
+	static function encapsulate(key:EitherType<String, EitherType<Buffer, EitherType<KeyObject, CryptoKeyInput>>>):EncapsulateResult;
+
+	/**
+		Key decapsulation using a private key.
+	**/
+	@:overload(function(key:EitherType<String, EitherType<Buffer, EitherType<KeyObject, CryptoKeyInput>>>,
+		ciphertext:EitherType<ArrayBuffer, ArrayBufferView>, callback:Error->Buffer->Void):Void {})
+	static function decapsulate(key:EitherType<String, EitherType<Buffer, EitherType<KeyObject, CryptoKeyInput>>>,
+		ciphertext:EitherType<ArrayBuffer, ArrayBufferView>):Buffer;
+
+	/**
+		Provides an asynchronous Argon2 implementation.
+	**/
+	static function argon2(algorithm:Argon2Algorithm, parameters:Argon2Parameters, callback:Error->Buffer->Void):Void;
+
+	/**
+		Provides a synchronous Argon2 implementation.
+	**/
+	static function argon2Sync(algorithm:Argon2Algorithm, parameters:Argon2Parameters):Buffer;
 }
 
 /**
@@ -552,4 +697,105 @@ typedef CipherInfo = {
 		`'ocb'`, `'ofb'`, `'stream'`, `'wrap'`, `'xts'`.
 	**/
 	@:optional var mode:String;
+}
+
+/**
+	Input object accepted by several crypto key helpers.
+**/
+typedef CryptoKeyInput = {
+	var key:EitherType<String, EitherType<Buffer, ArrayBufferView>>;
+	@:optional var format:String;
+	@:optional var type:String;
+	@:optional var passphrase:EitherType<String, Buffer>;
+	@:optional var encoding:String;
+}
+
+/**
+	Options for `Crypto.generateKey` / `generateKeySync`.
+**/
+typedef GenerateKeyOptions = {
+	var length:Int;
+}
+
+/**
+	Result when `generateKeyPairSync` returns KeyObject instances.
+**/
+typedef KeyPairKeyObjectResult = {
+	var publicKey:KeyObject;
+	var privateKey:KeyObject;
+}
+
+/**
+	Result when `generateKeyPairSync` returns encoded keys.
+**/
+typedef KeyPairEncodedResult = {
+	var publicKey:EitherType<String, Buffer>;
+	var privateKey:EitherType<String, Buffer>;
+}
+
+/**
+	Options for `Crypto.generatePrime` / `generatePrimeSync`.
+**/
+typedef GeneratePrimeOptions = {
+	@:optional var safe:Bool;
+	@:optional var bigint:Bool;
+	@:optional var add:EitherType<ArrayBuffer, ArrayBufferView>;
+	@:optional var rem:EitherType<ArrayBuffer, ArrayBufferView>;
+}
+
+/**
+	Options for one-shot `Crypto.hash`.
+**/
+typedef HashOptions = {
+	@:optional var outputEncoding:String;
+	@:optional var outputLength:Int;
+}
+
+/**
+	Options for `Crypto.diffieHellman`.
+**/
+typedef DiffieHellmanOptions = {
+	var privateKey:KeyObject;
+	var publicKey:KeyObject;
+}
+
+/**
+	Result of `Crypto.secureHeapUsed`.
+**/
+typedef SecureHeapUsage = {
+	var total:Float;
+	var min:Float;
+	var used:Float;
+	var utilization:Float;
+}
+
+/**
+	Result of `Crypto.encapsulate`.
+**/
+typedef EncapsulateResult = {
+	var sharedKey:Buffer;
+	var ciphertext:Buffer;
+}
+
+/**
+	Argon2 algorithm identifiers.
+**/
+enum abstract Argon2Algorithm(String) from String to String {
+	var Argon2d = "argon2d";
+	var Argon2i = "argon2i";
+	var Argon2id = "argon2id";
+}
+
+/**
+	Parameters for `Crypto.argon2` / `argon2Sync`.
+**/
+typedef Argon2Parameters = {
+	var message:EitherType<String, EitherType<ArrayBuffer, ArrayBufferView>>;
+	var nonce:EitherType<String, EitherType<ArrayBuffer, ArrayBufferView>>;
+	var parallelism:Int;
+	var tagLength:Int;
+	var memory:Int;
+	var passes:Int;
+	@:optional var secret:EitherType<String, EitherType<ArrayBuffer, ArrayBufferView>>;
+	@:optional var associatedData:EitherType<String, EitherType<ArrayBuffer, ArrayBufferView>>;
 }

--- a/src/js/node/Crypto.hx
+++ b/src/js/node/Crypto.hx
@@ -251,7 +251,7 @@ extern class Crypto {
 	/**
 		An alias for `getDiffieHellman`.
 	**/
-	static function createDiffieHellmanGroup(name:DiffieHellmanGroupName):IDiffieHellman;
+	static function createDiffieHellmanGroup(name:DiffieHellmanGroupName):DiffieHellmanGroup;
 
 	/**
 		Creates an Elliptic Curve (EC) Diffie-Hellman key exchange object using a predefined curve

--- a/src/js/node/Querystring.hx
+++ b/src/js/node/Querystring.hx
@@ -24,6 +24,7 @@ package js.node;
 
 import haxe.DynamicAccess;
 import haxe.extern.EitherType;
+import js.node.Buffer;
 
 /**
 	The `querystring` module provides utilities for parsing and formatting URL query strings.
@@ -76,7 +77,15 @@ extern class Querystring {
 
 		@see https://nodejs.org/api/querystring.html#querystring_querystring_unescape_str
 	**/
-	static dynamic function unescape(str:String):Dynamic;
+	static dynamic function unescape(str:String):String;
+
+	/**
+		The `querystring.unescapeBuffer()` method performs decoding of URL percent-encoded characters
+		on a `Buffer` of bytes, returning a new `Buffer`.
+
+		@see https://nodejs.org/api/querystring.html
+	**/
+	static function unescapeBuffer(buffer:Buffer, ?decodeSpaces:Bool):Buffer;
 }
 
 /**

--- a/src/js/node/Url.hx
+++ b/src/js/node/Url.hx
@@ -23,6 +23,7 @@
 package js.node;
 
 import haxe.extern.EitherType;
+import js.node.Buffer;
 import js.node.url.URL;
 
 /**
@@ -40,15 +41,23 @@ extern class Url {
 	/**
 		Returns the Unicode serialization of the `domain`. If `domain` is an invalid domain, the empty string is returned.
 
-		It performs the inverse operation to `url.dmainToASCII()`.
+		It performs the inverse operation to `url.domainToASCII()`.
 	**/
 	static function domainToUnicode(domain:String):String;
 
 	/**
 		This function ensures the correct decodings of percent-encoded characters as well as ensuring a cross-platform valid absolute path string.
 	**/
+	@:overload(function(url:String, ?options:FileUrlToPathOptions):String {})
+	@:overload(function(url:URL, ?options:FileUrlToPathOptions):String {})
 	@:overload(function(url:String):String {})
 	static function fileURLToPath(url:URL):String;
+
+	/**
+		Like `fileURLToPath` but returns a `Buffer` containing the path.
+	**/
+	@:overload(function(url:String, ?options:FileUrlToPathOptions):Buffer {})
+	static function fileURLToPathBuffer(url:URL, ?options:FileUrlToPathOptions):Buffer;
 
 	/**
 		Returns a customizable serialization of a URL `String` representation of a [WHATWG URL](https://nodejs.org/api/url.html#url_the_whatwg_url_api) object.
@@ -67,7 +76,7 @@ extern class Url {
 		This function ensures that `path` is resolved absolutely,
 		and that the URL control characters are correctly encoded when converting into a File URL.
 	**/
-	static function pathToFileURL(path:String):URL;
+	static function pathToFileURL(path:String, ?options:PathToFileUrlOptions):URL;
 
 	/**
 		Takes a URL string, parses it, and returns a URL object.
@@ -96,6 +105,14 @@ extern class Url {
 	**/
 	@:deprecated
 	static function resolve(from:String, to:String):String;
+
+	/**
+		Deprecated legacy helper similar to `resolve`, operating on URL objects.
+
+		@see https://nodejs.org/api/url.html
+	**/
+	@:deprecated
+	static function resolveObject(source:EitherType<String, UrlObject>, relative:EitherType<String, UrlObject>):UrlObject;
 
 	/**
 		This utility function converts a URL object into an ordinary options object as expected by the `http.request()` and `https.request()` APIs.
@@ -297,4 +314,24 @@ typedef UrlObject = {
 		For example: '#hash'
 	**/
 	@:optional var hash:String;
+}
+
+/**
+	Options for `Url.fileURLToPath` / `fileURLToPathBuffer`.
+**/
+typedef FileUrlToPathOptions = {
+	/**
+		`true` if the path should retain Windows-style separators.
+	**/
+	@:optional var windows:Bool;
+}
+
+/**
+	Options for `Url.pathToFileURL`.
+**/
+typedef PathToFileUrlOptions = {
+	/**
+		`true` if the path is a Windows path.
+	**/
+	@:optional var windows:Bool;
 }

--- a/src/js/node/Util.hx
+++ b/src/js/node/Util.hx
@@ -23,17 +23,16 @@
 package js.node;
 
 import haxe.Constraints.Function;
+import haxe.DynamicAccess;
 import haxe.extern.EitherType;
 import haxe.extern.Rest;
+import js.lib.Error;
+import js.lib.Map;
+import js.lib.Promise;
 import js.node.stream.Readable;
 import js.node.stream.Writable;
-#if haxe4
-import js.lib.Error;
-import js.lib.Promise;
-#else
-import js.Error;
-import js.Promise;
-#end
+import js.node.web.AbortController;
+import js.node.web.AbortSignal;
 
 /**
 	The `util` module is primarily designed to support the needs of Node.js' own internal APIs.
@@ -48,7 +47,8 @@ extern class Util {
 
 		@see https://nodejs.org/api/util.html#util_util_callbackify_original
 	**/
-	static function callbackify(original:Function, args:Rest<Dynamic>):Null<Error>->Null<Dynamic>->Void;
+	// TODO(section-4): tighten callbackify return/arg types beyond Function
+	static function callbackify(original:Function):Function;
 
 	/**
 		The `util.debuglog()` method is used to create a function that conditionally writes debug messages to `stderr`
@@ -56,15 +56,15 @@ extern class Util {
 
 		@see https://nodejs.org/api/util.html#util_util_debuglog_section
 	**/
-	static function debuglog(section:String):Rest<Dynamic>->Void;
+	static function debuglog(section:String):Rest<Any>->Void;
 
 	/**
 		The `util.deprecate()` method wraps `fn` (which may be a function or class) in such a way that it is marked
-		asdeprecated.
+		as deprecated.
 
 		@see https://nodejs.org/api/util.html#util_util_deprecate_fn_msg_code
 	**/
-	static function deprecate<T:haxe.Constraints.Function>(fun:T, msg:String, ?code:String):T;
+	static function deprecate<T:Function>(fun:T, msg:String, ?code:String):T;
 
 	/**
 		The `util.format()` method returns a formatted string using the first argument as a `printf`-like format string
@@ -72,8 +72,8 @@ extern class Util {
 
 		@see https://nodejs.org/api/util.html#util_util_format_format_args
 	**/
-	@:overload(function(args:Rest<Dynamic>):String {})
-	static function format(format:String, args:Rest<Dynamic>):String;
+	@:overload(function(args:Rest<Any>):String {})
+	static function format(format:String, args:Rest<Any>):String;
 
 	/**
 		This function is identical to `util.format()`, except in that it takes an `inspectOptions` argument which
@@ -81,8 +81,8 @@ extern class Util {
 
 		@see https://nodejs.org/api/util.html#util_util_formatwithoptions_inspectoptions_format_args
 	**/
-	@:overload(function(inspectOptions:InspectOptions, args:Rest<Dynamic>):String {})
-	static function formatWithOptions(inspectOptions:InspectOptions, format:String, args:Rest<Dynamic>):String;
+	@:overload(function(inspectOptions:InspectOptions, args:Rest<Any>):String {})
+	static function formatWithOptions(inspectOptions:InspectOptions, format:String, args:Rest<Any>):String;
 
 	/**
 		Returns the string name for a numeric error code that comes from a Node.js API.
@@ -90,6 +90,21 @@ extern class Util {
 		@see https://nodejs.org/api/util.html#util_util_getsystemerrorname_err
 	**/
 	static function getSystemErrorName(err:Int):String;
+
+	/**
+		Returns the system error message associated with a numeric error code.
+
+		@see https://nodejs.org/api/util.html#utilgetsystemerrormessageerr
+	**/
+	static function getSystemErrorMessage(err:Int):String;
+
+	/**
+		Returns a Map of all system error codes available from the Node.js API.
+		Map values are `[name, message]` string pairs.
+
+		@see https://nodejs.org/api/util.html#utilgetsystemerrormap
+	**/
+	static function getSystemErrorMap():Map<Int, Array<String>>;
 
 	/**
 		Inherit the prototype methods from one `constructor` into another.
@@ -104,15 +119,15 @@ extern class Util {
 
 		@see https://nodejs.org/api/util.html#util_util_inspect_object_options
 	**/
-	@:overload(function(object:Dynamic, ?showHidden:Bool, ?depth:Int, ?colors:Bool):String {})
-	static function inspect(object:Dynamic, ?options:InspectOptions):String;
+	@:overload(function(object:Any, ?showHidden:Bool, ?depth:Int, ?colors:Bool):String {})
+	static function inspect(object:Any, ?options:InspectOptions):String;
 
 	/**
 		Returns `true` if there is deep strict equality between `val1` and `val2`.
 
 		@see https://nodejs.org/api/util.html#util_util_isdeepstrictequal_val1_val2
 	**/
-	static function isDeepStrictEqual(val1:Dynamic, val2:Dynamic):Bool;
+	static function isDeepStrictEqual(val1:Any, val2:Any):Bool;
 
 	/**
 		Takes a function following the common error-first callback style, i.e. taking an `(err, value) => ...` callback
@@ -120,7 +135,90 @@ extern class Util {
 
 		@see https://nodejs.org/api/util.html#util_util_promisify_original
 	**/
-	static function promisify(original:Function):Rest<Dynamic>->Promise<Dynamic>;
+	// TODO(section-4): tighten promisify generic result typing
+	static function promisify(original:Function):Rest<Any>->Promise<Any>;
+
+	/**
+		Parses command-line `args` into an options object according to `config`.
+
+		// TODO(section-4): generic ParseArgsConfig / ParsedResults refinement
+
+		@see https://nodejs.org/api/util.html#utilparseargsconfig
+	**/
+	static function parseArgs(?config:ParseArgsConfig):ParseArgsResult;
+
+	/**
+		Parses the raw contents of an `.env` file.
+
+		@see https://nodejs.org/api/util.html#utilparseenvcontent
+	**/
+	static function parseEnv(content:String):DynamicAccess<String>;
+
+	/**
+		Removes any ANSI escape codes from the specified string.
+
+		@see https://nodejs.org/api/util.html#utilstripvtcontrolcharactersstr
+	**/
+	static function stripVTControlCharacters(str:String):String;
+
+	/**
+		Returns a formatted text considering the `format` passed for printing in a terminal.
+
+		@see https://nodejs.org/api/util.html#utilstyletextformat-text-options
+	**/
+	static function styleText(format:EitherType<String, Array<String>>, text:String, ?options:StyleTextOptions):String;
+
+	/**
+		Returns the `string` after replacing any unpaired surrogate code units with U+FFFD.
+
+		@see https://nodejs.org/api/util.html#utiltousvstringstring
+	**/
+	static function toUSVString(string:String):String;
+
+	/**
+		Returns an `AbortController` that can be transferred to a Worker via `postMessage`.
+
+		@see https://nodejs.org/api/util.html#utiltransferableabortcontroller
+	**/
+	static function transferableAbortController():AbortController;
+
+	/**
+		Marks an existing `AbortSignal` as transferable so it can be sent to a Worker.
+
+		@see https://nodejs.org/api/util.html#utiltransferableabortsignalsignal
+	**/
+	static function transferableAbortSignal(signal:AbortSignal):AbortSignal;
+
+	/**
+		Listens to abort on `signal` and resource lifetime; resolves when aborted (or resource GC'd).
+
+		@see https://nodejs.org/api/util.html#utilabortedsignal-resource
+	**/
+	static function aborted(signal:AbortSignal, resource:Any):Promise<Void>;
+
+	/**
+		Compares `actual` and `expected` and returns the differences as an array of diff entries.
+
+		@see https://nodejs.org/api/util.html#utildiffactual-expected
+	**/
+	static function diff(actual:EitherType<String, Array<String>>, expected:EitherType<String, Array<String>>):Array<DiffEntry>;
+
+	/**
+		Returns an array of call site objects from the current stack.
+
+		@see https://nodejs.org/api/util.html#utilgetcallsitesframecount-options
+	**/
+	@:overload(function(?options:GetCallSitesOptions):Array<CallSiteObject> {})
+	static function getCallSites(?frameCount:Int, ?options:GetCallSitesOptions):Array<CallSiteObject>;
+
+	/**
+		Legacy alias of `getCallSites`.
+
+		@see https://nodejs.org/api/util.html#utilgetcallsitesframecount-options
+	**/
+	@:deprecated("Use Util.getCallSites instead")
+	@:overload(function(?options:GetCallSitesOptions):Array<CallSiteObject> {})
+	static function getCallSite(?frameCount:Int, ?options:GetCallSitesOptions):Array<CallSiteObject>;
 
 	/**
 		Deprecated predecessor of `Console.error`.
@@ -132,115 +230,115 @@ extern class Util {
 		Deprecated predecessor of console.error.
 	**/
 	@:deprecated("Use js.Node.console.error instead")
-	static function error(args:Rest<Dynamic>):Void;
+	static function error(args:Rest<Any>):Void;
 
 	/**
 		Returns true if the given "object" is an Array. false otherwise.
 	**/
 	@:deprecated
-	static function isArray(object:Dynamic):Bool;
+	static function isArray(object:Any):Bool;
 
 	/**
 		Returns true if the given "object" is a Bool. false otherwise.
 	**/
 	@:deprecated
-	static function isBoolean(object:Dynamic):Bool;
+	static function isBoolean(object:Any):Bool;
 
 	/**
 		Returns true if the given "object" is a Buffer. false otherwise.
 	**/
 	@:deprecated
-	static function isBuffer(object:Dynamic):Bool;
+	static function isBuffer(object:Any):Bool;
 
 	/**
 		Returns true if the given "object" is a Date. false otherwise.
 	**/
 	@:deprecated
-	static function isDate(object:Dynamic):Bool;
+	static function isDate(object:Any):Bool;
 
 	/**
 		Returns true if the given "object" is an Error. false otherwise.
 	**/
 	@:deprecated
-	static function isError(object:Dynamic):Bool;
+	static function isError(object:Any):Bool;
 
 	/**
 		Returns true if the given "object" is a Function. false otherwise.
 	**/
 	@:deprecated
-	static function isFunction(object:Dynamic):Bool;
+	static function isFunction(object:Any):Bool;
 
 	/**
 		Returns true if the given "object" is strictly null. false otherwise.
 	**/
 	@:deprecated
-	static function isNull(object:Dynamic):Bool;
+	static function isNull(object:Any):Bool;
 
 	/**
 		Returns true if the given "object" is null or undefined. false otherwise.
 	**/
 	@:deprecated
-	static function isNullOrUndefined(object:Dynamic):Bool;
+	static function isNullOrUndefined(object:Any):Bool;
 
 	/**
 		Returns true if the given "object" is a Float. false otherwise.
 	**/
 	@:deprecated
-	static function isNumber(object:Dynamic):Bool;
+	static function isNumber(object:Any):Bool;
 
 	/**
 		Returns true if the given "object" is strictly an Object and not a Function. false otherwise.
 	**/
 	@:deprecated
-	static function isObject(object:Dynamic):Bool;
+	static function isObject(object:Any):Bool;
 
 	/**
 		Returns true if the given "object" is a primitive type. false otherwise.
 	**/
 	@:deprecated
-	static function isPrimitive(object:Dynamic):Bool;
+	static function isPrimitive(object:Any):Bool;
 
 	/**
 		Returns true if the given "object" is a RegExp. false otherwise.
 	**/
 	@:deprecated
-	static function isRegExp(object:Dynamic):Bool;
+	static function isRegExp(object:Any):Bool;
 
 	/**
 		Returns true if the given "object" is a String. false otherwise.
 	**/
 	@:deprecated
-	static function isString(object:Dynamic):Bool;
+	static function isString(object:Any):Bool;
 
 	/**
 		Returns true if the given "object" is a Symbol. false otherwise.
 	**/
 	@:deprecated
-	static function isSymbol(object:Dynamic):Bool;
+	static function isSymbol(object:Any):Bool;
 
 	/**
 		Returns true if the given "object" is undefined. false otherwise.
 	**/
 	@:deprecated
-	static function isUndefined(object:Dynamic):Bool;
+	static function isUndefined(object:Any):Bool;
 
 	/**
 		Output with timestamp on stdout.
 	**/
 	@:deprecated
-	static function log(args:Rest<Dynamic>):Void;
+	static function log(args:Rest<Any>):Void;
 
 	/**
 		Deprecated predecessor of console.log.
 	**/
 	@:deprecated("Use js.Node.console.log instead")
-	static function print(args:Rest<Dynamic>):Void;
+	static function print(args:Rest<Any>):Void;
 
 	/**
 		Deprecated predecessor of console.log.
 	**/
 	@:deprecated("Use js.Node.console.log instead")
-	static function puts(args:Rest<Dynamic>):Void;
+	static function puts(args:Rest<Any>):Void;
 
 	/**
 		Deprecated predecessor of stream.pipe().
@@ -338,7 +436,7 @@ typedef InspectOptions = {
 		If set to `true` the default sort is used.
 		If set to a function, it is used as a compare function.
 	**/
-	@:optional var sorted:EitherType<Bool, Dynamic->Dynamic->Int>;
+	@:optional var sorted:EitherType<Bool, Any->Any->Int>;
 
 	/**
 		If set to `true`, getters are inspected.
@@ -349,4 +447,76 @@ typedef InspectOptions = {
 		Default: `false`.
 	**/
 	@:optional var getters:EitherType<Bool, String>;
+}
+
+/**
+	Options object used by `Util.styleText`.
+**/
+typedef StyleTextOptions = {
+	/**
+		A stream that will be validated if it can be colored.
+
+		Default: `process.stdout`.
+	**/
+	@:optional var stream:Any;
+
+	/**
+		Value indicating whether `stream` is checked to see if it can handle colors.
+
+		Default: `true`.
+	**/
+	@:optional var validateStream:Bool;
+}
+
+/**
+	Configuration for `Util.parseArgs`.
+**/
+typedef ParseArgsConfig = {
+	@:optional var args:Array<String>;
+	@:optional var options:DynamicAccess<ParseArgsOptionDescriptor>;
+	@:optional var strict:Bool;
+	@:optional var allowPositionals:Bool;
+	@:optional var allowNegative:Bool;
+	@:optional var tokens:Bool;
+}
+
+/**
+	Descriptor for a single `parseArgs` option.
+**/
+typedef ParseArgsOptionDescriptor = {
+	@:optional var type:String;
+	@:optional var multiple:Bool;
+	@:optional var short:String;
+	@:optional @:native("default") var defaultValue:Any;
+}
+
+/**
+	Result of `Util.parseArgs`.
+**/
+typedef ParseArgsResult = {
+	var values:DynamicAccess<Any>;
+	var positionals:Array<String>;
+	@:optional var tokens:Array<Any>;
+}
+
+/**
+	A single entry from `Util.diff`.
+**/
+typedef DiffEntry = Array<EitherType<Int, String>>;
+
+/**
+	Options for `Util.getCallSites`.
+**/
+typedef GetCallSitesOptions = {
+	@:optional var sourceMap:Bool;
+}
+
+/**
+	A call site object returned by `Util.getCallSites`.
+**/
+typedef CallSiteObject = {
+	var functionName:String;
+	var scriptName:String;
+	var lineNumber:Int;
+	var columnNumber:Int;
 }

--- a/src/js/node/Util.hx
+++ b/src/js/node/Util.hx
@@ -221,6 +221,16 @@ extern class Util {
 	static function getCallSite(?frameCount:Int, ?options:GetCallSitesOptions):Array<CallSiteObject>;
 
 	/**
+		Converts a POSIX signal name (e.g. `'SIGTERM'`) to the corresponding process exit code.
+	**/
+	static function convertProcessSignalToExitCode(signal:String):Int;
+
+	/**
+		Enables or disables printing a stack trace when Node.js receives `SIGINT`.
+	**/
+	static function setTraceSigInt(enable:Bool):Void;
+
+	/**
 		Deprecated predecessor of `Console.error`.
 	**/
 	@:deprecated("Use js.Node.console.error instead")

--- a/src/js/node/assert/AssertionError.hx
+++ b/src/js/node/assert/AssertionError.hx
@@ -22,11 +22,8 @@
 
 package js.node.assert;
 
-#if haxe4
+import haxe.Constraints.Function;
 import js.lib.Error;
-#else
-import js.Error;
-#end
 
 /**
 	Indicates the failure of an assertion. All errors thrown by the `Assert` module will be instances of the `AssertionError` class.
@@ -43,12 +40,12 @@ extern class AssertionError extends Error {
 	/**
 		Set to the `actual` argument for methods such as `Assert.strictEqual()`.
 	**/
-	var actual:Dynamic;
+	var actual:Any;
 
 	/**
 		Set to the `expected` value for methods such as `Assert.strictEqual()`.
 	**/
-	var expected:Dynamic;
+	var expected:Any;
 
 	/**
 		Indicates if the message was auto-generated (`true`) or not.
@@ -78,22 +75,20 @@ typedef AssertionErrorOptions = {
 	/**
 		The `actual` property on the error instance.
 	**/
-	@:optional var actual:Dynamic;
+	@:optional var actual:Any;
 
 	/**
 		The `expected` property on the error instance.
 	**/
-	@:optional var expected:Dynamic;
+	@:optional var expected:Any;
 
-	#if (haxe_ver < 4)
 	/**
 		The `operator` property on the error instance.
 	**/
-	@:optional var operator:String;
-	#end
+	@:optional @:native("operator") var operator_:String;
 
 	/**
 		If provided, the generated stack trace omits frames before this function.
 	**/
-	@:optional var stackStartFunction:Dynamic;
+	@:optional var stackStartFunction:Function;
 }

--- a/src/js/node/assert/CallTracker.hx
+++ b/src/js/node/assert/CallTracker.hx
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.assert;
+
+import haxe.Constraints.Function;
+import js.lib.Error;
+
+/**
+	Deprecated tracking helper for verifying that functions were called the expected number of times.
+
+	@see https://nodejs.org/api/assert.html#class-assertcalltracker
+**/
+@:deprecated("assert.CallTracker is deprecated and may be removed in a future major release")
+@:jsRequire("assert", "CallTracker")
+extern class CallTracker {
+	function new();
+
+	/**
+		Returns a wrapper function that tracks calls to `fn`.
+		Must be called exactly `exact` times before `verify()`.
+	**/
+	@:overload(function(?exact:Int):Void->Void {})
+	@:overload(function(fn:Function, ?exact:Int):Function {})
+	function calls(?fn:Function, ?exact:Int):Function;
+
+	/**
+		Returns an array with information for all calls of the tracked function.
+	**/
+	function getCalls(fn:Function):Array<CallTrackerCall>;
+
+	/**
+		Reset call counts for a tracked function (or all if omitted).
+	**/
+	function reset(?fn:Function):Void;
+
+	/**
+		Report the number of times the tracked functions have been called.
+	**/
+	function report():Array<CallTrackerReportInformation>;
+
+	/**
+		Throw an error if expectations for tracked functions are not met.
+	**/
+	function verify():Void;
+}
+
+/**
+	A recorded call for `CallTracker.getCalls`.
+**/
+typedef CallTrackerCall = {
+	var thisArg:Any;
+	var arguments:Array<Any>;
+}
+
+/**
+	Report information from `CallTracker.report`.
+**/
+typedef CallTrackerReportInformation = {
+	var actual:Int;
+	var expected:Int;
+	var message:String;
+	@:optional @:native("operator") var operator_:String;
+	@:optional var stack:Any;
+}

--- a/src/js/node/crypto/Cipheriv.hx
+++ b/src/js/node/crypto/Cipheriv.hx
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation documents (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.crypto;
+
+/**
+	Constructor export for cipher instances created via `Crypto.createCipheriv`.
+	Prefer `Crypto.createCipheriv` over constructing this class directly.
+**/
+@:jsRequire("crypto", "Cipheriv")
+extern class Cipheriv extends Cipher {}

--- a/src/js/node/crypto/Cipheriv.hx
+++ b/src/js/node/crypto/Cipheriv.hx
@@ -2,7 +2,7 @@
  * Copyright (C)2014-2020 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation documents (the "Software"),
+ * copy of this software and associated documentation files (the "Software"),
  * to deal in the Software without restriction, including without limitation
  * the rights to use, copy, modify, merge, publish, distribute, sublicense,
  * and/or sell copies of the Software, and to permit persons to whom the

--- a/src/js/node/crypto/Decipheriv.hx
+++ b/src/js/node/crypto/Decipheriv.hx
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation documents (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.crypto;
+
+/**
+	Constructor export for decipher instances created via `Crypto.createDecipheriv`.
+	Prefer `Crypto.createDecipheriv` over constructing this class directly.
+**/
+@:jsRequire("crypto", "Decipheriv")
+extern class Decipheriv extends Decipher {}

--- a/src/js/node/crypto/Decipheriv.hx
+++ b/src/js/node/crypto/Decipheriv.hx
@@ -2,7 +2,7 @@
  * Copyright (C)2014-2020 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation documents (the "Software"),
+ * copy of this software and associated documentation files (the "Software"),
  * to deal in the Software without restriction, including without limitation
  * the rights to use, copy, modify, merge, publish, distribute, sublicense,
  * and/or sell copies of the Software, and to permit persons to whom the

--- a/src/js/node/crypto/DiffieHellmanGroup.hx
+++ b/src/js/node/crypto/DiffieHellmanGroup.hx
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation documents (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.crypto;
+
+/**
+	Predefined Diffie-Hellman group object returned by
+	`Crypto.getDiffieHellman` / `Crypto.createDiffieHellmanGroup`.
+
+	Unlike `DiffieHellman`, keys cannot be set with `setPublicKey` / `setPrivateKey`.
+**/
+@:jsRequire("crypto", "DiffieHellmanGroup")
+extern class DiffieHellmanGroup implements IDiffieHellman {
+	@:overload(function():js.node.Buffer {})
+	function generateKeys(encoding:String):String;
+
+	@:overload(function(other_public_key:js.node.Buffer):js.node.Buffer {})
+	@:overload(function(other_public_key:String, input_encoding:String):js.node.Buffer {})
+	function computeSecret(other_public_key:String, input_encoding:String, output_encoding:String):String;
+
+	@:overload(function():js.node.Buffer {})
+	function getPrime(encoding:String):String;
+
+	@:overload(function():js.node.Buffer {})
+	function getGenerator(encoding:String):String;
+
+	@:overload(function():js.node.Buffer {})
+	function getPublicKey(encoding:String):String;
+
+	@:overload(function():js.node.Buffer {})
+	function getPrivateKey(encoding:String):String;
+}

--- a/src/js/node/crypto/DiffieHellmanGroup.hx
+++ b/src/js/node/crypto/DiffieHellmanGroup.hx
@@ -2,7 +2,7 @@
  * Copyright (C)2014-2020 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation documents (the "Software"),
+ * copy of this software and associated documentation files (the "Software"),
  * to deal in the Software without restriction, including without limitation
  * the rights to use, copy, modify, merge, publish, distribute, sublicense,
  * and/or sell copies of the Software, and to permit persons to whom the
@@ -22,6 +22,8 @@
 
 package js.node.crypto;
 
+import js.node.Buffer;
+
 /**
 	Predefined Diffie-Hellman group object returned by
 	`Crypto.getDiffieHellman` / `Crypto.createDiffieHellmanGroup`.
@@ -29,23 +31,23 @@ package js.node.crypto;
 	Unlike `DiffieHellman`, keys cannot be set with `setPublicKey` / `setPrivateKey`.
 **/
 @:jsRequire("crypto", "DiffieHellmanGroup")
-extern class DiffieHellmanGroup implements IDiffieHellman {
-	@:overload(function():js.node.Buffer {})
+extern class DiffieHellmanGroup {
+	@:overload(function():Buffer {})
 	function generateKeys(encoding:String):String;
 
-	@:overload(function(other_public_key:js.node.Buffer):js.node.Buffer {})
-	@:overload(function(other_public_key:String, input_encoding:String):js.node.Buffer {})
+	@:overload(function(other_public_key:Buffer):Buffer {})
+	@:overload(function(other_public_key:String, input_encoding:String):Buffer {})
 	function computeSecret(other_public_key:String, input_encoding:String, output_encoding:String):String;
 
-	@:overload(function():js.node.Buffer {})
+	@:overload(function():Buffer {})
 	function getPrime(encoding:String):String;
 
-	@:overload(function():js.node.Buffer {})
+	@:overload(function():Buffer {})
 	function getGenerator(encoding:String):String;
 
-	@:overload(function():js.node.Buffer {})
+	@:overload(function():Buffer {})
 	function getPublicKey(encoding:String):String;
 
-	@:overload(function():js.node.Buffer {})
+	@:overload(function():Buffer {})
 	function getPrivateKey(encoding:String):String;
 }

--- a/src/js/node/crypto/KeyObject.hx
+++ b/src/js/node/crypto/KeyObject.hx
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.crypto;
+
+import haxe.extern.EitherType;
+import js.html.CryptoKey;
+import js.node.Buffer;
+
+/**
+	Node.js representation of a key for use by crypto APIs.
+	Instances are created via `Crypto.create*Key` / `generateKey*` helpers.
+
+	@see https://nodejs.org/api/crypto.html#class-keyobject
+**/
+@:jsRequire("crypto", "KeyObject")
+extern class KeyObject {
+	/**
+		Converts a Web Crypto `CryptoKey` to a Node.js `KeyObject`.
+	**/
+	static function from(key:CryptoKey):KeyObject;
+
+	/**
+		Depending on the type of this `KeyObject`, this property is either
+		`'secret'`, `'public'`, or `'private'`.
+	**/
+	var type(default, never):KeyObjectType;
+
+	/**
+		For asymmetric keys, the type of the key (e.g. `'rsa'`, `'ec'`, `'ed25519'`).
+		`undefined` for secret keys.
+	**/
+	@:optional var asymmetricKeyType(default, never):String;
+
+	/**
+		Details about an asymmetric key. `undefined` for secret keys.
+
+		// TODO(section-4): finer-grained AsymmetricKeyDetails fields
+	**/
+	@:optional var asymmetricKeyDetails(default, never):Any;
+
+	/**
+		For secret keys, the size of the key in bytes. `undefined` for asymmetric keys.
+	**/
+	@:optional var symmetricKeySize(default, never):Int;
+
+	/**
+		Returns `true` if the keys have exactly the same type, value, and parameters.
+	**/
+	function equals(otherKeyObject:KeyObject):Bool;
+
+	/**
+		Exports the key material.
+		Result type depends on `format` (`'pem'` → String, `'der'` → Buffer, `'jwk'` → object).
+	**/
+	function export(?options:KeyExportOptions):EitherType<String, EitherType<Buffer, Any>>;
+}
+
+/**
+	Possible values for `KeyObject.type`.
+**/
+enum abstract KeyObjectType(String) from String to String {
+	var Secret = "secret";
+	var Public = "public";
+	var Private = "private";
+}
+
+/**
+	Options for `KeyObject.export`.
+**/
+typedef KeyExportOptions = {
+	@:optional var type:String;
+	@:optional var format:String;
+	@:optional var cipher:String;
+	@:optional var passphrase:EitherType<String, Buffer>;
+}

--- a/src/js/node/crypto/X509Certificate.hx
+++ b/src/js/node/crypto/X509Certificate.hx
@@ -1,0 +1,170 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.crypto;
+
+import haxe.extern.EitherType;
+import js.node.Buffer;
+
+/**
+	Encapsulates an X509 certificate and provides read-only access to its information.
+
+	@see https://nodejs.org/api/crypto.html#class-x509certificate
+**/
+@:jsRequire("crypto", "X509Certificate")
+extern class X509Certificate {
+	/**
+		Creates a new `X509Certificate` object from PEM or DER encoded data.
+	**/
+	function new(buffer:EitherType<String, EitherType<Buffer, js.lib.ArrayBufferView>>);
+
+	/**
+		The SHA-1 fingerprint of this certificate.
+	**/
+	var fingerprint(default, never):String;
+
+	/**
+		The SHA-256 fingerprint of this certificate.
+	**/
+	var fingerprint256(default, never):String;
+
+	/**
+		The SHA-512 fingerprint of this certificate.
+	**/
+	var fingerprint512(default, never):String;
+
+	/**
+		The issuer identification included in this certificate.
+	**/
+	var issuer(default, never):String;
+
+	/**
+		The subject identification included in this certificate.
+	**/
+	var subject(default, never):String;
+
+	/**
+		The subject alternative names included in this certificate.
+	**/
+	@:optional var subjectAltName(default, never):String;
+
+	/**
+		Information access information for this certificate.
+	**/
+	@:optional var infoAccess(default, never):String;
+
+	/**
+		The date/time from which this certificate is valid (ISO string).
+	**/
+	var validFrom(default, never):String;
+
+	/**
+		The date/time until which this certificate is valid (ISO string).
+	**/
+	var validTo(default, never):String;
+
+	/**
+		The date from which this certificate is valid.
+	**/
+	var validFromDate(default, never):js.lib.Date;
+
+	/**
+		The date until which this certificate is valid.
+	**/
+	var validToDate(default, never):js.lib.Date;
+
+	/**
+		The serial number of this certificate.
+	**/
+	var serialNumber(default, never):String;
+
+	/**
+		The algorithm used to sign this certificate.
+	**/
+	var signatureAlgorithm(default, never):String;
+
+	/**
+		The raw DER bytes of this certificate.
+	**/
+	var raw(default, never):Buffer;
+
+	/**
+		The public key of this certificate.
+	**/
+	var publicKey(default, never):KeyObject;
+
+	/**
+		`true` if this is a Certificate Authority (CA) certificate.
+	**/
+	var ca(default, never):Bool;
+
+	/**
+		Key usages for this certificate, if any.
+	**/
+	var keyUsage(default, never):Array<String>;
+
+	/**
+		Checks whether the certificate matches the given host name.
+	**/
+	function checkHost(name:String, ?options:X509CheckOptions):Null<String>;
+
+	/**
+		Checks whether the certificate matches the given email address.
+	**/
+	function checkEmail(email:String, ?options:X509CheckOptions):Null<String>;
+
+	/**
+		Checks whether the certificate matches the given IP address (IPv4 or IPv6).
+	**/
+	function checkIP(ip:String):Null<String>;
+
+	/**
+		Checks whether this certificate was issued by the given `otherCert`.
+	**/
+	function checkIssued(otherCert:X509Certificate):Bool;
+
+	/**
+		Checks whether the public key for this certificate matches the given private key.
+	**/
+	function checkPrivateKey(privateKey:KeyObject):Bool;
+
+	/**
+		PEM encoding of this certificate.
+	**/
+	function toString():String;
+
+	/**
+		Legacy encoding used by older Node.js versions / JSON serialization helper.
+	**/
+	function toJSON():String;
+}
+
+/**
+	Options for `X509Certificate` host/email checks.
+**/
+typedef X509CheckOptions = {
+	@:optional var subject:String;
+	@:optional var wildcards:Bool;
+	@:optional var partialWildcards:Bool;
+	@:optional var multiLabelWildcards:Bool;
+	@:optional var singleLabelSubdomains:Bool;
+}

--- a/src/js/node/url/URL.hx
+++ b/src/js/node/url/URL.hx
@@ -36,6 +36,18 @@ extern class URL {
 	function new(input:String, ?base:String):Void;
 
 	/**
+		Checks whether `input` can be successfully parsed as a URL relative to `base`.
+	**/
+	@:overload(function(input:String, ?base:URL):Bool {})
+	static function canParse(input:String, ?base:String):Bool;
+
+	/**
+		Parses `input` relative to `base` into a `URL` object, or returns `null` on failure.
+	**/
+	@:overload(function(input:String, ?base:URL):Null<URL> {})
+	static function parse(input:String, ?base:String):Null<URL>;
+
+	/**
 		Gets and sets the fragment portion of the URL.
 	**/
 	var hash:String;

--- a/src/js/node/url/URLPattern.hx
+++ b/src/js/node/url/URLPattern.hx
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.url;
+
+import haxe.extern.EitherType;
+
+/**
+	The `URLPattern` API provides pattern matching for URLs.
+
+	@see https://nodejs.org/api/url.html#class-urlpattern
+**/
+@:jsRequire("url", "URLPattern")
+extern class URLPattern {
+	@:overload(function(input:EitherType<String, URLPatternInit>, baseURL:String, ?options:URLPatternOptions):Void {})
+	function new(?input:EitherType<String, URLPatternInit>, ?options:URLPatternOptions):Void;
+
+	final hasRegExpGroups:Bool;
+	final hash:String;
+	final hostname:String;
+	final password:String;
+	final pathname:String;
+	final port:String;
+	final protocol:String;
+	final search:String;
+	final username:String;
+
+	function exec(?input:EitherType<String, URLPatternInit>, ?baseURL:String):Null<URLPatternResult>;
+	function test(?input:EitherType<String, URLPatternInit>, ?baseURL:String):Bool;
+}
+
+/**
+	Initialization object for `URLPattern`.
+**/
+typedef URLPatternInit = {
+	@:optional var protocol:String;
+	@:optional var username:String;
+	@:optional var password:String;
+	@:optional var hostname:String;
+	@:optional var port:String;
+	@:optional var pathname:String;
+	@:optional var search:String;
+	@:optional var hash:String;
+	@:optional var baseURL:String;
+}
+
+/**
+	Options for `URLPattern`.
+**/
+typedef URLPatternOptions = {
+	@:optional var ignoreCase:Bool;
+}
+
+/**
+	Result of `URLPattern.exec`.
+**/
+typedef URLPatternResult = {
+	var inputs:Array<EitherType<String, URLPatternInit>>;
+	var protocol:URLPatternComponentResult;
+	var username:URLPatternComponentResult;
+	var password:URLPatternComponentResult;
+	var hostname:URLPatternComponentResult;
+	var port:URLPatternComponentResult;
+	var pathname:URLPatternComponentResult;
+	var search:URLPatternComponentResult;
+	var hash:URLPatternComponentResult;
+}
+
+/**
+	A single URL component match result.
+**/
+typedef URLPatternComponentResult = {
+	var input:String;
+	var groups:haxe.DynamicAccess<Null<String>>;
+}

--- a/src/js/node/url/URLSearchParams.hx
+++ b/src/js/node/url/URLSearchParams.hx
@@ -22,6 +22,7 @@
 
 package js.node.url;
 
+import haxe.DynamicAccess;
 import js.node.Iterator;
 
 /**
@@ -35,7 +36,7 @@ import js.node.Iterator;
 @:jsRequire("url", "URLSearchParams")
 extern class URLSearchParams {
 	@:overload(function(init:String):Void {})
-	@:overload(function(obj:Dynamic<String>):Void {})
+	@:overload(function(obj:DynamicAccess<String>):Void {})
 	@:overload(function(array:Array<URLSearchParamsEntry>):Void {})
 	@:overload(function(iter:Iterator<URLSearchParamsEntry>):Void {})
 	function new():Void;
@@ -60,15 +61,9 @@ extern class URLSearchParams {
 	/**
 		Iterates over each name-value pair in the query and invokes the given function.
 	**/
-	#if haxe4
-	@:overload(function(fn:(value:String) -> Void, ?thisArg:Dynamic):Void {})
-	@:overload(function(fn:(value:String, name:String) -> Void, ?thisArg:Dynamic):Void {})
-	function forEach(fn:(value:String, name:String, searchParams:URLSearchParams) -> Void, ?thisArg:Dynamic):Void;
-	#else
-	@:overload(function(fn:String->Void, ?thisArg:Dynamic):Void {})
-	@:overload(function(fn:String->String->Void, ?thisArg:Dynamic):Void {})
-	function forEach(fn:String->String->URLSearchParams->Void, ?thisArg:Dynamic):Void;
-	#end
+	@:overload(function(fn:(value:String) -> Void, ?thisArg:Any):Void {})
+	@:overload(function(fn:(value:String, name:String) -> Void, ?thisArg:Any):Void {})
+	function forEach(fn:(value:String, name:String, searchParams:URLSearchParams) -> Void, ?thisArg:Any):Void;
 
 	/**
 		Returns the value of the first name-value pair whose name is `name`.

--- a/src/js/node/util/Inspect.hx
+++ b/src/js/node/util/Inspect.hx
@@ -23,6 +23,7 @@
 package js.node.util;
 
 import haxe.DynamicAccess;
+import js.lib.Symbol;
 import js.node.Util.InspectOptions;
 
 @:jsRequire("util", "inspect")
@@ -33,8 +34,8 @@ extern class Inspect {
 		@see https://nodejs.org/api/util.html#util_util_inspect_object_options
 	**/
 	@:selfCall
-	@:overload(function(object:Dynamic, ?showHidden:Bool, ?depth:Int, ?colors:Bool):String {})
-	static function inspect(object:Dynamic, ?options:InspectOptions):String;
+	@:overload(function(object:Any, ?showHidden:Bool, ?depth:Int, ?colors:Bool):String {})
+	static function inspect(object:Any, ?options:InspectOptions):String;
 
 	/**
 		`util.inspect.styles` is a map associating a style name to a color from `util.inspect.colors` properties.
@@ -55,11 +56,7 @@ extern class Inspect {
 
 		@see https://nodejs.org/api/util.html#util_util_inspect_custom
 	**/
-	#if haxe4
-	static final custom:js.lib.Symbol;
-	#else
-	static var custom(default, never):Dynamic;
-	#end
+	static final custom:Symbol;
 
 	/**
 		The `defaultOptions` value allows customization of the default options used by `util.inspect`.

--- a/src/js/node/util/MIMEParams.hx
+++ b/src/js/node/util/MIMEParams.hx
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.util;
+
+import js.node.Iterator;
+import js.node.KeyValue;
+
+/**
+	The `MIMEParams` API provides read and write access to the parameters of a `MIMEType`.
+
+	@see https://nodejs.org/api/util.html#class-utilmimeparams
+**/
+@:jsRequire("util", "MIMEParams")
+extern class MIMEParams {
+	/**
+		Creates a new `MIMEParams` object with empty parameters.
+	**/
+	function new();
+
+	/**
+		Remove all name-value pairs whose name is `name`.
+	**/
+	function delete(name:String):Void;
+
+	/**
+		Returns an iterator over each of the name-value pairs in the parameters.
+	**/
+	function entries():Iterator<KeyValue<String, String>>;
+
+	/**
+		Returns the value of the first name-value pair whose name is `name`.
+		If there are no such pairs, `null` is returned.
+	**/
+	function get(name:String):Null<String>;
+
+	/**
+		Returns a value indicating whether there is at least one name-value pair whose name is `name`.
+	**/
+	function has(name:String):Bool;
+
+	/**
+		Returns an iterator over the names of each name-value pair.
+	**/
+	function keys():Iterator<String>;
+
+	/**
+		Sets the value in the `MIMEParams` object associated with `name` to `value`.
+		If there are any pre-existing name-value pairs whose names are `name`, set the first such pair's value to `value`.
+	**/
+	function set(name:String, value:String):Void;
+
+	/**
+		Returns an iterator over the values of each name-value pair.
+	**/
+	function values():Iterator<String>;
+}

--- a/src/js/node/util/MIMEType.hx
+++ b/src/js/node/util/MIMEType.hx
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.util;
+
+import haxe.extern.EitherType;
+
+/**
+	An implementation of the MIMEType class.
+
+	@see https://nodejs.org/api/util.html#class-utilmimetype
+**/
+@:jsRequire("util", "MIMEType")
+extern class MIMEType {
+	/**
+		Gets the essence of the MIME.
+	**/
+	final essence:String;
+
+	/**
+		Gets the `MIMEParams` object representing the parameters of the MIME.
+	**/
+	final params:MIMEParams;
+
+	/**
+		Gets and sets the subtype portion of the MIME.
+	**/
+	var subtype:String;
+
+	/**
+		Gets and sets the type portion of the MIME.
+	**/
+	var type:String;
+
+	/**
+		Creates a new `MIMEType` object by parsing the `input`.
+	**/
+	function new(input:EitherType<String, {toString:() -> String}>);
+
+	/**
+		Alias for `toString()`.
+	**/
+	function toJSON():String;
+
+	/**
+		Returns the serialized MIME.
+	**/
+	function toString():String;
+}

--- a/src/js/node/util/Promisify.hx
+++ b/src/js/node/util/Promisify.hx
@@ -1,54 +1,48 @@
-/*
- * Copyright (C)2014-2020 Haxe Foundation
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- */
-
-package js.node.util;
-
-import haxe.Constraints.Function;
-import haxe.extern.Rest;
-#if haxe4
-import js.lib.Promise;
-#else
-import js.Promise;
-#end
-
-@:jsRequire("util", "promisify")
-extern class Promisify {
-	/**
-		Takes a function following the common error-first callback style, i.e. taking an `(err, value) => ...` callback
-		as the last argument, and returns a version that returns promises.
-
-		@see https://nodejs.org/api/util.html#util_util_promisify_original
-	**/
-	@:selfCall
-	static function promisify(original:Function):Rest<Dynamic>->Promise<Dynamic>;
-
-	/**
-		That can be used to declare custom promisified variants of functions, see Custom promisified functions.
-
-		@see https://nodejs.org/api/util.html#util_util_promisify_custom
-	**/
-	#if haxe4
-	static final custom:js.lib.Symbol;
-	#else
-	static var custom(default, never):Dynamic;
-	#end
-}
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.util;
+
+import haxe.Constraints.Function;
+import haxe.extern.Rest;
+import js.lib.Promise;
+import js.lib.Symbol;
+
+@:jsRequire("util", "promisify")
+extern class Promisify {
+	/**
+		Takes a function following the common error-first callback style, i.e. taking an `(err, value) => ...` callback
+		as the last argument, and returns a version that returns promises.
+
+		@see https://nodejs.org/api/util.html#util_util_promisify_original
+	**/
+	@:selfCall
+	// TODO(section-4): tighten promisify generic result typing
+	static function promisify(original:Function):Rest<Any>->Promise<Any>;
+
+	/**
+		That can be used to declare custom promisified variants of functions, see Custom promisified functions.
+
+		@see https://nodejs.org/api/util.html#util_util_promisify_custom
+	**/
+	static final custom:Symbol;
+}

--- a/src/js/node/util/Promisify.hx
+++ b/src/js/node/util/Promisify.hx
@@ -1,48 +1,48 @@
-/*
- * Copyright (C)2014-2020 Haxe Foundation
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- */
-
-package js.node.util;
-
-import haxe.Constraints.Function;
-import haxe.extern.Rest;
-import js.lib.Promise;
-import js.lib.Symbol;
-
-@:jsRequire("util", "promisify")
-extern class Promisify {
-	/**
-		Takes a function following the common error-first callback style, i.e. taking an `(err, value) => ...` callback
-		as the last argument, and returns a version that returns promises.
-
-		@see https://nodejs.org/api/util.html#util_util_promisify_original
-	**/
-	@:selfCall
-	// TODO(section-4): tighten promisify generic result typing
-	static function promisify(original:Function):Rest<Any>->Promise<Any>;
-
-	/**
-		That can be used to declare custom promisified variants of functions, see Custom promisified functions.
-
-		@see https://nodejs.org/api/util.html#util_util_promisify_custom
-	**/
-	static final custom:Symbol;
-}
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.util;
+
+import haxe.Constraints.Function;
+import haxe.extern.Rest;
+import js.lib.Promise;
+import js.lib.Symbol;
+
+@:jsRequire("util", "promisify")
+extern class Promisify {
+	/**
+		Takes a function following the common error-first callback style, i.e. taking an `(err, value) => ...` callback
+		as the last argument, and returns a version that returns promises.
+
+		@see https://nodejs.org/api/util.html#util_util_promisify_original
+	**/
+	@:selfCall
+	// TODO(section-4): tighten promisify generic result typing
+	static function promisify(original:Function):Rest<Any>->Promise<Any>;
+
+	/**
+		That can be used to declare custom promisified variants of functions, see Custom promisified functions.
+
+		@see https://nodejs.org/api/util.html#util_util_promisify_custom
+	**/
+	static final custom:Symbol;
+}

--- a/src/js/node/util/TextDecoder.hx
+++ b/src/js/node/util/TextDecoder.hx
@@ -23,13 +23,8 @@
 package js.node.util;
 
 import haxe.extern.EitherType;
-#if haxe4
 import js.lib.ArrayBuffer;
 import js.lib.ArrayBufferView;
-#else
-import js.html.ArrayBuffer;
-import js.html.ArrayBufferView;
-#end
 
 /**
 	An implementation of the WHATWG Encoding Standard `TextDecoder` API.

--- a/src/js/node/util/TextEncoder.hx
+++ b/src/js/node/util/TextEncoder.hx
@@ -22,11 +22,7 @@
 
 package js.node.util;
 
-#if haxe4
 import js.lib.Uint8Array;
-#else
-import js.html.Uint8Array;
-#end
 
 /**
 	An implementation of the WHATWG Encoding Standard `TextEncoder` API.

--- a/src/js/node/util/Types.hx
+++ b/src/js/node/util/Types.hx
@@ -34,49 +34,56 @@ extern class Types {
 
 		@see https://nodejs.org/api/util.html#util_util_types_isanyarraybuffer_value
 	**/
-	static function isAnyArrayBuffer(value:Dynamic):Bool;
+	static function isAnyArrayBuffer(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is an `arguments` object.
 
 		@see https://nodejs.org/api/util.html#util_util_types_isargumentsobject_value
 	**/
-	static function isArgumentsObject(value:Dynamic):Bool;
+	static function isArgumentsObject(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a built-in `ArrayBuffer` instance.
 
 		@see https://nodejs.org/api/util.html#util_util_types_isarraybuffer_value
 	**/
-	static function isArrayBuffer(value:Dynamic):Bool;
+	static function isArrayBuffer(value:Any):Bool;
+
+	/**
+		Returns `true` if the value is an `ArrayBufferView` (TypedArray or DataView).
+
+		@see https://nodejs.org/api/util.html#util_util_types_isarraybufferview_value
+	**/
+	static function isArrayBufferView(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is an async function.
 
 		@see https://nodejs.org/api/util.html#util_util_types_isasyncfunction_value
 	**/
-	static function isAsyncFunction(value:Dynamic):Bool;
+	static function isAsyncFunction(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a `BigInt64Array` instance.
 
 		@see https://nodejs.org/api/util.html#util_util_types_isbigint64array_value
 	**/
-	static function isBigInt64Array(value:Dynamic):Bool;
+	static function isBigInt64Array(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a `BigUint64Array` instance.
 
 		@see https://nodejs.org/api/util.html#util_util_types_isbiguint64array_value
 	**/
-	static function isBigUint64Array(value:Dynamic):Bool;
+	static function isBigUint64Array(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a boolean object, e.g. created by `new Boolean()`.
 
 		@see https://nodejs.org/api/util.html#util_util_types_isbooleanobject_value
 	**/
-	static function isBooleanObject(value:Dynamic):Bool;
+	static function isBooleanObject(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is any boxed primitive object, e.g. created by `new Boolean()`, `new String()` or
@@ -84,222 +91,242 @@ extern class Types {
 
 		@see https://nodejs.org/api/util.html#util_util_types_isboxedprimitive_value
 	**/
-	static function isBoxedPrimitive(value:Dynamic):Bool;
+	static function isBoxedPrimitive(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a built-in `DataView` instance.
 
 		@see https://nodejs.org/api/util.html#util_util_types_isdataview_value
 	**/
-	static function isDataView(value:Dynamic):Bool;
+	static function isDataView(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a built-in `Date` instance.
 
 		@see https://nodejs.org/api/util.html#util_util_types_isdate_value
 	**/
-	static function isDate(value:Dynamic):Bool;
+	static function isDate(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a native `External` value.
 
 		@see https://nodejs.org/api/util.html#util_util_types_isexternal_value
 	**/
-	static function isExternal(value:Dynamic):Bool;
+	static function isExternal(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a built-in `Float32Array` instance.
 
 		@see https://nodejs.org/api/util.html#util_util_types_isfloat32array_value
 	**/
-	static function isFloat32Array(value:Dynamic):Bool;
+	static function isFloat32Array(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a built-in `Float64Array` instance.
 
 		@see https://nodejs.org/api/util.html#util_util_types_isfloat64array_value
 	**/
-	static function isFloat64Array(value:Dynamic):Bool;
+	static function isFloat64Array(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a generator function.
 
 		@see https://nodejs.org/api/util.html#util_util_types_isgeneratorfunction_value
 	**/
-	static function isGeneratorFunction(value:Dynamic):Bool;
+	static function isGeneratorFunction(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a generator object as returned from a built-in generator function.
 
 		@see https://nodejs.org/api/util.html#util_util_types_isgeneratorobject_value
 	**/
-	static function isGeneratorObject(value:Dynamic):Bool;
+	static function isGeneratorObject(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a built-in `Int8Array` instance.
 
 		@see https://nodejs.org/api/util.html#util_util_types_isint8array_value
 	**/
-	static function isInt8Array(value:Dynamic):Bool;
+	static function isInt8Array(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a built-in `Int16Array` instance.
 
 		@see https://nodejs.org/api/util.html#util_util_types_isint16array_value
 	**/
-	static function isInt16Array(value:Dynamic):Bool;
+	static function isInt16Array(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a built-in `Int32Array` instance.
 
 		@see https://nodejs.org/api/util.html#util_util_types_isint32array_value
 	**/
-	static function isInt32Array(value:Dynamic):Bool;
+	static function isInt32Array(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a built-in `Map` instance.
 
 		@see https://nodejs.org/api/util.html#util_util_types_ismap_value
 	**/
-	static function isMap(value:Dynamic):Bool;
+	static function isMap(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is an iterator returned for a built-in `Map` instance.
 
 		@see https://nodejs.org/api/util.html#util_util_types_ismapiterator_value
 	**/
-	static function isMapIterator(value:Dynamic):Bool;
+	static function isMapIterator(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is an instance of a Module Namespace Object.
 
 		@see https://nodejs.org/api/util.html#util_util_types_ismodulenamespaceobject_value
 	**/
-	static function isModuleNamespaceObject(value:Dynamic):Bool;
+	static function isModuleNamespaceObject(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is an instance of a built-in `Error` type.
 
 		@see https://nodejs.org/api/util.html#util_util_types_isnativeerror_value
 	**/
-	static function isNativeError(value:Dynamic):Bool;
+	static function isNativeError(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a number object, e.g. created by `new Number()`.
 
 		@see https://nodejs.org/api/util.html#util_util_types_isnumberobject_value
 	**/
-	static function isNumberObject(value:Dynamic):Bool;
+	static function isNumberObject(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a built-in `Promise`.
 
 		@see https://nodejs.org/api/util.html#util_util_types_ispromise_value
 	**/
-	static function isPromise(value:Dynamic):Bool;
+	static function isPromise(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a `Proxy` instance.
 
 		@see https://nodejs.org/api/util.html#util_util_types_isproxy_value
 	**/
-	static function isProxy(value:Dynamic):Bool;
+	static function isProxy(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a regular expression object.
 
 		@see https://nodejs.org/api/util.html#util_util_types_isregexp_value
 	**/
-	static function isRegExp(value:Dynamic):Bool;
+	static function isRegExp(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a built-in `Set` instance.
 
 		@see https://nodejs.org/api/util.html#util_util_types_isset_value
 	**/
-	static function isSet(value:Dynamic):Bool;
+	static function isSet(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is an iterator returned for a built-in `Set` instance.
 
 		@see https://nodejs.org/api/util.html#util_util_types_issetiterator_value
 	**/
-	static function isSetIterator(value:Dynamic):Bool;
+	static function isSetIterator(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a built-in `SharedArrayBuffer` instance.
 
 		@see https://nodejs.org/api/util.html#util_util_types_issharedarraybuffer_value
 	**/
-	static function isSharedArrayBuffer(value:Dynamic):Bool;
+	static function isSharedArrayBuffer(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a string object, e.g. created by `new String()`.
 
 		@see https://nodejs.org/api/util.html#util_util_types_isstringobject_value
 	**/
-	static function isStringObject(value:Dynamic):Bool;
+	static function isStringObject(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a symbol object, created by calling `Object()` on a `Symbol` primitive.
 
 		@see https://nodejs.org/api/util.html#util_util_types_issymbolobject_value
 	**/
-	static function isSymbolObject(value:Dynamic):Bool;
+	static function isSymbolObject(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a built-in `TypedArray` instance.
 
 		@see https://nodejs.org/api/util.html#util_util_types_istypedarray_value
 	**/
-	static function isTypedArray(value:Dynamic):Bool;
+	static function isTypedArray(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a built-in `Uint8Array` instance.
 
 		@see https://nodejs.org/api/util.html#util_util_types_isuint8array_value
 	**/
-	static function isUint8Array(value:Dynamic):Bool;
+	static function isUint8Array(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a built-in `Uint8ClampedArray` instance.
 
 		@see https://nodejs.org/api/util.html#util_util_types_isuint8clampedarray_value
 	**/
-	static function isUint8ClampedArray(value:Dynamic):Bool;
+	static function isUint8ClampedArray(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a built-in `Uint16Array` instance.
 
 		@see https://nodejs.org/api/util.html#util_util_types_isuint16array_value
 	**/
-	static function isUint16Array(value:Dynamic):Bool;
+	static function isUint16Array(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a built-in `Uint32Array` instance.
 
 		@see https://nodejs.org/api/util.html#util_util_types_isuint32array_value
 	**/
-	static function isUint32Array(value:Dynamic):Bool;
+	static function isUint32Array(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a built-in `WeakMap` instance.
 
 		@see https://nodejs.org/api/util.html#util_util_types_isweakmap_value
 	**/
-	static function isWeakMap(value:Dynamic):Bool;
+	static function isWeakMap(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a built-in `WeakSet` instance.
 
 		@see https://nodejs.org/api/util.html#util_util_types_isweakset_value
 	**/
-	static function isWeakSet(value:Dynamic):Bool;
+	static function isWeakSet(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a built-in `WebAssembly.Module` instance.
 
 		@see https://nodejs.org/api/util.html#util_util_types_iswebassemblycompiledmodule_value
 	**/
-	static function isWebAssemblyCompiledModule(value:Dynamic):Bool;
+	static function isWebAssemblyCompiledModule(value:Any):Bool;
+
+	/**
+		Returns `true` if the value is a `BigInt` object boxed wrapper (not a primitive BigInt).
+	**/
+	static function isBigIntObject(value:Any):Bool;
+
+	/**
+		Returns `true` if the value is a `Float16Array` instance.
+	**/
+	static function isFloat16Array(value:Any):Bool;
+
+	/**
+		Returns `true` if the value is a `KeyObject` from the `crypto` module.
+	**/
+	static function isKeyObject(value:Any):Bool;
+
+	/**
+		Returns `true` if the value is a Web Crypto `CryptoKey` instance.
+	**/
+	static function isCryptoKey(value:Any):Bool;
 }


### PR DESCRIPTION
## Summary
- Drop Haxe 3 `#if haxe4` / `js.html` ArrayBuffer fallbacks across crypto, util, assert, and url packages.
- Fill Node.js v24 Active LTS gaps: `KeyObject`/`X509Certificate`, key generation/KEM/argon2, one-shot `hash`/`sign`/`verify`, util `parseArgs`/`MIMEType`/`styleText`/etc., `assert.CallTracker`, `URLPattern`/`fileURLToPathBuffer`, `querystring.unescapeBuffer`.
- Replace avoidable `Dynamic` with `Any` / tighter types; leave remaining soft spots as `// TODO(section-4): …`.
- Web Crypto exposed via `crypto.subtle` / `crypto.webcrypto` (typed to std `js.html.*`); no separate `js.node.webcrypto` package.

## Test plan
- [x] `haxe build.hxml` with Haxe 4.0.0
- [x] `haxe build.hxml` with current Haxe
- [ ] Spot-check against Node 24 docs for any remaining missing exports

## Remaining TODOs
- Full SubtleCrypto / Node-only Web Crypto additions beyond `js.html.Crypto`
- Finer-grained `generateKeyPair*` overloads / encodings
- Finer `KeyObject.asymmetricKeyDetails` / `parseArgs` generics
- Tighten `callbackify` / `promisify` typings


Made with [Cursor](https://cursor.com)