### PR TITLE
Wire async_hooks and process IPC/module typing

### DIFF
--- a/src/js/node/Module.hx
+++ b/src/js/node/Module.hx
@@ -22,7 +22,9 @@
 
 package js.node;
 
+import haxe.Constraints.Function;
 import haxe.extern.EitherType;
+import js.node.module.SourceMap;
 import js.node.url.URL;
 
 /**
@@ -112,9 +114,10 @@ extern class Module {
 
 	/**
 		`findSourceMap` finds the corresponding source map for a given file path.
-		// TODO(section-5): refine SourceMap type when vm/module source-map types are audited.
+
+		@see https://nodejs.org/api/module.html#modulefindsourcemappath
 	**/
-	static function findSourceMap(path:String):Null<Dynamic>;
+	static function findSourceMap(path:String):Null<SourceMap>;
 
 	/**
 		Removes TypeScript type annotations from `code`.
@@ -123,9 +126,13 @@ extern class Module {
 
 	/**
 		Register synchronous customization hooks.
-		// TODO(section-5): refine hook option types when the module loader API is audited.
+
+		Hook callback signatures stay loosely typed (`Function`); full
+		`resolve`/`load` context models can be refined later.
+
+		@see https://nodejs.org/api/module.html#moduleregisterhooksoptions
 	**/
-	static function registerHooks(options:Dynamic):Void;
+	static function registerHooks(options:ModuleRegisterHooksOptions):ModuleHooks;
 
 	/**
 		Finds the closest `package.json` for the given specifier.
@@ -137,12 +144,13 @@ extern class Module {
 
 	/**
 		Register a module that exports hooks that customize Node.js module resolution and loading.
-		// TODO(section-5): refine register options / return types when the loader API is audited.
 
 		@see https://nodejs.org/api/module.html#moduleregisterspecifier-parenturl-options
 	**/
-	@:overload(function(specifier:String, parentURL:EitherType<String, URL>, ?options:Dynamic):Void {})
-	static function register(specifier:String, ?options:Dynamic):Void;
+	@:overload(function(specifier:String, parentURL:EitherType<String, URL>, ?options:ModuleRegisterOptions):Void {})
+	@:overload(function(specifier:URL, parentURL:EitherType<String, URL>, ?options:ModuleRegisterOptions):Void {})
+	@:overload(function(specifier:URL, ?options:ModuleRegisterOptions):Void {})
+	static function register(specifier:String, ?options:ModuleRegisterOptions):Void;
 
 	/**
 		Enable the module compile cache.
@@ -164,12 +172,12 @@ extern class Module {
 	/**
 		Enable or disable Source Map v3 support for stack traces.
 	**/
-	static function setSourceMapsSupport(enabled:Bool, ?options:Dynamic):Void;
+	static function setSourceMapsSupport(enabled:Bool, ?options:ModuleSetSourceMapsSupportOptions):Void;
 
 	/**
 		Return whether Source Map support is enabled and related options.
 	**/
-	static function getSourceMapsSupport():Dynamic;
+	static function getSourceMapsSupport():ModuleSourceMapsSupport;
 }
 
 /**
@@ -190,4 +198,86 @@ typedef ModuleStripTypeScriptTypesOptions = {
 		The filename used when generating source maps.
 	**/
 	@:optional var sourceUrl:String;
+}
+
+/**
+	Options for `Module.register`.
+**/
+typedef ModuleRegisterOptions = {
+	/**
+		Base URL used to resolve relative `specifier` values when `parentURL` is not
+		passed as a separate argument. Default: `'data:'`.
+	**/
+	@:optional var parentURL:EitherType<String, URL>;
+
+	/**
+		Arbitrary cloneable value passed into the initialize hook.
+	**/
+	@:optional var data:Dynamic;
+
+	/**
+		Transferable objects passed into the initialize hook.
+		// TODO(section-5): tighten once worker_threads transferable typing is settled.
+	**/
+	@:optional var transferList:Array<Dynamic>;
+}
+
+/**
+	Options for `Module.registerHooks`.
+**/
+typedef ModuleRegisterHooksOptions = {
+	/**
+		Synchronous load hook. See Node.js module customization hooks.
+	**/
+	@:optional var load:Function;
+
+	/**
+		Synchronous resolve hook. See Node.js module customization hooks.
+	**/
+	@:optional var resolve:Function;
+}
+
+/**
+	Handle returned by `Module.registerHooks`.
+**/
+typedef ModuleHooks = {
+	/**
+		Deregister the hook instance.
+	**/
+	function deregister():Void;
+}
+
+/**
+	Options for `Module.setSourceMapsSupport`.
+**/
+typedef ModuleSetSourceMapsSupportOptions = {
+	/**
+		Enable support for files in `node_modules`. Default: `false`.
+	**/
+	@:optional var nodeModules:Bool;
+
+	/**
+		Enable support for generated code from `eval` / `new Function`. Default: `false`.
+	**/
+	@:optional var generatedCode:Bool;
+}
+
+/**
+	Result of `Module.getSourceMapsSupport`.
+**/
+typedef ModuleSourceMapsSupport = {
+	/**
+		Whether Source Map v3 support is enabled.
+	**/
+	var enabled:Bool;
+
+	/**
+		Whether support is enabled for files in `node_modules`.
+	**/
+	var nodeModules:Bool;
+
+	/**
+		Whether support is enabled for generated code from `eval` / `new Function`.
+	**/
+	var generatedCode:Bool;
 }

--- a/src/js/node/Process.hx
+++ b/src/js/node/Process.hx
@@ -27,6 +27,8 @@ import haxe.Constraints.Function;
 import haxe.extern.EitherType;
 import haxe.extern.Rest;
 import js.lib.Error;
+import js.node.child_process.ChildProcess.ChildProcessChannel;
+import js.node.child_process.ChildProcess.ChildProcessSendHandle;
 import js.node.child_process.ChildProcess.ChildProcessSendOptions;
 import js.node.events.EventEmitter;
 import js.node.process.ProcessFinalization;
@@ -84,7 +86,7 @@ enum abstract ProcessEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 	/**
 		Emitted when a message is received over IPC. Available for child processes.
 	**/
-	var Message:ProcessEvent<(message:Dynamic, sendHandle:Dynamic) -> Void> = "message";
+	var Message:ProcessEvent<(message:Dynamic, sendHandle:Null<ChildProcessSendHandle>) -> Void> = "message";
 
 	/**
 		Emitted after calling `process.disconnect()` in a child process.
@@ -243,9 +245,8 @@ extern class Process extends EventEmitter<Process> {
 
 	/**
 		IPC channel reference for the process, if present.
-		// TODO(section-5): refine IPC channel type when child_process IPC is audited.
 	**/
-	var channel(default, null):Null<Dynamic>;
+	var channel(default, null):Null<ChildProcessChannel>;
 
 	/**
 		The debugger port of the Node.js process.
@@ -409,10 +410,9 @@ extern class Process extends EventEmitter<Process> {
 	/**
 		Send a message to the parent process.
 		Only available for child processes. See `ChildProcess.send`.
-		// TODO(section-5): type `sendHandle` with net.Socket / net.Server / dgram.Socket.
 	**/
-	@:overload(function(message:Dynamic, sendHandle:Dynamic, options:ChildProcessSendOptions, ?callback:Null<Error>->Void):Bool {})
-	@:overload(function(message:Dynamic, sendHandle:Dynamic, ?callback:Null<Error>->Void):Bool {})
+	@:overload(function(message:Dynamic, sendHandle:ChildProcessSendHandle, options:ChildProcessSendOptions, ?callback:Null<Error>->Void):Bool {})
+	@:overload(function(message:Dynamic, sendHandle:ChildProcessSendHandle, ?callback:Null<Error>->Void):Bool {})
 	function send(message:Dynamic, ?callback:Null<Error>->Void):Bool;
 
 	/**

--- a/src/js/node/child_process/ChildProcess.hx
+++ b/src/js/node/child_process/ChildProcess.hx
@@ -25,9 +25,29 @@ package js.node.child_process;
 import haxe.extern.EitherType;
 import js.lib.Error;
 import js.node.Stream;
+import js.node.dgram.Socket as DgramSocket;
 import js.node.events.EventEmitter;
+import js.node.net.Server as NetServer;
+import js.node.net.Socket as NetSocket;
 import js.node.stream.Readable;
 import js.node.stream.Writable;
+
+/**
+	Handle that may be sent over an IPC channel (`net.Socket`, `net.Server`, or `dgram.Socket`).
+
+	@see https://nodejs.org/docs/latest-v24.x/api/child_process.html#subprocesssendmessage-sendhandle-options-callback
+**/
+typedef ChildProcessSendHandle = EitherType<NetSocket, EitherType<NetServer, DgramSocket>>;
+
+/**
+	Control object for an open IPC channel (`process.channel` / `subprocess.channel`).
+
+	@see https://nodejs.org/docs/latest-v24.x/api/process.html#processchannel
+**/
+typedef ChildProcessChannel = {
+	function ref():Void;
+	function unref():Void;
+}
 
 /**
 	Enumeration of events emitted by `ChildProcess` objects.

--- a/src/js/node/diagnostics_channel/Channel.hx
+++ b/src/js/node/diagnostics_channel/Channel.hx
@@ -26,6 +26,7 @@ import haxe.Constraints.Function;
 import haxe.extern.EitherType;
 import haxe.extern.Rest;
 import js.lib.Symbol;
+import js.node.async_hooks.AsyncLocalStorage;
 
 /**
 	Channel name: a string or symbol.
@@ -113,11 +114,9 @@ extern class Channel {
 
 		Stability: 1 - Experimental
 
-		// TODO(section-5): type `store` as AsyncLocalStorage once async_hooks externs land.
-
 		@see https://nodejs.org/docs/latest-v24.x/api/diagnostics_channel.html#channelbindstorestore-transform
 	**/
-	function bindStore(store:Dynamic, ?transform:ChannelStoreTransform):Void;
+	function bindStore(store:AsyncLocalStorage<Dynamic>, ?transform:ChannelStoreTransform):Void;
 
 	/**
 		Remove a store previously bound to this channel with `channel.bindStore(store)`.
@@ -128,11 +127,9 @@ extern class Channel {
 
 		Stability: 1 - Experimental
 
-		// TODO(section-5): type `store` as AsyncLocalStorage once async_hooks externs land.
-
 		@see https://nodejs.org/docs/latest-v24.x/api/diagnostics_channel.html#channelunbindstorestore
 	**/
-	function unbindStore(store:Dynamic):Bool;
+	function unbindStore(store:AsyncLocalStorage<Dynamic>):Bool;
 
 	/**
 		Applies the given data to any AsyncLocalStorage instances bound to the channel

--- a/src/js/node/events/EventEmitter.hx
+++ b/src/js/node/events/EventEmitter.hx
@@ -26,6 +26,7 @@ import haxe.Constraints.Function;
 import haxe.extern.EitherType;
 import haxe.extern.Rest;
 import js.lib.Symbol;
+import js.node.async_hooks.AsyncResource;
 
 /**
 	Enumeration of events emitted by all `EventEmitter` instances.
@@ -293,9 +294,8 @@ extern class EventEmitterAsyncResource extends EventEmitter<EventEmitterAsyncRes
 
 	/**
 		The underlying `AsyncResource`.
-		// TODO(section-7): type as async_hooks.AsyncResource once that package is externed.
 	**/
-	var asyncResource(default, null):Dynamic;
+	var asyncResource(default, null):AsyncResource;
 }
 
 /**

--- a/src/js/node/module/SourceMap.hx
+++ b/src/js/node/module/SourceMap.hx
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C)2014-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.module;
+
+/**
+	Raw Source Map v3 payload used to construct a `SourceMap`.
+
+	@see https://nodejs.org/api/module.html#class-modulesourcemap
+**/
+typedef SourceMapPayload = {
+	var file:String;
+	var version:Float;
+	var sources:Array<String>;
+	var sourcesContent:Array<String>;
+	var names:Array<String>;
+	var mappings:String;
+	var sourceRoot:String;
+}
+
+/**
+	Options for constructing a `SourceMap`.
+**/
+typedef SourceMapConstructorOptions = {
+	/**
+		Optional line lengths used when the payload omits them.
+	**/
+	@:optional var lineLengths:Array<Float>;
+}
+
+/**
+	Zero-indexed Source Map range in the original file.
+**/
+typedef SourceMapping = {
+	var generatedLine:Float;
+	var generatedColumn:Float;
+	var originalSource:String;
+	var originalLine:Float;
+	var originalColumn:Float;
+}
+
+/**
+	1-indexed call-site location in the original source.
+**/
+typedef SourceOrigin = {
+	var name:Null<String>;
+	var fileName:String;
+	var lineNumber:Float;
+	var columnNumber:Float;
+}
+
+/**
+	Represents a [Source Map v3](https://tc39.es/ecma426/).
+
+	@see https://nodejs.org/api/module.html#class-modulesourcemap
+**/
+@:jsRequire("module", "SourceMap")
+extern class SourceMap {
+	function new(payload:SourceMapPayload, ?options:SourceMapConstructorOptions);
+
+	/**
+		Payload used to construct this `SourceMap` instance.
+	**/
+	var payload(default, null):SourceMapPayload;
+
+	/**
+		Given zero-indexed offsets in the generated source, returns the corresponding
+		Source Map range, or an empty object when not found.
+	**/
+	function findEntry(lineOffset:Float, columnOffset:Float):Dynamic;
+
+	/**
+		Given 1-indexed line/column from a call site in the generated source, returns
+		the corresponding original location, or an empty object when not found.
+	**/
+	function findOrigin(lineNumber:Float, columnNumber:Float):Dynamic;
+}


### PR DESCRIPTION
## Summary
- **A4:** Type `EventEmitterAsyncResource.asyncResource` as `AsyncResource`, and `Channel.bindStore`/`unbindStore` store args as `AsyncLocalStorage`.
- **A5:** Introduce `ChildProcessSendHandle` / `ChildProcessChannel` and wire `Process` channel, `send`, and `message` accordingly (`net.Socket` / `net.Server` / `dgram.Socket`).
- Add `js.node.module.SourceMap` and refine `Module.findSourceMap` / `register` / `registerHooks` / source-maps support options (hook callbacks remain `Function`; `transferList` left partial).

## Test plan
- [x] `haxe -js dummy -cp src --macro ImportAll.run("src") --no-output` with Haxe **4.0.5**
- [ ] Spot-check against Node 24 docs for `process.send` / `module.SourceMap` / diagnostics_channel store APIs


Made with [Cursor](https://cursor.com)