### PR TITLE
Audit js.node.web for Node 24 web globals

### DIFF
--- a/src/js/node/web/AbortController.hx
+++ b/src/js/node/web/AbortController.hx
@@ -26,6 +26,8 @@ package js.node.web;
 	A utility class used to signal cancelation in selected `Promise`-based APIs.
 	The API is based on the Web API `AbortController`.
 
+	// TODO(section-1): wire `AbortController` on `js.Node` / `globalThis` facade if desired.
+
 	@see https://nodejs.org/api/globals.html#class-abortcontroller
 **/
 @:native("AbortController")
@@ -42,5 +44,5 @@ extern class AbortController {
 
 		@param reason An optional reason, retrievable on the `AbortSignal`'s `reason` property.
 	**/
-	function abort(?reason:Dynamic):Void;
+	function abort(?reason:Any):Void;
 }

--- a/src/js/node/web/AbortSignal.hx
+++ b/src/js/node/web/AbortSignal.hx
@@ -22,8 +22,6 @@
 
 package js.node.web;
 
-import haxe.Constraints.Function;
-
 /**
 	Used to notify observers when `AbortController.abort()` is called.
 
@@ -37,7 +35,7 @@ extern class AbortSignal extends EventTarget {
 	/**
 		Returns a new already aborted `AbortSignal`.
 	**/
-	static function abort(?reason:Dynamic):AbortSignal;
+	static function abort(?reason:Any):AbortSignal;
 
 	/**
 		Returns a new `AbortSignal` which will be aborted in `delay` milliseconds.
@@ -58,13 +56,13 @@ extern class AbortSignal extends EventTarget {
 	/**
 		An optional reason specified when the `AbortSignal` was triggered.
 	**/
-	var reason(default, null):Dynamic;
+	var reason(default, null):Any;
 
 	/**
 		An optional callback function that may be set by user code to be notified
 		when `AbortController.abort()` has been called.
 	**/
-	var onabort:Function;
+	var onabort:Null<Event->Void>;
 
 	/**
 		If `aborted` is `true`, throws `reason`.

--- a/src/js/node/web/Blob.hx
+++ b/src/js/node/web/Blob.hx
@@ -23,17 +23,10 @@
 package js.node.web;
 
 import haxe.extern.EitherType;
-#if haxe4
 import js.lib.ArrayBuffer;
 import js.lib.ArrayBufferView;
 import js.lib.Promise;
 import js.lib.Uint8Array;
-#else
-import js.html.ArrayBuffer;
-import js.html.ArrayBufferView;
-import js.Promise;
-import js.html.Uint8Array;
-#end
 
 /**
 	Encapsulates immutable, raw data that can be safely shared across workers.
@@ -74,10 +67,8 @@ extern class Blob {
 
 	/**
 		Returns a new `ReadableStream` that allows the content of the `Blob` to be read.
-
-		Typed as `Dynamic` until web streams externs are added.
 	**/
-	function stream():Dynamic;
+	function stream():ReadableStream;
 
 	/**
 		Returns a promise that fulfills with the contents of the `Blob` decoded as a UTF-8 string.

--- a/src/js/node/web/BroadcastChannel.hx
+++ b/src/js/node/web/BroadcastChannel.hx
@@ -23,44 +23,42 @@
 package js.node.web;
 
 /**
-	A browser-compatible implementation of `CustomEvent`.
+	A channel for broadcasting messages to other contexts listening on the same name.
 
-	// TODO(section-1): wire `CustomEvent` on `js.Node` / `globalThis` facade if desired.
+	Also available via `worker_threads` (see section 5); this is the web global form.
 
-	@see https://nodejs.org/api/events.html#class-customevent
-	@see https://nodejs.org/api/globals.html#class-customevent
+	@see https://nodejs.org/api/globals.html#class-broadcastchannel
+	@see https://nodejs.org/api/worker_threads.html#class-broadcastchannel
 **/
-@:native("CustomEvent")
-extern class CustomEvent extends Event {
+@:native("BroadcastChannel")
+extern class BroadcastChannel extends EventTarget {
 	/**
-		Custom data passed when initializing the event.
+		The channel name.
 	**/
-	var detail(default, null):Any;
+	var name(default, null):String;
 
-	function new(type:String, ?eventInitDict:CustomEventInit):Void;
-}
+	var onmessage:Null<MessageEvent->Void>;
+	var onmessageerror:Null<MessageEvent->Void>;
 
-/**
-	Options passed to the `CustomEvent` constructor.
-**/
-typedef CustomEventInit = {
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
-	@:optional var bubbles:Bool;
+	function new(name:String):Void;
 
 	/**
-		When `true`, `preventDefault()` can cancel the event. Default: `false`.
+		Closes the channel.
 	**/
-	@:optional var cancelable:Bool;
+	function close():Void;
 
 	/**
-		Not used in Node.js. Default: `false`.
+		Posts a message that will be delivered to all other `BroadcastChannel` objects listening on the same name.
 	**/
-	@:optional var composed:Bool;
+	function postMessage(message:Any):Void;
 
 	/**
-		Custom data exposed as `detail`.
+		Increases the Node.js event-loop reference count for this channel. Returns `this`.
 	**/
-	@:optional var detail:Any;
+	function ref():BroadcastChannel;
+
+	/**
+		Decreases the Node.js event-loop reference count for this channel. Returns `this`.
+	**/
+	function unref():BroadcastChannel;
 }

--- a/src/js/node/web/ByteLengthQueuingStrategy.hx
+++ b/src/js/node/web/ByteLengthQueuingStrategy.hx
@@ -23,44 +23,19 @@
 package js.node.web;
 
 /**
-	A browser-compatible implementation of `CustomEvent`.
+	A queuing strategy that counts the byte length of chunks.
 
-	// TODO(section-1): wire `CustomEvent` on `js.Node` / `globalThis` facade if desired.
-
-	@see https://nodejs.org/api/events.html#class-customevent
-	@see https://nodejs.org/api/globals.html#class-customevent
+	@see https://nodejs.org/api/globals.html#class-bytelengthqueuingstrategy
+	@see https://nodejs.org/api/webstreams.html#class-bytelengthqueuingstrategy
 **/
-@:native("CustomEvent")
-extern class CustomEvent extends Event {
-	/**
-		Custom data passed when initializing the event.
-	**/
-	var detail(default, null):Any;
+@:native("ByteLengthQueuingStrategy")
+extern class ByteLengthQueuingStrategy {
+	function new(init:{var highWaterMark:Float;}):Void;
 
-	function new(type:String, ?eventInitDict:CustomEventInit):Void;
-}
-
-/**
-	Options passed to the `CustomEvent` constructor.
-**/
-typedef CustomEventInit = {
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
-	@:optional var bubbles:Bool;
+	var highWaterMark(default, null):Float;
 
 	/**
-		When `true`, `preventDefault()` can cancel the event. Default: `false`.
+		Returns the byte length of `chunk`.
 	**/
-	@:optional var cancelable:Bool;
-
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
-	@:optional var composed:Bool;
-
-	/**
-		Custom data exposed as `detail`.
-	**/
-	@:optional var detail:Any;
+	function size(chunk:Any):Float;
 }

--- a/src/js/node/web/CloseEvent.hx
+++ b/src/js/node/web/CloseEvent.hx
@@ -23,44 +23,38 @@
 package js.node.web;
 
 /**
-	A browser-compatible implementation of `CustomEvent`.
+	An event that fires when a `WebSocket` connection closes.
 
-	// TODO(section-1): wire `CustomEvent` on `js.Node` / `globalThis` facade if desired.
-
-	@see https://nodejs.org/api/events.html#class-customevent
-	@see https://nodejs.org/api/globals.html#class-customevent
+	@see https://nodejs.org/api/globals.html#class-closeevent
 **/
-@:native("CustomEvent")
-extern class CustomEvent extends Event {
+@:native("CloseEvent")
+extern class CloseEvent extends Event {
 	/**
-		Custom data passed when initializing the event.
+		Whether the connection closed cleanly.
 	**/
-	var detail(default, null):Any;
+	var wasClean(default, null):Bool;
 
-	function new(type:String, ?eventInitDict:CustomEventInit):Void;
+	/**
+		The WebSocket connection close code.
+	**/
+	var code(default, null):Int;
+
+	/**
+		The reason the WebSocket connection closed.
+	**/
+	var reason(default, null):String;
+
+	function new(type:String, ?eventInitDict:CloseEventInit):Void;
 }
 
 /**
-	Options passed to the `CustomEvent` constructor.
+	Options for the `CloseEvent` constructor.
 **/
-typedef CustomEventInit = {
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
+typedef CloseEventInit = {
 	@:optional var bubbles:Bool;
-
-	/**
-		When `true`, `preventDefault()` can cancel the event. Default: `false`.
-	**/
 	@:optional var cancelable:Bool;
-
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
 	@:optional var composed:Bool;
-
-	/**
-		Custom data exposed as `detail`.
-	**/
-	@:optional var detail:Any;
+	@:optional var wasClean:Bool;
+	@:optional var code:Int;
+	@:optional var reason:String;
 }

--- a/src/js/node/web/CompressionStream.hx
+++ b/src/js/node/web/CompressionStream.hx
@@ -23,44 +23,18 @@
 package js.node.web;
 
 /**
-	A browser-compatible implementation of `CustomEvent`.
+	A transform stream that performs compression (`gzip`, `deflate`, or `deflate-raw`).
 
-	// TODO(section-1): wire `CustomEvent` on `js.Node` / `globalThis` facade if desired.
-
-	@see https://nodejs.org/api/events.html#class-customevent
-	@see https://nodejs.org/api/globals.html#class-customevent
+	@see https://nodejs.org/api/globals.html#class-compressionstream
+	@see https://nodejs.org/api/webstreams.html#class-compressionstream
 **/
-@:native("CustomEvent")
-extern class CustomEvent extends Event {
-	/**
-		Custom data passed when initializing the event.
-	**/
-	var detail(default, null):Any;
-
-	function new(type:String, ?eventInitDict:CustomEventInit):Void;
-}
-
-/**
-	Options passed to the `CustomEvent` constructor.
-**/
-typedef CustomEventInit = {
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
-	@:optional var bubbles:Bool;
+@:native("CompressionStream")
+extern class CompressionStream {
+	var readable(default, null):ReadableStream;
+	var writable(default, null):WritableStream;
 
 	/**
-		When `true`, `preventDefault()` can cancel the event. Default: `false`.
+		@param format One of `'gzip'`, `'deflate'`, or `'deflate-raw'`.
 	**/
-	@:optional var cancelable:Bool;
-
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
-	@:optional var composed:Bool;
-
-	/**
-		Custom data exposed as `detail`.
-	**/
-	@:optional var detail:Any;
+	function new(format:String):Void;
 }

--- a/src/js/node/web/CountQueuingStrategy.hx
+++ b/src/js/node/web/CountQueuingStrategy.hx
@@ -23,44 +23,19 @@
 package js.node.web;
 
 /**
-	A browser-compatible implementation of `CustomEvent`.
+	A queuing strategy that counts the number of chunks.
 
-	// TODO(section-1): wire `CustomEvent` on `js.Node` / `globalThis` facade if desired.
-
-	@see https://nodejs.org/api/events.html#class-customevent
-	@see https://nodejs.org/api/globals.html#class-customevent
+	@see https://nodejs.org/api/globals.html#class-countqueuingstrategy
+	@see https://nodejs.org/api/webstreams.html#class-countqueuingstrategy
 **/
-@:native("CustomEvent")
-extern class CustomEvent extends Event {
-	/**
-		Custom data passed when initializing the event.
-	**/
-	var detail(default, null):Any;
+@:native("CountQueuingStrategy")
+extern class CountQueuingStrategy {
+	function new(init:{var highWaterMark:Float;}):Void;
 
-	function new(type:String, ?eventInitDict:CustomEventInit):Void;
-}
-
-/**
-	Options passed to the `CustomEvent` constructor.
-**/
-typedef CustomEventInit = {
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
-	@:optional var bubbles:Bool;
+	var highWaterMark(default, null):Float;
 
 	/**
-		When `true`, `preventDefault()` can cancel the event. Default: `false`.
+		Always returns `1`.
 	**/
-	@:optional var cancelable:Bool;
-
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
-	@:optional var composed:Bool;
-
-	/**
-		Custom data exposed as `detail`.
-	**/
-	@:optional var detail:Any;
+	function size(chunk:Any):Float;
 }

--- a/src/js/node/web/DOMException.hx
+++ b/src/js/node/web/DOMException.hx
@@ -22,13 +22,17 @@
 
 package js.node.web;
 
+import js.lib.Error;
+
 /**
 	The WHATWG `DOMException` class.
+
+	// TODO(section-1): wire `DOMException` on `js.Node` / `globalThis` facade if desired.
 
 	@see https://nodejs.org/api/globals.html#class-domexception
 **/
 @:native("DOMException")
-extern class DOMException {
+extern class DOMException extends Error {
 	static inline var INDEX_SIZE_ERR:Int = 1;
 	static inline var DOMSTRING_SIZE_ERR:Int = 2;
 	static inline var HIERARCHY_REQUEST_ERR:Int = 3;
@@ -56,18 +60,10 @@ extern class DOMException {
 	static inline var DATA_CLONE_ERR:Int = 25;
 
 	/**
-		One of the strings associated with an error name.
-	**/
-	var name(default, null):String;
-
-	/**
-		A message or description associated with the given error name.
-	**/
-	var message(default, null):String;
-
-	/**
 		One of the legacy error codes, or `0` if none match.
 		New DOM exceptions put this info in `name` instead.
+
+		`name` / `message` are inherited from `js.lib.Error`.
 	**/
 	var code(default, null):Int;
 

--- a/src/js/node/web/DecompressionStream.hx
+++ b/src/js/node/web/DecompressionStream.hx
@@ -23,44 +23,18 @@
 package js.node.web;
 
 /**
-	A browser-compatible implementation of `CustomEvent`.
+	A transform stream that performs decompression (`gzip`, `deflate`, or `deflate-raw`).
 
-	// TODO(section-1): wire `CustomEvent` on `js.Node` / `globalThis` facade if desired.
-
-	@see https://nodejs.org/api/events.html#class-customevent
-	@see https://nodejs.org/api/globals.html#class-customevent
+	@see https://nodejs.org/api/globals.html#class-decompressionstream
+	@see https://nodejs.org/api/webstreams.html#class-decompressionstream
 **/
-@:native("CustomEvent")
-extern class CustomEvent extends Event {
-	/**
-		Custom data passed when initializing the event.
-	**/
-	var detail(default, null):Any;
-
-	function new(type:String, ?eventInitDict:CustomEventInit):Void;
-}
-
-/**
-	Options passed to the `CustomEvent` constructor.
-**/
-typedef CustomEventInit = {
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
-	@:optional var bubbles:Bool;
+@:native("DecompressionStream")
+extern class DecompressionStream {
+	var readable(default, null):ReadableStream;
+	var writable(default, null):WritableStream;
 
 	/**
-		When `true`, `preventDefault()` can cancel the event. Default: `false`.
+		@param format One of `'gzip'`, `'deflate'`, or `'deflate-raw'`.
 	**/
-	@:optional var cancelable:Bool;
-
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
-	@:optional var composed:Bool;
-
-	/**
-		Custom data exposed as `detail`.
-	**/
-	@:optional var detail:Any;
+	function new(format:String):Void;
 }

--- a/src/js/node/web/Event.hx
+++ b/src/js/node/web/Event.hx
@@ -25,6 +25,8 @@ package js.node.web;
 /**
 	A browser-compatible implementation of the `Event` class.
 
+	// TODO(section-1): wire `Event` on `js.Node` / `globalThis` facade if desired.
+
 	@see https://nodejs.org/api/events.html#class-event
 	@see https://nodejs.org/api/globals.html#class-event
 **/

--- a/src/js/node/web/EventSource.hx
+++ b/src/js/node/web/EventSource.hx
@@ -22,45 +22,40 @@
 
 package js.node.web;
 
+import js.node.url.URL;
+
 /**
-	A browser-compatible implementation of `CustomEvent`.
+	A browser-compatible `EventSource` (Server-Sent Events) implementation.
 
-	// TODO(section-1): wire `CustomEvent` on `js.Node` / `globalThis` facade if desired.
+	Stability: 1 - Experimental. May require `--experimental-eventsource` depending on Node version.
 
-	@see https://nodejs.org/api/events.html#class-customevent
-	@see https://nodejs.org/api/globals.html#class-customevent
+	@see https://nodejs.org/api/globals.html#class-eventsource
 **/
-@:native("CustomEvent")
-extern class CustomEvent extends Event {
-	/**
-		Custom data passed when initializing the event.
-	**/
-	var detail(default, null):Any;
+@:native("EventSource")
+extern class EventSource extends EventTarget {
+	static inline var CONNECTING:Int = 0;
+	static inline var OPEN:Int = 1;
+	static inline var CLOSED:Int = 2;
 
-	function new(type:String, ?eventInitDict:CustomEventInit):Void;
+	var readyState(default, null):Int;
+	var url(default, null):String;
+	var withCredentials(default, null):Bool;
+
+	var onopen:Null<Event->Void>;
+	var onmessage:Null<MessageEvent->Void>;
+	var onerror:Null<Event->Void>;
+
+	@:overload(function(url:URL, ?eventSourceInitDict:EventSourceInit):Void {})
+	function new(url:String, ?eventSourceInitDict:EventSourceInit):Void;
+
+	function close():Void;
 }
 
 /**
-	Options passed to the `CustomEvent` constructor.
+	Options for the `EventSource` constructor.
 **/
-typedef CustomEventInit = {
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
-	@:optional var bubbles:Bool;
-
-	/**
-		When `true`, `preventDefault()` can cancel the event. Default: `false`.
-	**/
-	@:optional var cancelable:Bool;
-
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
-	@:optional var composed:Bool;
-
-	/**
-		Custom data exposed as `detail`.
-	**/
-	@:optional var detail:Any;
+typedef EventSourceInit = {
+	@:optional var withCredentials:Bool;
+	// TODO(section-6): type undici dispatcher options when available.
+	@:optional var dispatcher:Any;
 }

--- a/src/js/node/web/EventTarget.hx
+++ b/src/js/node/web/EventTarget.hx
@@ -28,6 +28,8 @@ import haxe.extern.EitherType;
 /**
 	A browser-compatible implementation of the `EventTarget` class.
 
+	// TODO(section-1): wire `EventTarget` on `js.Node` / `globalThis` facade if desired.
+
 	@see https://nodejs.org/api/events.html#class-eventtarget
 	@see https://nodejs.org/api/globals.html#class-eventtarget
 **/
@@ -99,9 +101,6 @@ typedef AddEventListenerOptions = {
 
 	/**
 		The listener will be removed when the given `AbortSignal` object's `abort()` method is called.
-
-		Typed as `Dynamic` so this module does not hard-depend on the AbortSignal externs;
-		use `js.node.web.AbortSignal` when that module is available.
 	**/
-	@:optional var signal:Dynamic;
+	@:optional var signal:AbortSignal;
 }

--- a/src/js/node/web/Fetch.hx
+++ b/src/js/node/web/Fetch.hx
@@ -22,18 +22,16 @@
 
 package js.node.web;
 
-import haxe.extern.EitherType;
-import js.node.web.Request.RequestInit;
-#if haxe4
 import js.lib.Promise;
-#else
-import js.Promise;
-#end
+import js.node.url.URL;
+import js.node.web.Request.RequestInit;
 
 /**
 	Browser-compatible `fetch()` (undici), exposed as a static on `globalThis`.
 
 	Usage: `Fetch.fetch(url)` / `Fetch.fetch(url, init)`.
+
+	TODO(section-1): wire `Node.fetch` / global aliases in `js.Node` if desired.
 
 	@see https://nodejs.org/api/globals.html#fetch
 **/
@@ -43,5 +41,6 @@ extern class Fetch {
 		Starts the process of fetching a resource from the network.
 	**/
 	@:overload(function(input:Request, ?init:RequestInit):Promise<Response> {})
+	@:overload(function(input:URL, ?init:RequestInit):Promise<Response> {})
 	static function fetch(input:String, ?init:RequestInit):Promise<Response>;
 }

--- a/src/js/node/web/File.hx
+++ b/src/js/node/web/File.hx
@@ -29,6 +29,8 @@ import js.node.web.Blob.BlobPart;
 
 	Available as a global and via `require('node:buffer').File`.
 
+	// TODO(section-1): wire `File` on `js.Node` / `globalThis` facade if desired.
+
 	@see https://nodejs.org/api/buffer.html#class-file
 	@see https://nodejs.org/api/globals.html#class-file
 **/

--- a/src/js/node/web/FormData.hx
+++ b/src/js/node/web/FormData.hx
@@ -70,5 +70,5 @@ extern class FormData {
 	function entries():Iterator<KeyValue<String, EitherType<String, EitherType<Blob, File>>>>;
 	function keys():Iterator<String>;
 	function values():Iterator<EitherType<String, EitherType<Blob, File>>>;
-	function forEach(callback:EitherType<String, EitherType<Blob, File>>->String->FormData->Void, ?thisArg:Dynamic):Void;
+	function forEach(callback:EitherType<String, EitherType<Blob, File>>->String->FormData->Void, ?thisArg:Any):Void;
 }

--- a/src/js/node/web/Headers.hx
+++ b/src/js/node/web/Headers.hx
@@ -23,7 +23,6 @@
 package js.node.web;
 
 import haxe.DynamicAccess;
-import haxe.extern.EitherType;
 import js.node.Iterator;
 import js.node.KeyValue;
 
@@ -71,5 +70,5 @@ extern class Headers {
 	function entries():Iterator<KeyValue<String, String>>;
 	function keys():Iterator<String>;
 	function values():Iterator<String>;
-	function forEach(callback:String->String->Headers->Void, ?thisArg:Dynamic):Void;
+	function forEach(callback:String->String->Headers->Void, ?thisArg:Any):Void;
 }

--- a/src/js/node/web/LockManager.hx
+++ b/src/js/node/web/LockManager.hx
@@ -22,45 +22,50 @@
 
 package js.node.web;
 
+import js.lib.Promise;
+
 /**
-	A browser-compatible implementation of `CustomEvent`.
+	Web Locks API (`navigator.locks`). Node.js exposes a partial implementation.
 
-	// TODO(section-1): wire `CustomEvent` on `js.Node` / `globalThis` facade if desired.
+	Not constructed as a global class; obtained via `navigator.locks`.
 
-	@see https://nodejs.org/api/events.html#class-customevent
-	@see https://nodejs.org/api/globals.html#class-customevent
+	@see https://nodejs.org/api/globals.html#navigatorlocks
 **/
-@:native("CustomEvent")
-extern class CustomEvent extends Event {
+extern class LockManager {
 	/**
-		Custom data passed when initializing the event.
+		Requests a lock and runs `callback` while holding it.
 	**/
-	var detail(default, null):Any;
+	@:overload(function(name:String, options:LockOptions, callback:Lock->Any):Promise<Any> {})
+	function request(name:String, callback:Lock->Any):Promise<Any>;
 
-	function new(type:String, ?eventInitDict:CustomEventInit):Void;
+	/**
+		Returns a promise for a snapshot of held and pending locks.
+	**/
+	function query():Promise<LockManagerSnapshot>;
 }
 
 /**
-	Options passed to the `CustomEvent` constructor.
+	Options for `LockManager.request`.
 **/
-typedef CustomEventInit = {
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
-	@:optional var bubbles:Bool;
+typedef LockOptions = {
+	@:optional var mode:String;
+	@:optional var ifAvailable:Bool;
+	@:optional var steal:Bool;
+	@:optional var signal:AbortSignal;
+}
 
-	/**
-		When `true`, `preventDefault()` can cancel the event. Default: `false`.
-	**/
-	@:optional var cancelable:Bool;
+/**
+	A held lock passed to the `LockManager.request` callback.
+**/
+typedef Lock = {
+	var name(default, null):String;
+	var mode(default, null):String;
+}
 
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
-	@:optional var composed:Bool;
-
-	/**
-		Custom data exposed as `detail`.
-	**/
-	@:optional var detail:Any;
+/**
+	Result of `LockManager.query()`.
+**/
+typedef LockManagerSnapshot = {
+	var held:Array<Lock>;
+	var pending:Array<Lock>;
 }

--- a/src/js/node/web/MessageChannel.hx
+++ b/src/js/node/web/MessageChannel.hx
@@ -23,44 +23,23 @@
 package js.node.web;
 
 /**
-	A browser-compatible implementation of `CustomEvent`.
+	Creates a pair of connected `MessagePort` objects.
 
-	// TODO(section-1): wire `CustomEvent` on `js.Node` / `globalThis` facade if desired.
+	Also available via `worker_threads` (see section 5); this is the web global form.
 
-	@see https://nodejs.org/api/events.html#class-customevent
-	@see https://nodejs.org/api/globals.html#class-customevent
+	@see https://nodejs.org/api/globals.html#class-messagechannel
 **/
-@:native("CustomEvent")
-extern class CustomEvent extends Event {
+@:native("MessageChannel")
+extern class MessageChannel {
 	/**
-		Custom data passed when initializing the event.
+		A `MessagePort` for receiving/sending messages.
 	**/
-	var detail(default, null):Any;
-
-	function new(type:String, ?eventInitDict:CustomEventInit):Void;
-}
-
-/**
-	Options passed to the `CustomEvent` constructor.
-**/
-typedef CustomEventInit = {
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
-	@:optional var bubbles:Bool;
+	var port1(default, null):MessagePort;
 
 	/**
-		When `true`, `preventDefault()` can cancel the event. Default: `false`.
+		The other end of the channel.
 	**/
-	@:optional var cancelable:Bool;
+	var port2(default, null):MessagePort;
 
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
-	@:optional var composed:Bool;
-
-	/**
-		Custom data exposed as `detail`.
-	**/
-	@:optional var detail:Any;
+	function new():Void;
 }

--- a/src/js/node/web/MessageEvent.hx
+++ b/src/js/node/web/MessageEvent.hx
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.web;
+
+/**
+	Represents a message sent via `MessagePort` / `BroadcastChannel` / `WebSocket`.
+
+	@see https://nodejs.org/api/globals.html#class-messageevent
+**/
+@:native("MessageEvent")
+extern class MessageEvent extends Event {
+	/**
+		The data sent by the message emitter.
+	**/
+	var data(default, null):Any;
+
+	/**
+		The origin of the message.
+	**/
+	var origin(default, null):String;
+
+	/**
+		A unique ID for the event.
+	**/
+	var lastEventId(default, null):String;
+
+	/**
+		A `MessagePort` object or `null`.
+	**/
+	var source(default, null):Null<MessagePort>;
+
+	/**
+		An array of `MessagePort` objects.
+	**/
+	var ports(default, null):Array<MessagePort>;
+
+	function new(type:String, ?eventInitDict:MessageEventInit):Void;
+
+	/**
+		Stability: 3 - Legacy. Initializes a `MessageEvent`. Prefer the constructor.
+	**/
+	function initMessageEvent(type:String, ?bubbles:Bool, ?cancelable:Bool, ?data:Any, ?origin:String, ?lastEventId:String,
+		?source:Null<MessagePort>, ?ports:Array<MessagePort>):Void;
+}
+
+/**
+	Options for the `MessageEvent` constructor.
+**/
+typedef MessageEventInit = {
+	@:optional var bubbles:Bool;
+	@:optional var cancelable:Bool;
+	@:optional var composed:Bool;
+	@:optional var data:Any;
+	@:optional var origin:String;
+	@:optional var lastEventId:String;
+	@:optional var source:Null<MessagePort>;
+	@:optional var ports:Array<MessagePort>;
+}

--- a/src/js/node/web/MessagePort.hx
+++ b/src/js/node/web/MessagePort.hx
@@ -23,44 +23,36 @@
 package js.node.web;
 
 /**
-	A browser-compatible implementation of `CustomEvent`.
+	One end of a two-way communication channel created by `MessageChannel`.
 
-	// TODO(section-1): wire `CustomEvent` on `js.Node` / `globalThis` facade if desired.
+	Also available via `worker_threads` (see section 5); this is the web global form.
 
-	@see https://nodejs.org/api/events.html#class-customevent
-	@see https://nodejs.org/api/globals.html#class-customevent
+	@see https://nodejs.org/api/globals.html#class-messageport
 **/
-@:native("CustomEvent")
-extern class CustomEvent extends Event {
-	/**
-		Custom data passed when initializing the event.
-	**/
-	var detail(default, null):Any;
-
-	function new(type:String, ?eventInitDict:CustomEventInit):Void;
-}
-
-/**
-	Options passed to the `CustomEvent` constructor.
-**/
-typedef CustomEventInit = {
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
-	@:optional var bubbles:Bool;
+@:native("MessagePort")
+extern class MessagePort extends EventTarget {
+	var onmessage:Null<MessageEvent->Void>;
+	var onmessageerror:Null<MessageEvent->Void>;
 
 	/**
-		When `true`, `preventDefault()` can cancel the event. Default: `false`.
+		Posts a message through the channel. `transfer` is a list of transferable objects
+		to transfer ownership of.
+
+		TODO(section-5): tighten `transfer` once worker_threads transferable types are externed.
 	**/
-	@:optional var cancelable:Bool;
+	function postMessage(message:Any, ?transfer:Array<Any>):Void;
 
 	/**
-		Not used in Node.js. Default: `false`.
+		Starts dispatching messages received on this port. (Implicit when `onmessage` is set.)
 	**/
-	@:optional var composed:Bool;
+	function start():Void;
 
 	/**
-		Custom data exposed as `detail`.
+		Disconnects the port and stops receiving messages.
 	**/
-	@:optional var detail:Any;
+	function close():Void;
+
+	function ref():MessagePort;
+	function unref():MessagePort;
+	function hasRef():Bool;
 }

--- a/src/js/node/web/Navigator.hx
+++ b/src/js/node/web/Navigator.hx
@@ -23,44 +23,43 @@
 package js.node.web;
 
 /**
-	A browser-compatible implementation of `CustomEvent`.
+	A partial browser-compatible `Navigator` implementation exposed as the
+	`navigator` global in Node.js.
 
-	// TODO(section-1): wire `CustomEvent` on `js.Node` / `globalThis` facade if desired.
+	TODO(section-1): expose `Node.navigator` alias in `js.Node` if desired.
 
-	@see https://nodejs.org/api/events.html#class-customevent
-	@see https://nodejs.org/api/globals.html#class-customevent
+	@see https://nodejs.org/api/globals.html#class-navigator
+	@see https://nodejs.org/api/globals.html#navigator
 **/
-@:native("CustomEvent")
-extern class CustomEvent extends Event {
+@:native("Navigator")
+extern class Navigator {
 	/**
-		Custom data passed when initializing the event.
+		The number of logical processors available.
 	**/
-	var detail(default, null):Any;
-
-	function new(type:String, ?eventInitDict:CustomEventInit):Void;
-}
-
-/**
-	Options passed to the `CustomEvent` constructor.
-**/
-typedef CustomEventInit = {
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
-	@:optional var bubbles:Bool;
+	var hardwareConcurrency(default, null):Int;
 
 	/**
-		When `true`, `preventDefault()` can cancel the event. Default: `false`.
+		The Web Locks API interface.
 	**/
-	@:optional var cancelable:Bool;
+	var locks(default, null):LockManager;
 
 	/**
-		Not used in Node.js. Default: `false`.
+		Preferred language of the Node.js instance.
 	**/
-	@:optional var composed:Bool;
+	var language(default, null):String;
 
 	/**
-		Custom data exposed as `detail`.
+		An array of preferred languages.
 	**/
-	@:optional var detail:Any;
+	var languages(default, null):Array<String>;
+
+	/**
+		The user agent of this Node.js instance.
+	**/
+	var userAgent(default, null):String;
+
+	/**
+		The platform of this Node.js instance.
+	**/
+	var platform(default, null):String;
 }

--- a/src/js/node/web/QueuingStrategy.hx
+++ b/src/js/node/web/QueuingStrategy.hx
@@ -23,44 +23,18 @@
 package js.node.web;
 
 /**
-	A browser-compatible implementation of `CustomEvent`.
+	A queuing strategy for web streams.
 
-	// TODO(section-1): wire `CustomEvent` on `js.Node` / `globalThis` facade if desired.
-
-	@see https://nodejs.org/api/events.html#class-customevent
-	@see https://nodejs.org/api/globals.html#class-customevent
+	@see https://nodejs.org/api/webstreams.html#class-bytelengthqueuingstrategy
 **/
-@:native("CustomEvent")
-extern class CustomEvent extends Event {
+typedef QueuingStrategy = {
 	/**
-		Custom data passed when initializing the event.
+		The high water mark.
 	**/
-	var detail(default, null):Any;
-
-	function new(type:String, ?eventInitDict:CustomEventInit):Void;
-}
-
-/**
-	Options passed to the `CustomEvent` constructor.
-**/
-typedef CustomEventInit = {
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
-	@:optional var bubbles:Bool;
+	@:optional var highWaterMark:Float;
 
 	/**
-		When `true`, `preventDefault()` can cancel the event. Default: `false`.
+		A function that computes the size of a chunk.
 	**/
-	@:optional var cancelable:Bool;
-
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
-	@:optional var composed:Bool;
-
-	/**
-		Custom data exposed as `detail`.
-	**/
-	@:optional var detail:Any;
+	@:optional var size:Any->Float;
 }

--- a/src/js/node/web/ReadableByteStreamController.hx
+++ b/src/js/node/web/ReadableByteStreamController.hx
@@ -22,45 +22,19 @@
 
 package js.node.web;
 
-/**
-	A browser-compatible implementation of `CustomEvent`.
-
-	// TODO(section-1): wire `CustomEvent` on `js.Node` / `globalThis` facade if desired.
-
-	@see https://nodejs.org/api/events.html#class-customevent
-	@see https://nodejs.org/api/globals.html#class-customevent
-**/
-@:native("CustomEvent")
-extern class CustomEvent extends Event {
-	/**
-		Custom data passed when initializing the event.
-	**/
-	var detail(default, null):Any;
-
-	function new(type:String, ?eventInitDict:CustomEventInit):Void;
-}
+import js.lib.ArrayBufferView;
 
 /**
-	Options passed to the `CustomEvent` constructor.
+	Controller for a byte-oriented `ReadableStream`.
+
+	@see https://nodejs.org/api/globals.html#class-readablebytestreamcontroller
 **/
-typedef CustomEventInit = {
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
-	@:optional var bubbles:Bool;
+@:native("ReadableByteStreamController")
+extern class ReadableByteStreamController {
+	var byobRequest(default, null):Null<ReadableStreamBYOBRequest>;
+	var desiredSize(default, null):Null<Float>;
 
-	/**
-		When `true`, `preventDefault()` can cancel the event. Default: `false`.
-	**/
-	@:optional var cancelable:Bool;
-
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
-	@:optional var composed:Bool;
-
-	/**
-		Custom data exposed as `detail`.
-	**/
-	@:optional var detail:Any;
+	function close():Void;
+	function enqueue(chunk:ArrayBufferView):Void;
+	function error(?e:Any):Void;
 }

--- a/src/js/node/web/ReadableStream.hx
+++ b/src/js/node/web/ReadableStream.hx
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.web;
+
+import js.lib.Promise;
+
+/**
+	A browser-compatible implementation of `ReadableStream`.
+
+	@see https://nodejs.org/api/globals.html#class-readablestream
+	@see https://nodejs.org/api/webstreams.html#class-readablestream
+**/
+@:native("ReadableStream")
+extern class ReadableStream {
+	/**
+		Creates a `ReadableStream` from an iterable or async iterable.
+	**/
+	static function from(iterable:Any):ReadableStream;
+
+	/**
+		Whether a reader is currently locked onto this stream.
+	**/
+	var locked(default, null):Bool;
+
+	function new(?underlyingSource:ReadableStreamUnderlyingSource, ?strategy:QueuingStrategy):Void;
+
+	/**
+		Cancels the stream, signaling a reason why consumer is no longer interested.
+	**/
+	function cancel(?reason:Any):Promise<Void>;
+
+	/**
+		Creates a reader and locks this stream to it.
+
+		When `options.mode` is `"byob"`, returns a `ReadableStreamBYOBReader`.
+	**/
+	@:overload(function(options:{var mode:String;}):ReadableStreamBYOBReader {})
+	function getReader(?options:Any):ReadableStreamDefaultReader;
+
+	/**
+		Pipes this readable stream through a transform stream pair.
+	**/
+	function pipeThrough(transform:ReadableWritablePair, ?options:StreamPipeOptions):ReadableStream;
+
+	/**
+		Pipes this readable stream to a writable stream.
+	**/
+	function pipeTo(destination:WritableStream, ?options:StreamPipeOptions):Promise<Void>;
+
+	/**
+		Tees this readable stream, returning a pair of branching streams.
+	**/
+	function tee():Array<ReadableStream>;
+
+	/**
+		Async iterator over stream chunks (`[Symbol.asyncIterator]` / `values()`).
+		Typed as `Any` because Haxe lacks a standard async-iterator type in 4.0.5.
+	**/
+	function values(?options:{@:optional var preventCancel:Bool;}):Any;
+}
+
+/**
+	Underlying source object for `ReadableStream` construction.
+
+	Callback controller arguments use stream controller types when known;
+	start/pull/cancel remain loosely typed for byte vs default sources.
+**/
+typedef ReadableStreamUnderlyingSource = {
+	@:optional var type:String;
+	@:optional var autoAllocateChunkSize:Int;
+	@:optional var start:Any->Any;
+	@:optional var pull:Any->Any;
+	@:optional var cancel:Any->Any;
+}
+
+/**
+	A `{ readable, writable }` pair used by `pipeThrough`.
+**/
+typedef ReadableWritablePair = {
+	var readable:ReadableStream;
+	var writable:WritableStream;
+}
+
+/**
+	Options for `pipeTo` / `pipeThrough`.
+**/
+typedef StreamPipeOptions = {
+	@:optional var preventClose:Bool;
+	@:optional var preventAbort:Bool;
+	@:optional var preventCancel:Bool;
+	@:optional var signal:AbortSignal;
+}

--- a/src/js/node/web/ReadableStreamBYOBReader.hx
+++ b/src/js/node/web/ReadableStreamBYOBReader.hx
@@ -22,45 +22,26 @@
 
 package js.node.web;
 
-/**
-	A browser-compatible implementation of `CustomEvent`.
-
-	// TODO(section-1): wire `CustomEvent` on `js.Node` / `globalThis` facade if desired.
-
-	@see https://nodejs.org/api/events.html#class-customevent
-	@see https://nodejs.org/api/globals.html#class-customevent
-**/
-@:native("CustomEvent")
-extern class CustomEvent extends Event {
-	/**
-		Custom data passed when initializing the event.
-	**/
-	var detail(default, null):Any;
-
-	function new(type:String, ?eventInitDict:CustomEventInit):Void;
-}
+import js.lib.ArrayBufferView;
+import js.lib.Promise;
 
 /**
-	Options passed to the `CustomEvent` constructor.
+	BYOB reader for a byte-oriented `ReadableStream`.
+
+	@see https://nodejs.org/api/globals.html#class-readablestreambyobreader
+	@see https://nodejs.org/api/webstreams.html#class-readablestreambyobreader
 **/
-typedef CustomEventInit = {
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
-	@:optional var bubbles:Bool;
+@:native("ReadableStreamBYOBReader")
+extern class ReadableStreamBYOBReader {
+	function new(stream:ReadableStream):Void;
+
+	var closed(default, null):Promise<Void>;
 
 	/**
-		When `true`, `preventDefault()` can cancel the event. Default: `false`.
+		Reads into the provided view.
 	**/
-	@:optional var cancelable:Bool;
+	function read(view:ArrayBufferView, ?options:{@:optional var min:Int;}):Promise<ReadableStreamReadResult>;
 
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
-	@:optional var composed:Bool;
-
-	/**
-		Custom data exposed as `detail`.
-	**/
-	@:optional var detail:Any;
+	function releaseLock():Void;
+	function cancel(?reason:Any):Promise<Void>;
 }

--- a/src/js/node/web/ReadableStreamBYOBRequest.hx
+++ b/src/js/node/web/ReadableStreamBYOBRequest.hx
@@ -22,45 +22,17 @@
 
 package js.node.web;
 
-/**
-	A browser-compatible implementation of `CustomEvent`.
-
-	// TODO(section-1): wire `CustomEvent` on `js.Node` / `globalThis` facade if desired.
-
-	@see https://nodejs.org/api/events.html#class-customevent
-	@see https://nodejs.org/api/globals.html#class-customevent
-**/
-@:native("CustomEvent")
-extern class CustomEvent extends Event {
-	/**
-		Custom data passed when initializing the event.
-	**/
-	var detail(default, null):Any;
-
-	function new(type:String, ?eventInitDict:CustomEventInit):Void;
-}
+import js.lib.ArrayBufferView;
 
 /**
-	Options passed to the `CustomEvent` constructor.
+	A pull-into request associated with a `ReadableByteStreamController`.
+
+	@see https://nodejs.org/api/globals.html#class-readablestreambyobrequest
 **/
-typedef CustomEventInit = {
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
-	@:optional var bubbles:Bool;
+@:native("ReadableStreamBYOBRequest")
+extern class ReadableStreamBYOBRequest {
+	var view(default, null):Null<ArrayBufferView>;
 
-	/**
-		When `true`, `preventDefault()` can cancel the event. Default: `false`.
-	**/
-	@:optional var cancelable:Bool;
-
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
-	@:optional var composed:Bool;
-
-	/**
-		Custom data exposed as `detail`.
-	**/
-	@:optional var detail:Any;
+	function respond(bytesWritten:Int):Void;
+	function respondWithNewView(view:ArrayBufferView):Void;
 }

--- a/src/js/node/web/ReadableStreamDefaultController.hx
+++ b/src/js/node/web/ReadableStreamDefaultController.hx
@@ -23,44 +23,15 @@
 package js.node.web;
 
 /**
-	A browser-compatible implementation of `CustomEvent`.
+	Default controller for a `ReadableStream`.
 
-	// TODO(section-1): wire `CustomEvent` on `js.Node` / `globalThis` facade if desired.
-
-	@see https://nodejs.org/api/events.html#class-customevent
-	@see https://nodejs.org/api/globals.html#class-customevent
+	@see https://nodejs.org/api/globals.html#class-readablestreamdefaultcontroller
 **/
-@:native("CustomEvent")
-extern class CustomEvent extends Event {
-	/**
-		Custom data passed when initializing the event.
-	**/
-	var detail(default, null):Any;
+@:native("ReadableStreamDefaultController")
+extern class ReadableStreamDefaultController {
+	var desiredSize(default, null):Null<Float>;
 
-	function new(type:String, ?eventInitDict:CustomEventInit):Void;
-}
-
-/**
-	Options passed to the `CustomEvent` constructor.
-**/
-typedef CustomEventInit = {
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
-	@:optional var bubbles:Bool;
-
-	/**
-		When `true`, `preventDefault()` can cancel the event. Default: `false`.
-	**/
-	@:optional var cancelable:Bool;
-
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
-	@:optional var composed:Bool;
-
-	/**
-		Custom data exposed as `detail`.
-	**/
-	@:optional var detail:Any;
+	function close():Void;
+	function enqueue(?chunk:Any):Void;
+	function error(?e:Any):Void;
 }

--- a/src/js/node/web/ReadableStreamDefaultReader.hx
+++ b/src/js/node/web/ReadableStreamDefaultReader.hx
@@ -22,45 +22,35 @@
 
 package js.node.web;
 
-/**
-	A browser-compatible implementation of `CustomEvent`.
-
-	// TODO(section-1): wire `CustomEvent` on `js.Node` / `globalThis` facade if desired.
-
-	@see https://nodejs.org/api/events.html#class-customevent
-	@see https://nodejs.org/api/globals.html#class-customevent
-**/
-@:native("CustomEvent")
-extern class CustomEvent extends Event {
-	/**
-		Custom data passed when initializing the event.
-	**/
-	var detail(default, null):Any;
-
-	function new(type:String, ?eventInitDict:CustomEventInit):Void;
-}
+import js.lib.Promise;
 
 /**
-	Options passed to the `CustomEvent` constructor.
+	Default reader for a `ReadableStream`.
+
+	@see https://nodejs.org/api/globals.html#class-readablestreamdefaultreader
+	@see https://nodejs.org/api/webstreams.html#class-readablestreamdefaultreader
 **/
-typedef CustomEventInit = {
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
-	@:optional var bubbles:Bool;
+@:native("ReadableStreamDefaultReader")
+extern class ReadableStreamDefaultReader {
+	function new(stream:ReadableStream):Void;
 
 	/**
-		When `true`, `preventDefault()` can cancel the event. Default: `false`.
+		A promise that fulfills when the stream closes, or rejects on error.
 	**/
-	@:optional var cancelable:Bool;
+	var closed(default, null):Promise<Void>;
 
 	/**
-		Not used in Node.js. Default: `false`.
+		Returns a promise for the next chunk.
 	**/
-	@:optional var composed:Bool;
+	function read():Promise<ReadableStreamReadResult>;
 
 	/**
-		Custom data exposed as `detail`.
+		Releases the lock on the stream.
 	**/
-	@:optional var detail:Any;
+	function releaseLock():Void;
+
+	/**
+		Cancels the stream.
+	**/
+	function cancel(?reason:Any):Promise<Void>;
 }

--- a/src/js/node/web/ReadableStreamReadResult.hx
+++ b/src/js/node/web/ReadableStreamReadResult.hx
@@ -23,44 +23,9 @@
 package js.node.web;
 
 /**
-	A browser-compatible implementation of `CustomEvent`.
-
-	// TODO(section-1): wire `CustomEvent` on `js.Node` / `globalThis` facade if desired.
-
-	@see https://nodejs.org/api/events.html#class-customevent
-	@see https://nodejs.org/api/globals.html#class-customevent
+	Result of `ReadableStreamDefaultReader.read()` / BYOB `read()`.
 **/
-@:native("CustomEvent")
-extern class CustomEvent extends Event {
-	/**
-		Custom data passed when initializing the event.
-	**/
-	var detail(default, null):Any;
-
-	function new(type:String, ?eventInitDict:CustomEventInit):Void;
-}
-
-/**
-	Options passed to the `CustomEvent` constructor.
-**/
-typedef CustomEventInit = {
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
-	@:optional var bubbles:Bool;
-
-	/**
-		When `true`, `preventDefault()` can cancel the event. Default: `false`.
-	**/
-	@:optional var cancelable:Bool;
-
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
-	@:optional var composed:Bool;
-
-	/**
-		Custom data exposed as `detail`.
-	**/
-	@:optional var detail:Any;
+typedef ReadableStreamReadResult = {
+	var done:Bool;
+	@:optional var value:Any;
 }

--- a/src/js/node/web/Request.hx
+++ b/src/js/node/web/Request.hx
@@ -24,18 +24,12 @@ package js.node.web;
 
 import haxe.DynamicAccess;
 import haxe.extern.EitherType;
-import js.node.url.URLSearchParams;
-#if haxe4
 import js.lib.ArrayBuffer;
 import js.lib.ArrayBufferView;
 import js.lib.Promise;
 import js.lib.Uint8Array;
-#else
-import js.html.ArrayBuffer;
-import js.html.ArrayBufferView;
-import js.Promise;
-import js.html.Uint8Array;
-#end
+import js.node.url.URL;
+import js.node.url.URLSearchParams;
 
 /**
 	The Fetch API `Request` interface (undici).
@@ -60,14 +54,24 @@ extern class Request {
 	var duplex(default, null):String;
 
 	/**
-		A `ReadableStream` of the body contents, or `null`.
-		Typed as `Dynamic` until web streams externs are added.
+		Always `false` in Node.js (undici); provided for browser API completeness.
 	**/
-	var body(default, null):Dynamic;
+	var isHistoryNavigation(default, null):Bool;
+
+	/**
+		Always `false` in Node.js (undici); provided for browser API completeness.
+	**/
+	var isReloadNavigation(default, null):Bool;
+
+	/**
+		A `ReadableStream` of the body contents, or `null`.
+	**/
+	var body(default, null):Null<ReadableStream>;
 
 	var bodyUsed(default, null):Bool;
 
 	@:overload(function(input:Request, ?init:RequestInit):Void {})
+	@:overload(function(input:URL, ?init:RequestInit):Void {})
 	function new(input:String, ?init:RequestInit):Void;
 
 	function clone():Request;
@@ -75,7 +79,7 @@ extern class Request {
 	function blob():Promise<Blob>;
 	function bytes():Promise<Uint8Array>;
 	function formData():Promise<FormData>;
-	function json():Promise<Dynamic>;
+	function json():Promise<Any>;
 	function text():Promise<String>;
 }
 
@@ -99,12 +103,16 @@ typedef RequestInit = {
 
 	/**
 		Undici-specific: custom dispatcher for the request.
+
+		TODO(section-6): type as undici `Dispatcher` if a module extern is added.
 	**/
-	@:optional var dispatcher:Dynamic;
+	@:optional var dispatcher:Any;
 }
 
 /**
 	Values accepted as request/response bodies.
 **/
 typedef BodyInit = EitherType<Blob,
-	EitherType<FormData, EitherType<URLSearchParams, EitherType<ArrayBuffer, EitherType<ArrayBufferView, EitherType<String, Dynamic>>>>>>;
+	EitherType<FormData,
+		EitherType<URLSearchParams,
+			EitherType<ArrayBuffer, EitherType<ArrayBufferView, EitherType<String, EitherType<ReadableStream, Any>>>>>>>;

--- a/src/js/node/web/Response.hx
+++ b/src/js/node/web/Response.hx
@@ -24,16 +24,10 @@ package js.node.web;
 
 import haxe.DynamicAccess;
 import haxe.extern.EitherType;
-import js.node.web.Request.BodyInit;
-#if haxe4
 import js.lib.ArrayBuffer;
 import js.lib.Promise;
 import js.lib.Uint8Array;
-#else
-import js.html.ArrayBuffer;
-import js.Promise;
-import js.html.Uint8Array;
-#end
+import js.node.web.Request.BodyInit;
 
 /**
 	The Fetch API `Response` interface (undici).
@@ -55,7 +49,7 @@ extern class Response {
 	/**
 		Creates a new response with a JSON body.
 	**/
-	static function json(data:Dynamic, ?init:ResponseInit):Response;
+	static function json(data:Any, ?init:ResponseInit):Response;
 
 	var type(default, null):String;
 	var url(default, null):String;
@@ -67,9 +61,8 @@ extern class Response {
 
 	/**
 		A `ReadableStream` of the body contents, or `null`.
-		Typed as `Dynamic` until web streams externs are added.
 	**/
-	var body(default, null):Dynamic;
+	var body(default, null):Null<ReadableStream>;
 
 	var bodyUsed(default, null):Bool;
 
@@ -80,7 +73,7 @@ extern class Response {
 	function blob():Promise<Blob>;
 	function bytes():Promise<Uint8Array>;
 	function formData():Promise<FormData>;
-	function json():Promise<Dynamic>;
+	function json():Promise<Any>;
 	function text():Promise<String>;
 }
 

--- a/src/js/node/web/Storage.hx
+++ b/src/js/node/web/Storage.hx
@@ -23,44 +23,23 @@
 package js.node.web;
 
 /**
-	A browser-compatible implementation of `CustomEvent`.
+	Web Storage API `Storage` interface used by `localStorage` / `sessionStorage`.
 
-	// TODO(section-1): wire `CustomEvent` on `js.Node` / `globalThis` facade if desired.
+	Stability: 1.2 - Release candidate. Enable with `--experimental-webstorage`.
+	`localStorage` persists to the file given by `--localstorage-file`.
 
-	@see https://nodejs.org/api/events.html#class-customevent
-	@see https://nodejs.org/api/globals.html#class-customevent
+	// TODO(section-1): expose `localStorage` / `sessionStorage` / `Storage` on `js.Node`.
+
+	@see https://nodejs.org/api/globals.html#class-storage
+	@see https://nodejs.org/api/globals.html#localstorage
 **/
-@:native("CustomEvent")
-extern class CustomEvent extends Event {
-	/**
-		Custom data passed when initializing the event.
-	**/
-	var detail(default, null):Any;
+@:native("Storage")
+extern class Storage {
+	var length(default, null):Int;
 
-	function new(type:String, ?eventInitDict:CustomEventInit):Void;
-}
-
-/**
-	Options passed to the `CustomEvent` constructor.
-**/
-typedef CustomEventInit = {
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
-	@:optional var bubbles:Bool;
-
-	/**
-		When `true`, `preventDefault()` can cancel the event. Default: `false`.
-	**/
-	@:optional var cancelable:Bool;
-
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
-	@:optional var composed:Bool;
-
-	/**
-		Custom data exposed as `detail`.
-	**/
-	@:optional var detail:Any;
+	function key(index:Int):Null<String>;
+	function getItem(key:String):Null<String>;
+	function setItem(key:String, value:String):Void;
+	function removeItem(key:String):Void;
+	function clear():Void;
 }

--- a/src/js/node/web/TextDecoder.hx
+++ b/src/js/node/web/TextDecoder.hx
@@ -22,45 +22,38 @@
 
 package js.node.web;
 
+import haxe.extern.EitherType;
+import js.lib.ArrayBuffer;
+import js.lib.ArrayBufferView;
+
 /**
-	A browser-compatible implementation of `CustomEvent`.
+	WHATWG Encoding Standard `TextDecoder` (global).
 
-	// TODO(section-1): wire `CustomEvent` on `js.Node` / `globalThis` facade if desired.
+	Also available via `js.node.util.TextDecoder`.
 
-	@see https://nodejs.org/api/events.html#class-customevent
-	@see https://nodejs.org/api/globals.html#class-customevent
+	// TODO(section-1): wire on `js.Node` / `globalThis` facade if desired.
+
+	@see https://nodejs.org/api/globals.html#class-textdecoder
 **/
-@:native("CustomEvent")
-extern class CustomEvent extends Event {
-	/**
-		Custom data passed when initializing the event.
-	**/
-	var detail(default, null):Any;
+@:native("TextDecoder")
+extern class TextDecoder {
+	var encoding(default, null):String;
+	var fatal(default, null):Bool;
+	var ignoreBOM(default, null):Bool;
 
-	function new(type:String, ?eventInitDict:CustomEventInit):Void;
+	function new(?label:String, ?options:TextDecoderOptions):Void;
+
+	/**
+		Decodes `input` and returns a string. When `stream` is true, incomplete
+		byte sequences may be buffered until a subsequent `decode` call.
+	**/
+	function decode(?input:EitherType<ArrayBuffer, ArrayBufferView>, ?options:{@:optional var stream:Bool;}):String;
 }
 
 /**
-	Options passed to the `CustomEvent` constructor.
+	Options for the `TextDecoder` constructor.
 **/
-typedef CustomEventInit = {
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
-	@:optional var bubbles:Bool;
-
-	/**
-		When `true`, `preventDefault()` can cancel the event. Default: `false`.
-	**/
-	@:optional var cancelable:Bool;
-
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
-	@:optional var composed:Bool;
-
-	/**
-		Custom data exposed as `detail`.
-	**/
-	@:optional var detail:Any;
+typedef TextDecoderOptions = {
+	@:optional var fatal:Bool;
+	@:optional var ignoreBOM:Bool;
 }

--- a/src/js/node/web/TextDecoderStream.hx
+++ b/src/js/node/web/TextDecoderStream.hx
@@ -23,44 +23,27 @@
 package js.node.web;
 
 /**
-	A browser-compatible implementation of `CustomEvent`.
+	A transform stream that decodes bytes into strings.
 
-	// TODO(section-1): wire `CustomEvent` on `js.Node` / `globalThis` facade if desired.
-
-	@see https://nodejs.org/api/events.html#class-customevent
-	@see https://nodejs.org/api/globals.html#class-customevent
+	@see https://nodejs.org/api/globals.html#class-textdecoderstream
+	@see https://nodejs.org/api/webstreams.html#class-textdecoderstream
 **/
-@:native("CustomEvent")
-extern class CustomEvent extends Event {
-	/**
-		Custom data passed when initializing the event.
-	**/
-	var detail(default, null):Any;
+@:native("TextDecoderStream")
+extern class TextDecoderStream {
+	var encoding(default, null):String;
+	var fatal(default, null):Bool;
+	var ignoreBOM(default, null):Bool;
 
-	function new(type:String, ?eventInitDict:CustomEventInit):Void;
+	var readable(default, null):ReadableStream;
+	var writable(default, null):WritableStream;
+
+	function new(?label:String, ?options:TextDecoderStreamOptions):Void;
 }
 
 /**
-	Options passed to the `CustomEvent` constructor.
+	Options for `TextDecoderStream`.
 **/
-typedef CustomEventInit = {
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
-	@:optional var bubbles:Bool;
-
-	/**
-		When `true`, `preventDefault()` can cancel the event. Default: `false`.
-	**/
-	@:optional var cancelable:Bool;
-
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
-	@:optional var composed:Bool;
-
-	/**
-		Custom data exposed as `detail`.
-	**/
-	@:optional var detail:Any;
+typedef TextDecoderStreamOptions = {
+	@:optional var fatal:Bool;
+	@:optional var ignoreBOM:Bool;
 }

--- a/src/js/node/web/TextEncoder.hx
+++ b/src/js/node/web/TextEncoder.hx
@@ -22,45 +22,42 @@
 
 package js.node.web;
 
+import js.lib.Uint8Array;
+
 /**
-	A browser-compatible implementation of `CustomEvent`.
+	WHATWG Encoding Standard `TextEncoder` (global).
 
-	// TODO(section-1): wire `CustomEvent` on `js.Node` / `globalThis` facade if desired.
+	Also available via `js.node.util.TextEncoder` (`require("util").TextEncoder`).
 
-	@see https://nodejs.org/api/events.html#class-customevent
-	@see https://nodejs.org/api/globals.html#class-customevent
+	// TODO(section-1): wire on `js.Node` / `globalThis` facade if desired.
+	// TODO(section-4): consider aligning `js.node.util.TextEncoder` with `encodeInto`.
+
+	@see https://nodejs.org/api/globals.html#class-textencoder
 **/
-@:native("CustomEvent")
-extern class CustomEvent extends Event {
+@:native("TextEncoder")
+extern class TextEncoder {
 	/**
-		Custom data passed when initializing the event.
+		Always `'utf-8'`.
 	**/
-	var detail(default, null):Any;
+	var encoding(default, null):String;
 
-	function new(type:String, ?eventInitDict:CustomEventInit):Void;
+	function new():Void;
+
+	/**
+		UTF-8 encodes `input` and returns a `Uint8Array` of the encoded bytes.
+	**/
+	function encode(?input:String):Uint8Array;
+
+	/**
+		Encodes `source` into `destination` and returns how many code units / bytes were written.
+	**/
+	function encodeInto(source:String, destination:Uint8Array):TextEncoderEncodeIntoResult;
 }
 
 /**
-	Options passed to the `CustomEvent` constructor.
+	Result of `TextEncoder.encodeInto`.
 **/
-typedef CustomEventInit = {
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
-	@:optional var bubbles:Bool;
-
-	/**
-		When `true`, `preventDefault()` can cancel the event. Default: `false`.
-	**/
-	@:optional var cancelable:Bool;
-
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
-	@:optional var composed:Bool;
-
-	/**
-		Custom data exposed as `detail`.
-	**/
-	@:optional var detail:Any;
+typedef TextEncoderEncodeIntoResult = {
+	var read:Int;
+	var written:Int;
 }

--- a/src/js/node/web/TextEncoderStream.hx
+++ b/src/js/node/web/TextEncoderStream.hx
@@ -23,44 +23,20 @@
 package js.node.web;
 
 /**
-	A browser-compatible implementation of `CustomEvent`.
+	A transform stream that encodes strings into UTF-8 bytes.
 
-	// TODO(section-1): wire `CustomEvent` on `js.Node` / `globalThis` facade if desired.
-
-	@see https://nodejs.org/api/events.html#class-customevent
-	@see https://nodejs.org/api/globals.html#class-customevent
+	@see https://nodejs.org/api/globals.html#class-textencoderstream
+	@see https://nodejs.org/api/webstreams.html#class-textencoderstream
 **/
-@:native("CustomEvent")
-extern class CustomEvent extends Event {
+@:native("TextEncoderStream")
+extern class TextEncoderStream {
 	/**
-		Custom data passed when initializing the event.
+		Always `"utf-8"`.
 	**/
-	var detail(default, null):Any;
+	var encoding(default, null):String;
 
-	function new(type:String, ?eventInitDict:CustomEventInit):Void;
-}
+	var readable(default, null):ReadableStream;
+	var writable(default, null):WritableStream;
 
-/**
-	Options passed to the `CustomEvent` constructor.
-**/
-typedef CustomEventInit = {
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
-	@:optional var bubbles:Bool;
-
-	/**
-		When `true`, `preventDefault()` can cancel the event. Default: `false`.
-	**/
-	@:optional var cancelable:Bool;
-
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
-	@:optional var composed:Bool;
-
-	/**
-		Custom data exposed as `detail`.
-	**/
-	@:optional var detail:Any;
+	function new():Void;
 }

--- a/src/js/node/web/TransformStream.hx
+++ b/src/js/node/web/TransformStream.hx
@@ -23,44 +23,27 @@
 package js.node.web;
 
 /**
-	A browser-compatible implementation of `CustomEvent`.
+	A browser-compatible implementation of `TransformStream`.
 
-	// TODO(section-1): wire `CustomEvent` on `js.Node` / `globalThis` facade if desired.
-
-	@see https://nodejs.org/api/events.html#class-customevent
-	@see https://nodejs.org/api/globals.html#class-customevent
+	@see https://nodejs.org/api/globals.html#class-transformstream
+	@see https://nodejs.org/api/webstreams.html#class-transformstream
 **/
-@:native("CustomEvent")
-extern class CustomEvent extends Event {
-	/**
-		Custom data passed when initializing the event.
-	**/
-	var detail(default, null):Any;
+@:native("TransformStream")
+extern class TransformStream {
+	var readable(default, null):ReadableStream;
+	var writable(default, null):WritableStream;
 
-	function new(type:String, ?eventInitDict:CustomEventInit):Void;
+	function new(?transformer:Transformer, ?writableStrategy:QueuingStrategy, ?readableStrategy:QueuingStrategy):Void;
 }
 
 /**
-	Options passed to the `CustomEvent` constructor.
+	Transformer callbacks for `TransformStream`.
 **/
-typedef CustomEventInit = {
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
-	@:optional var bubbles:Bool;
-
-	/**
-		When `true`, `preventDefault()` can cancel the event. Default: `false`.
-	**/
-	@:optional var cancelable:Bool;
-
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
-	@:optional var composed:Bool;
-
-	/**
-		Custom data exposed as `detail`.
-	**/
-	@:optional var detail:Any;
+typedef Transformer = {
+	@:optional var start:TransformStreamDefaultController->Any;
+	@:optional var transform:Any->TransformStreamDefaultController->Any;
+	@:optional var flush:TransformStreamDefaultController->Any;
+	@:optional var cancel:Any->Any;
+	@:optional var readableType:Any;
+	@:optional var writableType:Any;
 }

--- a/src/js/node/web/TransformStreamDefaultController.hx
+++ b/src/js/node/web/TransformStreamDefaultController.hx
@@ -23,44 +23,15 @@
 package js.node.web;
 
 /**
-	A browser-compatible implementation of `CustomEvent`.
+	Controller associated with a `TransformStream`.
 
-	// TODO(section-1): wire `CustomEvent` on `js.Node` / `globalThis` facade if desired.
-
-	@see https://nodejs.org/api/events.html#class-customevent
-	@see https://nodejs.org/api/globals.html#class-customevent
+	@see https://nodejs.org/api/globals.html#class-transformstreamdefaultcontroller
 **/
-@:native("CustomEvent")
-extern class CustomEvent extends Event {
-	/**
-		Custom data passed when initializing the event.
-	**/
-	var detail(default, null):Any;
+@:native("TransformStreamDefaultController")
+extern class TransformStreamDefaultController {
+	var desiredSize(default, null):Null<Float>;
 
-	function new(type:String, ?eventInitDict:CustomEventInit):Void;
-}
-
-/**
-	Options passed to the `CustomEvent` constructor.
-**/
-typedef CustomEventInit = {
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
-	@:optional var bubbles:Bool;
-
-	/**
-		When `true`, `preventDefault()` can cancel the event. Default: `false`.
-	**/
-	@:optional var cancelable:Bool;
-
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
-	@:optional var composed:Bool;
-
-	/**
-		Custom data exposed as `detail`.
-	**/
-	@:optional var detail:Any;
+	function enqueue(?chunk:Any):Void;
+	function error(?reason:Any):Void;
+	function terminate():Void;
 }

--- a/src/js/node/web/WebSocket.hx
+++ b/src/js/node/web/WebSocket.hx
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.web;
+
+import haxe.extern.EitherType;
+import js.lib.ArrayBuffer;
+import js.lib.ArrayBufferView;
+import js.node.url.URL;
+
+/**
+	A browser-compatible `WebSocket` implementation (undici).
+
+	@see https://nodejs.org/api/globals.html#class-websocket
+**/
+@:native("WebSocket")
+extern class WebSocket extends EventTarget {
+	static inline var CONNECTING:Int = 0;
+	static inline var OPEN:Int = 1;
+	static inline var CLOSING:Int = 2;
+	static inline var CLOSED:Int = 3;
+
+	var binaryType:String;
+	var bufferedAmount(default, null):Int;
+	var extensions(default, null):String;
+	var protocol(default, null):String;
+	var readyState(default, null):Int;
+	var url(default, null):String;
+
+	var onopen:Null<Event->Void>;
+	var onerror:Null<Event->Void>;
+	var onclose:Null<CloseEvent->Void>;
+	var onmessage:Null<MessageEvent->Void>;
+
+	@:overload(function(url:URL, ?protocols:EitherType<String, Array<String>>):Void {})
+	@:overload(function(url:String, ?options:WebSocketInit):Void {})
+	@:overload(function(url:URL, ?options:WebSocketInit):Void {})
+	function new(url:String, ?protocols:EitherType<String, Array<String>>):Void;
+
+	function close(?code:Int, ?reason:String):Void;
+
+	@:overload(function(data:ArrayBuffer):Void {})
+	@:overload(function(data:ArrayBufferView):Void {})
+	@:overload(function(data:Blob):Void {})
+	function send(data:String):Void;
+}
+
+/**
+	Undici / Node `WebSocket` constructor options (headers, protocols, etc.).
+**/
+typedef WebSocketInit = {
+	@:optional var protocols:EitherType<String, Array<String>>;
+	@:optional var headers:EitherType<Headers, Any>;
+	// TODO(section-6): type undici dispatcher options when available.
+	@:optional var dispatcher:Any;
+}

--- a/src/js/node/web/WritableStream.hx
+++ b/src/js/node/web/WritableStream.hx
@@ -22,45 +22,32 @@
 
 package js.node.web;
 
+import js.lib.Promise;
+
 /**
-	A browser-compatible implementation of `CustomEvent`.
+	A browser-compatible implementation of `WritableStream`.
 
-	// TODO(section-1): wire `CustomEvent` on `js.Node` / `globalThis` facade if desired.
-
-	@see https://nodejs.org/api/events.html#class-customevent
-	@see https://nodejs.org/api/globals.html#class-customevent
+	@see https://nodejs.org/api/globals.html#class-writablestream
+	@see https://nodejs.org/api/webstreams.html#class-writablestream
 **/
-@:native("CustomEvent")
-extern class CustomEvent extends Event {
-	/**
-		Custom data passed when initializing the event.
-	**/
-	var detail(default, null):Any;
+@:native("WritableStream")
+extern class WritableStream {
+	var locked(default, null):Bool;
 
-	function new(type:String, ?eventInitDict:CustomEventInit):Void;
+	function new(?underlyingSink:WritableStreamUnderlyingSink, ?strategy:QueuingStrategy):Void;
+
+	function abort(?reason:Any):Promise<Void>;
+	function close():Promise<Void>;
+	function getWriter():WritableStreamDefaultWriter;
 }
 
 /**
-	Options passed to the `CustomEvent` constructor.
+	Underlying sink for `WritableStream` construction.
 **/
-typedef CustomEventInit = {
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
-	@:optional var bubbles:Bool;
-
-	/**
-		When `true`, `preventDefault()` can cancel the event. Default: `false`.
-	**/
-	@:optional var cancelable:Bool;
-
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
-	@:optional var composed:Bool;
-
-	/**
-		Custom data exposed as `detail`.
-	**/
-	@:optional var detail:Any;
+typedef WritableStreamUnderlyingSink = {
+	@:optional var type:Any;
+	@:optional var start:WritableStreamDefaultController->Any;
+	@:optional var write:Any->WritableStreamDefaultController->Any;
+	@:optional var close:Void->Any;
+	@:optional var abort:Any->Any;
 }

--- a/src/js/node/web/WritableStreamDefaultController.hx
+++ b/src/js/node/web/WritableStreamDefaultController.hx
@@ -23,44 +23,13 @@
 package js.node.web;
 
 /**
-	A browser-compatible implementation of `CustomEvent`.
+	Controller associated with a `WritableStream`.
 
-	// TODO(section-1): wire `CustomEvent` on `js.Node` / `globalThis` facade if desired.
-
-	@see https://nodejs.org/api/events.html#class-customevent
-	@see https://nodejs.org/api/globals.html#class-customevent
+	@see https://nodejs.org/api/globals.html#class-writablestreamdefaultcontroller
 **/
-@:native("CustomEvent")
-extern class CustomEvent extends Event {
-	/**
-		Custom data passed when initializing the event.
-	**/
-	var detail(default, null):Any;
+@:native("WritableStreamDefaultController")
+extern class WritableStreamDefaultController {
+	var signal(default, null):AbortSignal;
 
-	function new(type:String, ?eventInitDict:CustomEventInit):Void;
-}
-
-/**
-	Options passed to the `CustomEvent` constructor.
-**/
-typedef CustomEventInit = {
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
-	@:optional var bubbles:Bool;
-
-	/**
-		When `true`, `preventDefault()` can cancel the event. Default: `false`.
-	**/
-	@:optional var cancelable:Bool;
-
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
-	@:optional var composed:Bool;
-
-	/**
-		Custom data exposed as `detail`.
-	**/
-	@:optional var detail:Any;
+	function error(?e:Any):Void;
 }

--- a/src/js/node/web/WritableStreamDefaultWriter.hx
+++ b/src/js/node/web/WritableStreamDefaultWriter.hx
@@ -22,45 +22,24 @@
 
 package js.node.web;
 
-/**
-	A browser-compatible implementation of `CustomEvent`.
-
-	// TODO(section-1): wire `CustomEvent` on `js.Node` / `globalThis` facade if desired.
-
-	@see https://nodejs.org/api/events.html#class-customevent
-	@see https://nodejs.org/api/globals.html#class-customevent
-**/
-@:native("CustomEvent")
-extern class CustomEvent extends Event {
-	/**
-		Custom data passed when initializing the event.
-	**/
-	var detail(default, null):Any;
-
-	function new(type:String, ?eventInitDict:CustomEventInit):Void;
-}
+import js.lib.Promise;
 
 /**
-	Options passed to the `CustomEvent` constructor.
+	Default writer for a `WritableStream`.
+
+	@see https://nodejs.org/api/globals.html#class-writablestreamdefaultwriter
+	@see https://nodejs.org/api/webstreams.html#class-writablestreamdefaultwriter
 **/
-typedef CustomEventInit = {
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
-	@:optional var bubbles:Bool;
+@:native("WritableStreamDefaultWriter")
+extern class WritableStreamDefaultWriter {
+	function new(stream:WritableStream):Void;
 
-	/**
-		When `true`, `preventDefault()` can cancel the event. Default: `false`.
-	**/
-	@:optional var cancelable:Bool;
+	var closed(default, null):Promise<Void>;
+	var ready(default, null):Promise<Void>;
+	var desiredSize(default, null):Null<Float>;
 
-	/**
-		Not used in Node.js. Default: `false`.
-	**/
-	@:optional var composed:Bool;
-
-	/**
-		Custom data exposed as `detail`.
-	**/
-	@:optional var detail:Any;
+	function abort(?reason:Any):Promise<Void>;
+	function close():Promise<Void>;
+	function releaseLock():Void;
+	function write(chunk:Any):Promise<Void>;
 }


### PR DESCRIPTION
## Summary
- Audit and expand `js.node.web` against Node.js 24 web platform globals (undici fetch + EventTarget family + streams/messaging).
- Drop Haxe 3 `#if haxe4` import branches; keep Haxe 4 `js.lib.*` only.
- Replace loose `Dynamic` with `Any` / concrete types where clear; type `Blob.stream()` / `Request`/`Response.body` as `ReadableStream`.
- Add missing globals: web streams (+ controllers/readers/writers), compression streams, queuing strategies, `BroadcastChannel`/`MessageChannel`/`MessagePort`/`MessageEvent`, `WebSocket`/`CloseEvent`, `EventSource`, `Navigator`/`LockManager`, `Storage`, global `TextEncoder`/`TextDecoder` (+ stream variants).
- Fetch/`Request` accept `URL`; Request gains `isHistoryNavigation` / `isReloadNavigation`.

## Coordination TODOs
- **section-1**: wire globals on `js.Node` / `globalThis` facade (`fetch`, Abort*, Event*, Blob/File, Navigator, Storage, TextEncoder/Decoder, …).
- **section-4**: `URLPattern` global (URL package affinity); align `js.node.util.TextEncoder` with global `encodeInto` if desired; webcrypto remains crypto-util.
- **section-5**: tighten `MessagePort.postMessage` transfer list once `worker_threads` transferables exist.
- **section-6 (follow-ups)**: undici `Dispatcher` typing for `RequestInit` / `WebSocket` / `EventSource`; deeper BYOB/underlying-source callback typing if needed.

## Test plan
- [x] `haxe build.hxml` (ImportAll + examples) succeeds
- [ ] Spot-check new types against Node 24 docs / undici behavior
- [ ] Confirm section-1 wiring after merge coordination


Made with [Cursor](https://cursor.com)