### PR TITLE
Audit cluster externs for Node 24 and Haxe 4

### DIFF
--- a/src/js/node/Cluster.hx
+++ b/src/js/node/Cluster.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -23,58 +23,74 @@
 package js.node;
 
 import haxe.DynamicAccess;
+import haxe.extern.EitherType;
 import js.node.ChildProcess.ChildProcessSerialization;
 import js.node.ChildProcess.ChildProcessSpawnOptionsStdio;
+import js.node.child_process.ChildProcess.ChildProcessSendHandle;
 import js.node.cluster.Worker;
 import js.node.events.EventEmitter;
 
 /**
+	Events emitted by the `cluster` module.
+
 	@see https://nodejs.org/docs/latest-v24.x/api/cluster.html
 **/
 enum abstract ClusterEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 	/**
-		When a new worker is forked the cluster module will emit a 'fork' event.
-		This can be used to log worker activity, and create your own timeout.
+		Emitted when a new worker is forked.
+		Useful for logging worker activity or creating a custom timeout.
 	**/
-	var Fork:ClusterEvent<Worker->Void> = "fork";
+	var Fork:ClusterEvent<(worker:Worker) -> Void> = "fork";
 
 	/**
-		After forking a new worker, the worker should respond with an online message.
-		When the primary receives an online message it will emit this event.
+		Emitted when the primary receives an online message from a worker.
+
+		The difference between `'fork'` and `'online'` is that `'fork'` is emitted
+		when the primary forks a worker, and `'online'` when the worker is running.
 	**/
-	var Online:ClusterEvent<Worker->Void> = "online";
+	var Online:ClusterEvent<(worker:Worker) -> Void> = "online";
 
 	/**
-		After calling `listen` from a worker, when the 'listening' event is emitted on the server,
-		a listening event will also be emitted on cluster in the primary.
+		Emitted on the primary after a worker's server emits `'listening'`.
+
+		`address` contains `address`, `port`, and `addressType`.
 	**/
-	var Listening:ClusterEvent<Worker->ListeningEventAddress->Void> = "listening";
+	var Listening:ClusterEvent<(worker:Worker, address:ListeningEventAddress) -> Void> = "listening";
 
 	/**
 		Emitted after the worker IPC channel has disconnected.
+
+		There may be a delay between `'disconnect'` and `'exit'`.
 	**/
-	var Disconnect:ClusterEvent<Worker->Void> = "disconnect";
+	var Disconnect:ClusterEvent<(worker:Worker) -> Void> = "disconnect";
 
 	/**
-		When any of the workers die the cluster module will emit the 'exit' event.
+		Emitted when any worker dies.
+
+		Can be used to restart the worker by calling `fork` again.
 	**/
-	var Exit:ClusterEvent<Worker->Int->String->Void> = "exit";
+	var Exit:ClusterEvent<(worker:Worker, code:Int, signal:String) -> Void> = "exit";
 
 	/**
 		Emitted every time `setupPrimary` is called.
+
+		`settings` is advisory only; prefer reading `Cluster.settings` for accuracy
+		when multiple calls happen in a single tick.
 	**/
-	var Setup:ClusterEvent<ClusterSettings->Void> = "setup";
+	var Setup:ClusterEvent<(settings:ClusterSettings) -> Void> = "setup";
 
 	/**
-		Emitted when any worker receives a message.
+		Emitted when the cluster primary receives a message from any worker.
 
-		// TODO(section-5): tighten message/handle typing beyond Dynamic
+		@see https://nodejs.org/docs/latest-v24.x/api/cluster.html#event-message
 	**/
-	var Message:ClusterEvent<Worker->Dynamic->Dynamic->Void> = "message";
+	var Message:ClusterEvent<(worker:Worker, message:Dynamic, handle:Null<ChildProcessSendHandle>) -> Void> = "message";
 }
 
 /**
-	Structure emitted by 'listening' event.
+	Connection properties passed with the `'listening'` event.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/cluster.html#event-listening
 **/
 typedef ListeningEventAddress = {
 	var address:String;
@@ -82,7 +98,13 @@ typedef ListeningEventAddress = {
 	var addressType:ListeningEventAddressType;
 }
 
-enum abstract ListeningEventAddressType(haxe.extern.EitherType<Int, String>) to haxe.extern.EitherType<Int, String> {
+/**
+	`addressType` for `ListeningEventAddress`:
+	- `4` / `6` — TCPv4 / TCPv6
+	- `-1` — Unix domain socket
+	- `"udp4"` / `"udp6"` — UDPv4 / UDPv6
+**/
+enum abstract ListeningEventAddressType(EitherType<Int, String>) to EitherType<Int, String> {
 	var TCPv4 = 4;
 	var TCPv6 = 6;
 	var Unix = -1;
@@ -90,6 +112,14 @@ enum abstract ListeningEventAddressType(haxe.extern.EitherType<Int, String>) to 
 	var UDPv6 = "udp6";
 }
 
+/**
+	Scheduling policy for distributing connections across workers.
+
+	`SCHED_RR` is the default on all platforms except Windows.
+	Can also be set via `NODE_CLUSTER_SCHED_POLICY` (`rr` / `none`).
+
+	@see https://nodejs.org/docs/latest-v24.x/api/cluster.html#clusterschedulingpolicy
+**/
 @:jsRequire("cluster")
 extern enum abstract ClusterSchedulingPolicy(Int) {
 	var SCHED_NONE;
@@ -97,144 +127,180 @@ extern enum abstract ClusterSchedulingPolicy(Int) {
 }
 
 /**
-	The cluster module allows easy creation of child processes that all share server ports.
+	The `node:cluster` module allows easy creation of child processes that all share server ports.
+
+	Stability: 2 - Stable
 
 	@see https://nodejs.org/docs/latest-v24.x/api/cluster.html
 **/
 @:jsRequire("cluster")
 extern class Cluster extends EventEmitter<Cluster> {
 	/**
-		A reference to the `Cluster` object returned by node.js module.
+		A reference to the `Cluster` object returned by the Node.js module.
 
-		It can be imported into module namespace by using: "import js.node.Cluster.instance in cluster"
+		Import into a local name with: `import js.node.Cluster.instance in cluster`
 	**/
-	public static inline var instance:Cluster = cast Cluster;
+	public static inline final instance:Cluster = cast Cluster;
 
 	/**
 		The scheduling policy, either `SCHED_RR` for round-robin
 		or `SCHED_NONE` to leave it to the operating system.
+
+		Global setting; frozen once the first worker is spawned or `setupPrimary`
+		is called, whichever comes first.
 	**/
 	var schedulingPolicy:ClusterSchedulingPolicy;
 
 	/**
-		After calling `setupPrimary` (or `fork`) this settings object will contain the settings,
-		including the default values.
+		Settings after `setupPrimary` (or `fork`), including defaults.
+
+		Not intended to be changed or set manually.
 	**/
 	var settings(default, null):ClusterSettings;
 
 	/**
-		True if the process is a primary.
 		Deprecated alias for `isPrimary`.
+
+		@since v0.8.1
+		@deprecated since v16.0.0
 	**/
 	@:deprecated("Use isPrimary instead")
 	var isMaster(default, null):Bool;
 
 	/**
-		True if the process is a primary.
-		This is determined by the process.env.NODE_UNIQUE_ID.
-		If process.env.NODE_UNIQUE_ID is undefined, then `isPrimary` is true.
+		`true` if the process is a primary.
+
+		Determined by `process.env.NODE_UNIQUE_ID`.
+		If that variable is undefined, then `isPrimary` is `true`.
 	**/
 	var isPrimary(default, null):Bool;
 
 	/**
-		True if the process is not a primary (it is the negation of `isPrimary`).
+		`true` if the process is not a primary (negation of `isPrimary`).
 	**/
 	var isWorker(default, null):Bool;
 
 	/**
 		Deprecated alias for `setupPrimary`.
+
+		@since v0.7.1
+		@deprecated since v16.0.0
 	**/
 	@:deprecated("Use setupPrimary instead")
 	function setupMaster(?settings:ClusterSettings):Void;
 
 	/**
-		Used to change the default `fork` behavior. Once called, the settings will be present in `settings`.
+		Change the default `fork` behavior. After calling, values are present in `settings`.
+
+		Only affects future `fork` calls; already-running workers are unchanged.
+		The only worker attribute that cannot be set here is the `env` passed to `fork`.
+
+		Can only be called from the primary process.
 	**/
 	function setupPrimary(?settings:ClusterSettings):Void;
 
 	/**
-		Spawn a new worker process. This can only be called from the primary process.
+		Spawn a new worker process.
+
+		Can only be called from the primary process.
 	**/
 	function fork(?env:DynamicAccess<String>):Worker;
 
 	/**
 		Calls `disconnect` on each worker in `workers`.
+
+		When they are disconnected, internal handles close so the primary can exit
+		gracefully if nothing else is waiting.
+
+		Can only be called from the primary process.
 	**/
-	function disconnect(?callback:Void->Void):Void;
+	function disconnect(?callback:() -> Void):Void;
 
 	/**
-		A reference to the current worker object. Not available in the primary process.
+		Reference to the current worker object.
+
+		Not available in the primary process.
 	**/
 	var worker(default, null):Worker;
 
 	/**
-		A hash that stores the active worker objects, keyed by `id` field.
-		It is only available in the primary process.
+		Active worker objects keyed by `id`.
+
+		Only available in the primary process.
+		A worker is removed after it has disconnected and exited.
 	**/
 	var workers(default, null):DynamicAccess<Worker>;
 }
 
+/**
+	Options for `setupPrimary` / reflected in `Cluster.settings`.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/cluster.html#clustersettings
+**/
 typedef ClusterSettings = {
 	/**
-		list of string arguments passed to the node executable.
-		Default: process.execArgv
+		Arguments passed to the Node.js executable.
+		Default: `process.execArgv`
 	**/
 	@:optional var execArgv:Array<String>;
 
 	/**
-		file path to worker file.
-		Default: process.argv[1]
+		File path to the worker file.
+		Default: `process.argv[1]`
 	**/
 	@:optional var exec:String;
 
 	/**
-		string arguments passed to worker.
-		Default: process.argv.slice(2)
+		Arguments passed to the worker.
+		Default: `process.argv.slice(2)`
 	**/
 	@:optional var args:Array<String>;
 
 	/**
 		Current working directory of the worker process.
-		Default: `undefined` (inherits from parent process).
+		Default: `undefined` (inherits from parent).
 	**/
 	@:optional var cwd:String;
 
 	/**
-		Specify the kind of serialization used for sending messages between processes.
+		Serialization used for IPC messages (`json` or `advanced`).
 	**/
 	@:optional var serialization:ChildProcessSerialization;
 
 	/**
-		whether or not to send output to parent's stdio.
-		Default: false
+		Whether to send worker output to the parent's stdio.
+		Default: `false`
 	**/
 	@:optional var silent:Bool;
 
 	/**
-		Configures the stdio of forked processes.
+		Stdio configuration for forked processes.
+
 		Must contain an `'ipc'` entry. When provided, overrides `silent`.
 	**/
 	@:optional var stdio:ChildProcessSpawnOptionsStdio;
 
 	/**
-		Sets the user identity of the process.
+		User identity of the process (`setuid(2)`).
 	**/
 	@:optional var uid:Int;
 
 	/**
-		Sets the group identity of the process.
+		Group identity of the process (`setgid(2)`).
 	**/
 	@:optional var gid:Int;
 
 	/**
-		Sets inspector port of worker. Can be a number, or a function that returns a number.
+		Inspector port of the worker.
+
+		A number, or a zero-argument function that returns a number.
+		Default: each worker gets its own port, incremented from the primary's `process.debugPort`.
 	**/
-	// TODO(section-5): model inspectPort callback `() -> Int` without losing Int assignability
-	@:optional var inspectPort:haxe.extern.EitherType<Int, Void->Int>;
+	@:optional var inspectPort:EitherType<Int, () -> Int>;
 
 	/**
-		Hide the forked processes console window that would normally be created on Windows.
-		Default: `false`.
+		Hide the forked process console window on Windows.
+		Default: `false`
 	**/
 	@:optional var windowsHide:Bool;
 }

--- a/src/js/node/Cluster.hx
+++ b/src/js/node/Cluster.hx
@@ -67,9 +67,12 @@ enum abstract ClusterEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 	/**
 		Emitted when any worker dies.
 
+		`code` is the exit code if it exited normally; `signal` is the signal name
+		if it was killed (the other is then `null`).
+
 		Can be used to restart the worker by calling `fork` again.
 	**/
-	var Exit:ClusterEvent<(worker:Worker, code:Int, signal:String) -> Void> = "exit";
+	var Exit:ClusterEvent<(worker:Worker, code:Null<Int>, signal:Null<String>) -> Void> = "exit";
 
 	/**
 		Emitted every time `setupPrimary` is called.

--- a/src/js/node/cluster/Worker.hx
+++ b/src/js/node/cluster/Worker.hx
@@ -61,8 +61,11 @@ enum abstract WorkerEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 
 	/**
 		Similar to the cluster `'exit'` event, but specific to this worker.
+
+		`code` is the exit code if it exited normally; `signal` is the signal name
+		if it was killed (the other is then `null`).
 	**/
-	var Exit:WorkerEvent<(code:Int, signal:String) -> Void> = "exit";
+	var Exit:WorkerEvent<(code:Null<Int>, signal:Null<String>) -> Void> = "exit";
 
 	/**
 		Same as the `'error'` event from `ChildProcess.fork`.
@@ -122,9 +125,9 @@ extern class Worker extends EventEmitter<Worker> {
 		In the primary this targets a specific worker (same as `ChildProcess.send`).
 		In a worker this sends to the primary (same as `process.send`).
 	**/
-	@:overload(function(message:Dynamic, sendHandle:ChildProcessSendHandle, options:ChildProcessSendOptions, ?callback:Null<Error>->Void):Bool {})
-	@:overload(function(message:Dynamic, sendHandle:ChildProcessSendHandle, ?callback:Null<Error>->Void):Bool {})
-	function send(message:Dynamic, ?callback:Null<Error>->Void):Bool;
+	@:overload(function(message:Dynamic, sendHandle:ChildProcessSendHandle, options:ChildProcessSendOptions, ?callback:(error:Null<Error>) -> Void):Bool {})
+	@:overload(function(message:Dynamic, sendHandle:ChildProcessSendHandle, ?callback:(error:Null<Error>) -> Void):Bool {})
+	function send(message:Dynamic, ?callback:(error:Null<Error>) -> Void):Bool;
 
 	/**
 		Kill the worker.

--- a/src/js/node/cluster/Worker.hx
+++ b/src/js/node/cluster/Worker.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,86 +25,142 @@ package js.node.cluster;
 import js.lib.Error;
 import js.node.Cluster.ListeningEventAddress;
 import js.node.child_process.ChildProcess;
+import js.node.child_process.ChildProcess.ChildProcessSendHandle;
+import js.node.child_process.ChildProcess.ChildProcessSendOptions;
 import js.node.events.EventEmitter;
 
 /**
+	Events emitted by a `Worker`.
+
 	@see https://nodejs.org/docs/latest-v24.x/api/cluster.html#class-worker
 **/
 enum abstract WorkerEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
-	// TODO(section-5): tighten message/handle typing beyond Dynamic
-	var Message:WorkerEvent<Dynamic->Dynamic->Void> = "message";
-	var Online:WorkerEvent<Void->Void> = "online";
-	var Listening:WorkerEvent<ListeningEventAddress->Void> = "listening";
-	var Disconnect:WorkerEvent<Void->Void> = "disconnect";
-	var Exit:WorkerEvent<Int->String->Void> = "exit";
-	var Error:WorkerEvent<Error->Void> = "error";
+	/**
+		Similar to the cluster `'message'` event, but specific to this worker.
+
+		Within a worker, `process.on('message')` may also be used.
+	**/
+	var Message:WorkerEvent<(message:Dynamic, handle:Null<ChildProcessSendHandle>) -> Void> = "message";
+
+	/**
+		Similar to the cluster `'online'` event, but specific to this worker.
+		Not emitted in the worker itself.
+	**/
+	var Online:WorkerEvent<() -> Void> = "online";
+
+	/**
+		Similar to the cluster `'listening'` event, but specific to this worker.
+		Not emitted in the worker itself.
+	**/
+	var Listening:WorkerEvent<(address:ListeningEventAddress) -> Void> = "listening";
+
+	/**
+		Similar to the cluster `'disconnect'` event, but specific to this worker.
+	**/
+	var Disconnect:WorkerEvent<() -> Void> = "disconnect";
+
+	/**
+		Similar to the cluster `'exit'` event, but specific to this worker.
+	**/
+	var Exit:WorkerEvent<(code:Int, signal:String) -> Void> = "exit";
+
+	/**
+		Same as the `'error'` event from `ChildProcess.fork`.
+
+		Within a worker, `process.on('error')` may also be used.
+	**/
+	var Error:WorkerEvent<(error:Error) -> Void> = "error";
 }
 
 /**
-	A Worker object contains all public information and method about a worker.
+	A `Worker` object contains all public information and methods about a worker.
+
 	In the primary it can be obtained using `Cluster.workers`.
 	In a worker it can be obtained using `Cluster.worker`.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/cluster.html#class-worker
 **/
+@:jsRequire("cluster", "Worker")
 extern class Worker extends EventEmitter<Worker> {
 	/**
-		Each new worker is given its own unique id, this id is stored in the `id`.
+		Unique id for this worker.
 
-		While a worker is alive, this is the key that indexes it in `Cluster.workers`
+		While the worker is alive, this is the key that indexes it in `Cluster.workers`.
 	**/
 	var id(default, null):Int;
 
 	/**
-		All workers are created using `ChildProcess.fork`, the returned object from this function is stored as `process`.
-		In a worker, the global process is stored.
+		Underlying process from `ChildProcess.fork`.
+
+		In a worker, the global `process` is stored here.
+
+		Workers call `process.exit(0)` if `'disconnect'` occurs on `process`
+		and `exitedAfterDisconnect` is not `true`.
 	**/
 	var process:ChildProcess;
 
 	/**
 		Deprecated alias for `exitedAfterDisconnect`.
+
+		Removed from modern Node.js docs; retained for older runtimes and existing Haxe code.
 	**/
 	@:deprecated("Use exitedAfterDisconnect instead")
 	var suicide:Null<Bool>;
 
 	/**
-		Set by calling `kill` or `disconnect`. Until then, it is `undefined`.
+		`true` if the worker exited due to `disconnect`.
+		`false` if it exited any other way.
+		`undefined` if it has not exited.
 
-		Lets you distinguish between voluntary and accidental exit, the primary may choose
-		not to respawn a worker based on this value.
+		Lets the primary distinguish voluntary vs accidental exit when deciding whether to respawn.
 	**/
 	var exitedAfterDisconnect:Null<Bool>;
 
 	/**
-		This function is equal to the `send` methods provided by `ChildProcess.fork`.
-		In the primary you should use this function to send a `message` to a specific worker.
+		Send a message to a worker or primary, optionally with a handle.
 
-		// TODO(section-5): replace Dynamic message/sendHandle with structured IPC types
+		In the primary this targets a specific worker (same as `ChildProcess.send`).
+		In a worker this sends to the primary (same as `process.send`).
 	**/
-	@:overload(function(message:Dynamic, sendHandle:Dynamic, ?callback:Null<Error>->Void):Bool {})
+	@:overload(function(message:Dynamic, sendHandle:ChildProcessSendHandle, options:ChildProcessSendOptions, ?callback:Null<Error>->Void):Bool {})
+	@:overload(function(message:Dynamic, sendHandle:ChildProcessSendHandle, ?callback:Null<Error>->Void):Bool {})
 	function send(message:Dynamic, ?callback:Null<Error>->Void):Bool;
 
 	/**
-		This function will kill the worker. In the primary, it does this by disconnecting the `worker.process`,
-		and once disconnected, killing with `signal`. In the worker, it does it by disconnecting the channel,
-		and then exiting with code 0.
+		Kill the worker.
+
+		In the primary: disconnects `worker.process`, then kills with `signal`.
+		In the worker: kills the process with `signal`.
+
+		Does not wait for a graceful disconnect (same behavior as `worker.process.kill()`).
+		Default signal: `'SIGTERM'`.
 	**/
 	function kill(?signal:String):Void;
 
 	/**
-		In a worker, this function will close all servers, wait for the 'close' event on those servers,
-		and then disconnect the IPC channel.
+		Alias for `kill` (backwards compatibility).
+	**/
+	function destroy(?signal:String):Void;
 
-		Returns a reference to `worker`.
+	/**
+		In a worker: close all servers, wait for `'close'`, then disconnect the IPC channel.
+
+		In the primary: sends an internal message causing the worker to call `disconnect` on itself.
+
+		Sets `exitedAfterDisconnect`.
+		Returns a reference to this worker.
 	**/
 	function disconnect():Worker;
 
 	/**
-		This function returns true if the worker is connected to its primary via its IPC channel, false otherwise.
+		`true` if connected to the primary via IPC, `false` otherwise.
+
+		Connected after creation; disconnected after the `'disconnect'` event.
 	**/
 	function isConnected():Bool;
 
 	/**
-		This function returns true if the worker's process has terminated (either because of exiting or being signaled).
-		Otherwise, it returns false.
+		`true` if the worker's process has terminated (exit or signal), else `false`.
 	**/
 	function isDead():Bool;
 }


### PR DESCRIPTION
## Summary
- Align `cluster` / `Worker` IPC `send` / `'message'` typing with `ChildProcessSendHandle` / `ChildProcessSendOptions`
- Add missing `worker.destroy` alias; modernize event listener signatures to named-arg arrow types; refresh docs and copyright to 2014–2026

## Test plan
- [x] `haxe completion.hxml` (full `js` include) succeeds with only unrelated deprecation warnings
- [ ] Spot-check `ClusterExample` still typechecks against `isMaster` / event args
- [ ] Confirm `Worker.send` overloads match Node 24 docs (message / sendHandle / options / callback)


Made with [Cursor](https://cursor.com)