### PR TITLE
Audit assert externs for Node.js 24 and Haxe 4

### DIFF
--- a/src/js/node/Assert.hx
+++ b/src/js/node/Assert.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -29,25 +29,29 @@ import js.lib.RegExp;
 import js.node.assert.AssertMethods;
 
 /**
-	The `assert module` provides a set of assertion functions for verifying invariants.
-	The module provides a recommended [strict mode](https://nodejs.org/api/assert.html#assert_strict_mode) and a more lenient legacy mode.
+	The `assert` module provides a set of assertion functions for verifying invariants.
+	The module provides a recommended [strict mode](https://nodejs.org/docs/latest-v24.x/api/assert.html#strict-assertion-mode)
+	and a more lenient legacy mode.
 
-	@see https://nodejs.org/api/assert.html#assert_assert
+	For independent assertion instances with custom options (`diff`, `strict`,
+	`skipPrototype`), see `js.node.assert.Assert`.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/assert.html
 **/
 @:jsRequire("assert")
 extern class Assert {
 	/**
-		In strict mode, assert functions use the comparison in the corresponding strict functions.
-		For example, `Assert.deepEqual()` will behave like `Assert.deepStrictEqual()`.
+		In strict assertion mode, non-strict methods behave like their corresponding
+		strict methods. For example, `Assert.deepEqual()` behaves like `Assert.deepStrictEqual()`.
 
-		@see https://nodejs.org/api/assert.html#assert_strict_mode
+		@see https://nodejs.org/docs/latest-v24.x/api/assert.html#strict-assertion-mode
 	**/
-	static var strict(default, never):AssertMethods;
+	static final strict:AssertMethods;
 
 	/**
 		An alias of `Assert.ok()`.
 
-		@see https://nodejs.org/api/assert.html#assert_assert_value_message
+		@see https://nodejs.org/docs/latest-v24.x/api/assert.html#assertvalue-message
 	**/
 	@:selfCall
 	@:overload(function(value:Any, ?message:Error):Void {})
@@ -56,7 +60,7 @@ extern class Assert {
 	/**
 		An alias of `Assert.deepStrictEqual()`.
 
-		@see https://nodejs.org/api/assert.html#assert_assert_deepequal_actual_expected_message
+		@see https://nodejs.org/docs/latest-v24.x/api/assert.html#assertdeepequalactual-expected-message
 	**/
 	@:deprecated("Use deepStrictEqual instead")
 	@:overload(function<T>(actual:T, expected:T, ?message:Error):Void {})
@@ -67,7 +71,7 @@ extern class Assert {
 		"Deep" equality means that the enumerable "own" properties of child objects
 		are recursively evaluated also by the following rules.
 
-		@see https://nodejs.org/api/assert.html#assert_assert_deepstrictequal_actual_expected_message
+		@see https://nodejs.org/docs/latest-v24.x/api/assert.html#assertdeepstrictequalactual-expected-message
 	**/
 	@:overload(function<T>(actual:T, expected:T, ?message:Error):Void {})
 	static function deepStrictEqual<T>(actual:T, expected:T, ?message:String):Void;
@@ -75,7 +79,7 @@ extern class Assert {
 	/**
 		Expects the `string` input not to match the regular expression.
 
-		@see https://nodejs.org/api/assert.html#assert_assert_doesnotmatch_string_regexp_message
+		@see https://nodejs.org/docs/latest-v24.x/api/assert.html#assertdoesnotmatchstring-regexp-message
 	**/
 	@:overload(function(string:String, regexp:RegExp, ?message:Error):Void {})
 	static function doesNotMatch(string:String, regexp:RegExp, ?message:String):Void;
@@ -85,14 +89,14 @@ extern class Assert {
 		immediately calls the function and awaits the returned promise to complete.
 		It will then check that the promise is not rejected.
 
-		@see https://nodejs.org/api/assert.html#assert_assert_doesnotreject_asyncfn_error_message
+		@see https://nodejs.org/docs/latest-v24.x/api/assert.html#assertdoesnotrejectasyncfn-error-message
 	**/
-	@:overload(function(asyncFn:Void->Promise<Any>, ?error:Class<Any>, ?message:String):Void {})
-	@:overload(function(asyncFn:Void->Promise<Any>, ?error:RegExp, ?message:String):Void {})
-	@:overload(function(asyncFn:Void->Promise<Any>, ?error:Any->Bool, ?message:String):Void {})
-	@:overload(function(asyncFn:Promise<Any>, ?error:Class<Any>, ?message:String):Void {})
-	@:overload(function(asyncFn:Promise<Any>, ?error:RegExp, ?message:String):Void {})
-	static function doesNotReject(asyncFn:Promise<Any>, ?error:Any->Bool, ?message:String):Void;
+	@:overload(function(asyncFn:() -> Promise<Any>, ?error:Class<Any>, ?message:String):Promise<Void> {})
+	@:overload(function(asyncFn:() -> Promise<Any>, ?error:RegExp, ?message:String):Promise<Void> {})
+	@:overload(function(asyncFn:() -> Promise<Any>, ?error:(error:Any) -> Bool, ?message:String):Promise<Void> {})
+	@:overload(function(asyncFn:Promise<Any>, ?error:Class<Any>, ?message:String):Promise<Void> {})
+	@:overload(function(asyncFn:Promise<Any>, ?error:RegExp, ?message:String):Promise<Void> {})
+	static function doesNotReject(asyncFn:Promise<Any>, ?error:(error:Any) -> Bool, ?message:String):Promise<Void>;
 
 	/**
 		Asserts that the function `fn` does not throw an error.
@@ -102,17 +106,18 @@ extern class Assert {
 		Instead, consider adding a comment next to the specific code path that should not throw
 		and keep error messages as expressive as possible.
 
-		@see https://nodejs.org/api/assert.html#assert_assert_doesnotthrow_fn_error_message
+		@see https://nodejs.org/docs/latest-v24.x/api/assert.html#assertdoesnotthrowfn-error-message
 	**/
-	@:overload(function(fn:Void->Void, ?error:Class<Any>, ?message:String):Void {})
-	@:overload(function(fn:Void->Void, ?error:RegExp, ?message:String):Void {})
-	static function doesNotThrow(fn:Void->Void, ?error:Any->Bool, ?message:String):Void;
+	@:overload(function(fn:() -> Void, ?error:Class<Any>, ?message:String):Void {})
+	@:overload(function(fn:() -> Void, ?error:RegExp, ?message:String):Void {})
+	static function doesNotThrow(fn:() -> Void, ?error:(error:Any) -> Bool, ?message:String):Void;
 
 	/**
 		An alias of `strictEqual`.
 
-		@see https://nodejs.org/api/assert.html#assert_assert_equal_actual_expected_message
+		@see https://nodejs.org/docs/latest-v24.x/api/assert.html#assertequalactual-expected-message
 	**/
+	@:deprecated("Use strictEqual instead")
 	@:overload(function<T>(actual:T, expected:T, ?message:String):Void {})
 	static function equal<T>(actual:T, expected:T, ?message:Error):Void;
 
@@ -120,7 +125,7 @@ extern class Assert {
 		Throws an `AssertionError` with the provided error message or a default error message.
 		If the `message` parameter is an instance of an `Error` then it will be thrown instead of the `AssertionError`.
 
-		@see https://nodejs.org/api/assert.html#assert_assert_fail_message
+		@see https://nodejs.org/docs/latest-v24.x/api/assert.html#assertfailmessage
 	**/
 	@:overload(function(?message:String):Void {})
 	static function fail(?message:Error):Void;
@@ -130,7 +135,7 @@ extern class Assert {
 		of `actual` and `expected` separated by the provided `operator`.
 		Otherwise, the error message is the value of `message`.
 
-		@see https://nodejs.org/api/assert.html#assert_assert_fail_actual_expected_message_operator_stackstartfn
+		@see https://nodejs.org/docs/latest-v24.x/api/assert.html#assertfailactual-expected-message-operator-stackstartfn
 	**/
 	@:deprecated("Use fail with a message or Error instead")
 	@:native("fail")
@@ -142,14 +147,14 @@ extern class Assert {
 		This is useful when testing the `error` argument in callbacks.
 		The stack trace contains all frames from the error passed to `ifError()` including the potential new frames for `ifError()` itself.
 
-		@see https://nodejs.org/api/assert.html#assert_assert_iferror_value
+		@see https://nodejs.org/docs/latest-v24.x/api/assert.html#assertiferrorvalue
 	**/
 	static function ifError(value:Any):Void;
 
 	/**
 		Expects the `string` input to match the regular expression.
 
-		@see https://nodejs.org/api/assert.html#assert_assert_match_string_regexp_message
+		@see https://nodejs.org/docs/latest-v24.x/api/assert.html#assertmatchstring-regexp-message
 	**/
 	@:overload(function(string:String, regexp:RegExp, ?message:Error):Void {})
 	static function match(string:String, regexp:RegExp, ?message:String):Void;
@@ -157,7 +162,7 @@ extern class Assert {
 	/**
 		An alias of `Assert.notDeepStrictEqual()`.
 
-		@see https://nodejs.org/api/assert.html#assert_assert_notdeepequal_actual_expected_message
+		@see https://nodejs.org/docs/latest-v24.x/api/assert.html#assertnotdeepequalactual-expected-message
 	**/
 	@:deprecated("Use notDeepStrictEqual instead")
 	@:overload(function<T>(actual:T, expected:T, ?message:Error):Void {})
@@ -166,7 +171,7 @@ extern class Assert {
 	/**
 		Tests for deep strict inequality. Opposite of `Assert.deepStrictEqual()`.
 
-		@see https://nodejs.org/api/assert.html#assert_assert_notdeepstrictequal_actual_expected_message
+		@see https://nodejs.org/docs/latest-v24.x/api/assert.html#assertnotdeepstrictequalactual-expected-message
 	**/
 	@:overload(function<T>(actual:T, expected:T, ?message:Error):Void {})
 	static function notDeepStrictEqual<T>(actual:T, expected:T, ?message:String):Void;
@@ -174,7 +179,7 @@ extern class Assert {
 	/**
 		An alias of `Assert.notStrictEqual()`.
 
-		@see https://nodejs.org/api/assert.html#assert_assert_notequal_actual_expected_message
+		@see https://nodejs.org/docs/latest-v24.x/api/assert.html#assertnotequalactual-expected-message
 	**/
 	@:deprecated("Use notStrictEqual instead")
 	@:overload(function<T>(actual:T, expected:T, ?message:Error):Void {})
@@ -183,7 +188,7 @@ extern class Assert {
 	/**
 		Tests strict inequality between the `actual` and `expected` parameters as determined by the SameValue Comparison.
 
-		@see https://nodejs.org/api/assert.html#assert_assert_notstrictequal_actual_expected_message
+		@see https://nodejs.org/docs/latest-v24.x/api/assert.html#assertnotstrictequalactual-expected-message
 	**/
 	@:overload(function<T>(actual:T, expected:T, ?message:Error):Void {})
 	static function notStrictEqual<T>(actual:T, expected:T, ?message:String):Void;
@@ -192,7 +197,7 @@ extern class Assert {
 		Tests if `value` is truthy.
 		It is equivalent to `Assert.equal(!!value, true, message)`.
 
-		@see https://nodejs.org/api/assert.html#assert_assert_ok_value_message
+		@see https://nodejs.org/docs/latest-v24.x/api/assert.html#assertokvalue-message
 	**/
 	@:overload(function(value:Any, ?message:Error):Void {})
 	static function ok(value:Any, ?message:String):Void;
@@ -202,7 +207,7 @@ extern class Assert {
 		"Partial" equality means that only properties that exist on the `expected`
 		parameter are compared.
 
-		@see https://nodejs.org/api/assert.html#assert_assert_partialdeepstrictequal_actual_expected_message
+		@see https://nodejs.org/docs/latest-v24.x/api/assert.html#assertpartialdeepstrictequalactual-expected-message
 	**/
 	@:overload(function<T>(actual:T, expected:T, ?message:Error):Void {})
 	static function partialDeepStrictEqual<T>(actual:T, expected:T, ?message:String):Void;
@@ -212,24 +217,24 @@ extern class Assert {
 		immediately calls the function and awaits the returned promise to complete.
 		It will then check that the promise is rejected.
 
-		@see https://nodejs.org/api/assert.html#assert_assert_rejects_asyncfn_error_message
+		@see https://nodejs.org/docs/latest-v24.x/api/assert.html#assertrejectsasyncfn-error-message
 	**/
-	@:overload(function(asyncFn:Void->Promise<Any>, ?error:Class<Any>, ?message:String):Void {})
-	@:overload(function(asyncFn:Void->Promise<Any>, ?error:RegExp, ?message:String):Void {})
-	@:overload(function(asyncFn:Void->Promise<Any>, ?error:Any->Bool, ?message:String):Void {})
-	@:overload(function(asyncFn:Void->Promise<Any>, ?error:Any, ?message:String):Void {})
-	@:overload(function(asyncFn:Void->Promise<Any>, ?error:Error, ?message:String):Void {})
-	@:overload(function(asyncFn:Promise<Any>, ?error:Class<Any>, ?message:String):Void {})
-	@:overload(function(asyncFn:Promise<Any>, ?error:RegExp, ?message:String):Void {})
-	@:overload(function(asyncFn:Promise<Any>, ?error:Any->Bool, ?message:String):Void {})
-	@:overload(function(asyncFn:Promise<Any>, ?error:Any, ?message:String):Void {})
-	static function rejects(asyncFn:Promise<Any>, ?error:Error, ?message:String):Void;
+	@:overload(function(asyncFn:() -> Promise<Any>, ?error:Class<Any>, ?message:String):Promise<Void> {})
+	@:overload(function(asyncFn:() -> Promise<Any>, ?error:RegExp, ?message:String):Promise<Void> {})
+	@:overload(function(asyncFn:() -> Promise<Any>, ?error:(error:Any) -> Bool, ?message:String):Promise<Void> {})
+	@:overload(function(asyncFn:() -> Promise<Any>, ?error:Any, ?message:String):Promise<Void> {})
+	@:overload(function(asyncFn:() -> Promise<Any>, ?error:Error, ?message:String):Promise<Void> {})
+	@:overload(function(asyncFn:Promise<Any>, ?error:Class<Any>, ?message:String):Promise<Void> {})
+	@:overload(function(asyncFn:Promise<Any>, ?error:RegExp, ?message:String):Promise<Void> {})
+	@:overload(function(asyncFn:Promise<Any>, ?error:(error:Any) -> Bool, ?message:String):Promise<Void> {})
+	@:overload(function(asyncFn:Promise<Any>, ?error:Any, ?message:String):Promise<Void> {})
+	static function rejects(asyncFn:Promise<Any>, ?error:Error, ?message:String):Promise<Void>;
 
 	/**
 		Tests strict equality between the `actual` and `expected` parameter as
 		determined by the SameValue Comparison.
 
-		@see https://nodejs.org/api/assert.html#assert_assert_strictequal_actual_expected_message
+		@see https://nodejs.org/docs/latest-v24.x/api/assert.html#assertstrictequalactual-expected-message
 	**/
 	@:overload(function<T>(actual:T, expected:T, ?message:Error):Void {})
 	static function strictEqual<T>(actual:T, expected:T, ?message:String):Void;
@@ -237,10 +242,11 @@ extern class Assert {
 	/**
 		Expects the function `fn` to throw an error.
 
-		@see https://nodejs.org/api/assert.html#assert_assert_throws_fn_error_message
+		@see https://nodejs.org/docs/latest-v24.x/api/assert.html#assertthrowsfn-error-message
 	**/
-	@:overload(function(fn:Void->Void, ?error:RegExp, ?message:String):Void {})
-	@:overload(function(fn:Void->Void, ?error:Any->Bool, ?message:String):Void {})
-	@:overload(function(fn:Void->Void, ?error:Any, ?message:String):Void {})
-	static function throws(fn:Void->Void, ?error:Error, ?message:String):Void;
+	@:overload(function(fn:() -> Void, ?error:Class<Any>, ?message:String):Void {})
+	@:overload(function(fn:() -> Void, ?error:RegExp, ?message:String):Void {})
+	@:overload(function(fn:() -> Void, ?error:(error:Any) -> Bool, ?message:String):Void {})
+	@:overload(function(fn:() -> Void, ?error:Any, ?message:String):Void {})
+	static function throws(fn:() -> Void, ?error:Error, ?message:String):Void;
 }

--- a/src/js/node/assert/Assert.hx
+++ b/src/js/node/assert/Assert.hx
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C)2014-2026 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.assert;
+
+/**
+	Independent assertion instance with custom options (`diff`, `strict`, `skipPrototype`).
+
+	When methods are destructured from an instance they lose that configuration and fall
+	back to default assert behavior.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/assert.html#class-assertassert
+**/
+@:jsRequire("assert", "Assert")
+extern class Assert extends AssertMethods {
+	/**
+		Creates a new assertion instance.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/assert.html#new-assertassertoptions
+	**/
+	function new(?options:AssertOptions);
+}

--- a/src/js/node/assert/AssertDiff.hx
+++ b/src/js/node/assert/AssertDiff.hx
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C)2014-2026 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.assert;
+
+/**
+	Diff verbosity for assertion error messages (`simple` or `full`).
+
+	@see https://nodejs.org/docs/latest-v24.x/api/assert.html#new-assertassertoptions
+**/
+enum abstract AssertDiff(String) from String to String {
+	var Simple = "simple";
+	var Full = "full";
+}

--- a/src/js/node/assert/AssertMethods.hx
+++ b/src/js/node/assert/AssertMethods.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -29,10 +29,11 @@ import js.lib.RegExp;
 /**
 	Instance-oriented surface matching `js.node.Assert` method signatures.
 
-	Used for bound assert objects such as `TestContext.assert` and `Assert.strict`.
+	Used for bound assert objects such as `TestContext.assert` and `Assert.strict`,
+	and as the base of constructible `js.node.assert.Assert` instances.
 	Keep in sync with the static methods on `js.node.Assert`.
 
-	@see https://nodejs.org/api/assert.html
+	@see https://nodejs.org/docs/latest-v24.x/api/assert.html
 **/
 extern class AssertMethods {
 	/**
@@ -57,23 +58,24 @@ extern class AssertMethods {
 	/**
 		Awaits `asyncFn` and checks that the promise is not rejected.
 	**/
-	@:overload(function(asyncFn:Void->Promise<Any>, ?error:Class<Any>, ?message:String):Void {})
-	@:overload(function(asyncFn:Void->Promise<Any>, ?error:RegExp, ?message:String):Void {})
-	@:overload(function(asyncFn:Void->Promise<Any>, ?error:Any->Bool, ?message:String):Void {})
-	@:overload(function(asyncFn:Promise<Any>, ?error:Class<Any>, ?message:String):Void {})
-	@:overload(function(asyncFn:Promise<Any>, ?error:RegExp, ?message:String):Void {})
-	function doesNotReject(asyncFn:Promise<Any>, ?error:Any->Bool, ?message:String):Void;
+	@:overload(function(asyncFn:() -> Promise<Any>, ?error:Class<Any>, ?message:String):Promise<Void> {})
+	@:overload(function(asyncFn:() -> Promise<Any>, ?error:RegExp, ?message:String):Promise<Void> {})
+	@:overload(function(asyncFn:() -> Promise<Any>, ?error:(error:Any) -> Bool, ?message:String):Promise<Void> {})
+	@:overload(function(asyncFn:Promise<Any>, ?error:Class<Any>, ?message:String):Promise<Void> {})
+	@:overload(function(asyncFn:Promise<Any>, ?error:RegExp, ?message:String):Promise<Void> {})
+	function doesNotReject(asyncFn:Promise<Any>, ?error:(error:Any) -> Bool, ?message:String):Promise<Void>;
 
 	/**
 		Asserts that `fn` does not throw.
 	**/
-	@:overload(function(fn:Void->Void, ?error:Class<Any>, ?message:String):Void {})
-	@:overload(function(fn:Void->Void, ?error:RegExp, ?message:String):Void {})
-	function doesNotThrow(fn:Void->Void, ?error:Any->Bool, ?message:String):Void;
+	@:overload(function(fn:() -> Void, ?error:Class<Any>, ?message:String):Void {})
+	@:overload(function(fn:() -> Void, ?error:RegExp, ?message:String):Void {})
+	function doesNotThrow(fn:() -> Void, ?error:(error:Any) -> Bool, ?message:String):Void;
 
 	/**
 		An alias of `strictEqual`.
 	**/
+	@:deprecated("Use strictEqual instead")
 	@:overload(function<T>(actual:T, expected:T, ?message:String):Void {})
 	function equal<T>(actual:T, expected:T, ?message:Error):Void;
 
@@ -135,16 +137,16 @@ extern class AssertMethods {
 	/**
 		Awaits `asyncFn` and checks that the promise is rejected.
 	**/
-	@:overload(function(asyncFn:Void->Promise<Any>, ?error:Class<Any>, ?message:String):Void {})
-	@:overload(function(asyncFn:Void->Promise<Any>, ?error:RegExp, ?message:String):Void {})
-	@:overload(function(asyncFn:Void->Promise<Any>, ?error:Any->Bool, ?message:String):Void {})
-	@:overload(function(asyncFn:Void->Promise<Any>, ?error:Any, ?message:String):Void {})
-	@:overload(function(asyncFn:Void->Promise<Any>, ?error:Error, ?message:String):Void {})
-	@:overload(function(asyncFn:Promise<Any>, ?error:Class<Any>, ?message:String):Void {})
-	@:overload(function(asyncFn:Promise<Any>, ?error:RegExp, ?message:String):Void {})
-	@:overload(function(asyncFn:Promise<Any>, ?error:Any->Bool, ?message:String):Void {})
-	@:overload(function(asyncFn:Promise<Any>, ?error:Any, ?message:String):Void {})
-	function rejects(asyncFn:Promise<Any>, ?error:Error, ?message:String):Void;
+	@:overload(function(asyncFn:() -> Promise<Any>, ?error:Class<Any>, ?message:String):Promise<Void> {})
+	@:overload(function(asyncFn:() -> Promise<Any>, ?error:RegExp, ?message:String):Promise<Void> {})
+	@:overload(function(asyncFn:() -> Promise<Any>, ?error:(error:Any) -> Bool, ?message:String):Promise<Void> {})
+	@:overload(function(asyncFn:() -> Promise<Any>, ?error:Any, ?message:String):Promise<Void> {})
+	@:overload(function(asyncFn:() -> Promise<Any>, ?error:Error, ?message:String):Promise<Void> {})
+	@:overload(function(asyncFn:Promise<Any>, ?error:Class<Any>, ?message:String):Promise<Void> {})
+	@:overload(function(asyncFn:Promise<Any>, ?error:RegExp, ?message:String):Promise<Void> {})
+	@:overload(function(asyncFn:Promise<Any>, ?error:(error:Any) -> Bool, ?message:String):Promise<Void> {})
+	@:overload(function(asyncFn:Promise<Any>, ?error:Any, ?message:String):Promise<Void> {})
+	function rejects(asyncFn:Promise<Any>, ?error:Error, ?message:String):Promise<Void>;
 
 	/**
 		Tests strict equality between `actual` and `expected`.
@@ -155,8 +157,9 @@ extern class AssertMethods {
 	/**
 		Expects `fn` to throw an error.
 	**/
-	@:overload(function(fn:Void->Void, ?error:RegExp, ?message:String):Void {})
-	@:overload(function(fn:Void->Void, ?error:Any->Bool, ?message:String):Void {})
-	@:overload(function(fn:Void->Void, ?error:Any, ?message:String):Void {})
-	function throws(fn:Void->Void, ?error:Error, ?message:String):Void;
+	@:overload(function(fn:() -> Void, ?error:Class<Any>, ?message:String):Void {})
+	@:overload(function(fn:() -> Void, ?error:RegExp, ?message:String):Void {})
+	@:overload(function(fn:() -> Void, ?error:(error:Any) -> Bool, ?message:String):Void {})
+	@:overload(function(fn:() -> Void, ?error:Any, ?message:String):Void {})
+	function throws(fn:() -> Void, ?error:Error, ?message:String):Void;
 }

--- a/src/js/node/assert/AssertOptions.hx
+++ b/src/js/node/assert/AssertOptions.hx
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C)2014-2026 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.assert;
+
+/**
+	Options for `new assert.Assert([options])`.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/assert.html#new-assertassertoptions
+**/
+typedef AssertOptions = {
+	/**
+		If set to `Full`, shows the full diff in assertion errors. Defaults to `Simple`.
+	**/
+	@:optional var diff:AssertDiff;
+
+	/**
+		If `true`, non-strict methods behave like their corresponding strict methods.
+		Defaults to `true`.
+	**/
+	@:optional var strict:Bool;
+
+	/**
+		If `true`, skips prototype and constructor comparison in deep equality checks.
+		Defaults to `false`. Added in Node.js v24.9.0.
+	**/
+	@:optional var skipPrototype:Bool;
+}

--- a/src/js/node/assert/AssertionError.hx
+++ b/src/js/node/assert/AssertionError.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -26,45 +26,46 @@ import haxe.Constraints.Function;
 import js.lib.Error;
 
 /**
-	Indicates the failure of an assertion. All errors thrown by the `Assert` module will be instances of the `AssertionError` class.
+	Indicates the failure of an assertion. All errors thrown by the `assert`
+	module will be instances of the `AssertionError` class.
 
-	@see https://nodejs.org/api/assert.html#assert_class_assert_assertionerror
+	@see https://nodejs.org/docs/latest-v24.x/api/assert.html#class-assertassertionerror
 **/
 @:jsRequire("assert", "AssertionError")
 extern class AssertionError extends Error {
 	/**
-		A subclass of Error that indicates the failure of an assertion.
+		A subclass of `Error` that indicates the failure of an assertion.
 	**/
 	function new(options:AssertionErrorOptions);
 
 	/**
 		Set to the `actual` argument for methods such as `Assert.strictEqual()`.
 	**/
-	var actual:Any;
+	final actual:Any;
 
 	/**
 		Set to the `expected` value for methods such as `Assert.strictEqual()`.
 	**/
-	var expected:Any;
+	final expected:Any;
 
 	/**
 		Indicates if the message was auto-generated (`true`) or not.
 	**/
-	var generatedMessage:Bool;
+	final generatedMessage:Bool;
 
 	/**
 		Value is always `ERR_ASSERTION` to show that the error is an assertion error.
 	**/
-	var code:String;
+	final code:String;
 
 	/**
 		Set to the passed in operator value.
 	**/
-	@:native("operator") var operator_:String;
+	@:native("operator") final operator_:String;
 }
 
 /**
-	An options type for `new` of `AssertionError`.
+	Options for `new AssertionError()`.
 **/
 typedef AssertionErrorOptions = {
 	/**
@@ -90,5 +91,11 @@ typedef AssertionErrorOptions = {
 	/**
 		If provided, the generated stack trace omits frames before this function.
 	**/
-	@:optional var stackStartFunction:Function;
+	@:optional var stackStartFn:Function;
+
+	/**
+		If set to `'full'`, shows the full diff in assertion errors.
+		Defaults to `'simple'`.
+	**/
+	@:optional var diff:AssertDiff;
 }

--- a/src/js/node/assert/CallTracker.hx
+++ b/src/js/node/assert/CallTracker.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -23,14 +23,16 @@
 package js.node.assert;
 
 import haxe.Constraints.Function;
-import js.lib.Error;
 
 /**
-	Deprecated tracking helper for verifying that functions were called the expected number of times.
+	Deprecated tracking helper for verifying that functions were called the
+	expected number of times.
 
-	@see https://nodejs.org/api/assert.html#class-assertcalltracker
+	Stability: 0 - Deprecated since Node.js v20.1.0. Prefer `node:test` mock helpers.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/assert.html#class-assertcalltracker
 **/
-@:deprecated("Use custom call tracking instead")
+@:deprecated("Use node:test mock helpers instead")
 @:jsRequire("assert", "CallTracker")
 extern class CallTracker {
 	function new();
@@ -39,7 +41,7 @@ extern class CallTracker {
 		Returns a wrapper function that tracks calls to `fn`.
 		Must be called exactly `exact` times before `verify()`.
 	**/
-	@:overload(function(?exact:Int):Void->Void {})
+	@:overload(function(?exact:Int):() -> Void {})
 	@:overload(function(fn:Function, ?exact:Int):Function {})
 	function calls(?fn:Function, ?exact:Int):Function;
 


### PR DESCRIPTION
## Summary
- Add `js.node.assert.Assert` (Node.js 24.6+) with `AssertOptions` (`diff`, `strict`, `skipPrototype`) and `AssertDiff`
- Fix `AssertionErrorOptions`: rename `stackStartFunction` → `stackStartFn`, add `diff`; use `final` on error fields
- Align `rejects` / `doesNotReject` return types with Node (`Promise<Void>`); modernize named function types; mark legacy `equal` deprecated; copyright years → 2014-2026

## Test plan
- [x] `haxe build.hxml` (ImportAll + examples)
- [x] Compile `examples/AssertThrows.hx`
- [x] Smoke-compile usage of `js.node.assert.Assert`, `AssertionError` with `stackStartFn`/`diff`, and `Promise`-typed `rejects`
- [ ] Spot-check against https://nodejs.org/docs/latest-v24.x/api/assert.html

Made with [Cursor](https://cursor.com)