### PR TITLE
Audit js.node.module for Node 24 + Haxe 4

### DIFF
--- a/src/js/node/Module.hx
+++ b/src/js/node/Module.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -26,94 +26,140 @@ import haxe.Constraints.Function;
 import haxe.extern.EitherType;
 import js.node.module.SourceMap;
 import js.node.url.URL;
+import js.node.worker_threads.Transferable;
 
 /**
-	In each module, the `module` free variable is a reference to the object representing the current module.
-	For convenience, `module.exports` is also accessible via the `exports` module-global.
-	`module` is not actually a global but rather local to each module.
+	Provides general utility methods when interacting with instances of `Module`
+	(the `module` variable in CommonJS modules), plus helpers such as
+	`createRequire`, compile cache, and customization hooks.
 
-	@see https://nodejs.org/api/modules.html#modules_the_module_object
+	Accessed via `require("node:module")` / `import "node:module"`.
+	In each CommonJS module, the `module` free variable refers to the current
+	module object; `module.exports` is also available as the `exports` binding.
+
+	@see https://nodejs.org/api/module.html
+	@see https://nodejs.org/api/modules.html#the-module-object
 **/
 @:jsRequire("module")
 extern class Module {
 	/**
 		The module objects required for the first time by this one.
 
-		@see https://nodejs.org/api/modules.html#modules_module_children
+		@see https://nodejs.org/api/modules.html#modulechildren
 	**/
 	var children(default, null):Array<Module>;
 
 	/**
 		The `module.exports` object is created by the Module system.
+		Sometimes this is not acceptable; many want their module to return an
+		object other than the export object. Assign the desired value to
+		`module.exports` to replace the object.
+
+		@see https://nodejs.org/api/modules.html#moduleexports
 	**/
 	var exports:Dynamic;
 
 	/**
 		The fully resolved filename of the module.
+
+		@see https://nodejs.org/api/modules.html#modulefilename
 	**/
 	var filename(default, null):String;
 
 	/**
 		The identifier for the module.
 		Typically this is the fully resolved filename.
+
+		@see https://nodejs.org/api/modules.html#moduleid
 	**/
 	var id(default, null):String;
 
 	/**
 		Whether or not the module is done loading, or is in the process of loading.
+
+		@see https://nodejs.org/api/modules.html#moduleloaded
 	**/
 	var loaded(default, null):Bool;
 
 	/**
-		The module that first required this one.
+		The module that first required this one, or `null` / `undefined` if the
+		current module is the entry point of the current process.
+
+		@see https://nodejs.org/api/modules.html#moduleparent
 	**/
-	var parent(default, null):Module;
+	@:deprecated("Use require.main and module.children instead")
+	var parent(default, null):Null<Module>;
 
 	/**
 		The search paths for the module.
+
+		@see https://nodejs.org/api/modules.html#modulepaths
 	**/
 	var paths(default, null):Array<String>;
 
 	/**
-		True if the module is running during the Node.js bootstrap process.
+		`true` if the module is running during the Node.js bootstrap process.
+
+		@see https://nodejs.org/api/modules.html#moduleispreloading
 	**/
 	var isPreloading(default, null):Bool;
 
 	/**
 		The directory name of the module.
+
+		@see https://nodejs.org/api/modules.html#modulepath
 	**/
 	var path(default, null):String;
 
 	/**
-		The `module.require()` method provides a way to load a module as if `require()` was called from the original
-		module.
+		Provides a way to load a module as if `require()` was called from the
+		original module.
+
+		@see https://nodejs.org/api/modules.html#modulerequireid
 	**/
 	function require(id:String):Dynamic;
 
 	/**
 		A list of the names of all modules provided by Node.js.
+		Can be used to verify if a module is maintained by a third party or not.
+
+		@see https://nodejs.org/api/module.html#modulebuiltinmodules
 	**/
 	static var builtinModules(default, null):Array<String>;
 
 	/**
+		Module compile-cache status constants and related values.
+
+		@see https://nodejs.org/api/module.html#moduleconstantscompilecachestatus
+	**/
+	static var constants(default, null):ModuleConstants;
+
+	/**
 		Returns `true` if the module is a core/built-in module.
+
+		@see https://nodejs.org/api/module.html#moduleisbuiltinmodulename
 	**/
 	static function isBuiltin(moduleName:String):Bool;
 
 	/**
-		@see https://nodejs.org/api/modules.html#modules_module_createrequire_filename
+		Creates a `require` function that can be used to import modules as if
+		they were referenced from the given filename.
+
+		@see https://nodejs.org/api/module.html#modulecreaterequirefilename
 	**/
 	@:overload(function(filename:URL):String->Dynamic {})
 	static function createRequire(filename:String):String->Dynamic;
 
 	/**
-		The `module.syncBuiltinESMExports()` method updates all the live bindings for builtin ES Modules to match the
-		properties of the CommonJS exports.
+		Updates all live bindings for builtin ES Modules to match the properties
+		of the CommonJS exports. Does not add or remove exported names.
+
+		@see https://nodejs.org/api/module.html#modulesyncbuiltinesmexports
 	**/
 	static function syncBuiltinESMExports():Void;
 
 	/**
-		`findSourceMap` finds the corresponding source map for a given file path.
+		Finds the corresponding `SourceMap` for a given file path, if present.
 
 		@see https://nodejs.org/api/module.html#modulefindsourcemappath
 	**/
@@ -121,11 +167,15 @@ extern class Module {
 
 	/**
 		Removes TypeScript type annotations from `code`.
+		When `mode` is `"transform"`, also transforms TypeScript features to JavaScript.
+
+		@see https://nodejs.org/api/module.html#modulestriptypescripttypescode-options
 	**/
 	static function stripTypeScriptTypes(code:String, ?options:ModuleStripTypeScriptTypesOptions):String;
 
 	/**
-		Register synchronous customization hooks.
+		Register synchronous customization hooks that run on the thread where
+		modules are loaded.
 
 		Hook callback signatures stay loosely typed (`Function`); full
 		`resolve`/`load` context models can be refined later.
@@ -143,41 +193,142 @@ extern class Module {
 	static function findPackageJSON(specifier:String, ?base:EitherType<String, URL>):Null<String>;
 
 	/**
-		Register a module that exports hooks that customize Node.js module resolution and loading.
+		Register a module that exports asynchronous hooks that customize Node.js
+		module resolution and loading.
 
 		@see https://nodejs.org/api/module.html#moduleregisterspecifier-parenturl-options
 	**/
+	@:deprecated("Use Module.registerHooks instead")
 	@:overload(function(specifier:String, parentURL:EitherType<String, URL>, ?options:ModuleRegisterOptions):Void {})
 	@:overload(function(specifier:URL, parentURL:EitherType<String, URL>, ?options:ModuleRegisterOptions):Void {})
 	@:overload(function(specifier:URL, ?options:ModuleRegisterOptions):Void {})
 	static function register(specifier:String, ?options:ModuleRegisterOptions):Void;
 
 	/**
-		Enable the module compile cache.
+		Enable the module compile cache in the current Node.js instance.
+		If a string is passed, it is treated as `options.directory`.
 
-		@see https://nodejs.org/api/module.html#moduleenablecompilecachecachedir
+		@see https://nodejs.org/api/module.html#moduleenablecompilecacheoptions
 	**/
-	static function enableCompileCache(?cacheDir:String):Dynamic;
+	@:overload(function(?options:ModuleEnableCompileCacheOptions):ModuleEnableCompileCacheResult {})
+	static function enableCompileCache(?cacheDir:String):ModuleEnableCompileCacheResult;
 
 	/**
-		Flush the module compile cache to disk.
+		Flush the module compile cache accumulated from already-loaded modules to disk.
+
+		@see https://nodejs.org/api/module.html#moduleflushcompilecache
 	**/
 	static function flushCompileCache():Void;
 
 	/**
 		Return the directory where the module compile cache is stored, if enabled.
+
+		@see https://nodejs.org/api/module.html#modulegetcompilecachedir
 	**/
 	static function getCompileCacheDir():Null<String>;
 
 	/**
 		Enable or disable Source Map v3 support for stack traces.
+
+		@see https://nodejs.org/api/module.html#modulesetsourcemapssupportenabled-options
 	**/
 	static function setSourceMapsSupport(enabled:Bool, ?options:ModuleSetSourceMapsSupportOptions):Void;
 
 	/**
 		Return whether Source Map support is enabled and related options.
+
+		@see https://nodejs.org/api/module.html#modulegetsourcemapssupport
 	**/
 	static function getSourceMapsSupport():ModuleSourceMapsSupport;
+}
+
+/**
+	Top-level `module.constants` object.
+**/
+typedef ModuleConstants = {
+	/**
+		Status codes returned by `Module.enableCompileCache`.
+
+		@see https://nodejs.org/api/module.html#moduleconstantscompilecachestatus
+	**/
+	var compileCacheStatus:ModuleCompileCacheStatus;
+}
+
+/**
+	Values of `module.constants.compileCacheStatus`.
+**/
+typedef ModuleCompileCacheStatus = {
+	/**
+		Compile cache enabled successfully.
+	**/
+	var ENABLED:Int;
+
+	/**
+		Compile cache was already enabled.
+	**/
+	var ALREADY_ENABLED:Int;
+
+	/**
+		Failed to enable the compile cache.
+	**/
+	var FAILED:Int;
+
+	/**
+		Compile cache disabled via `NODE_DISABLE_COMPILE_CACHE=1`.
+	**/
+	var DISABLED:Int;
+}
+
+/**
+	Options for `Module.enableCompileCache` when passing an object.
+**/
+typedef ModuleEnableCompileCacheOptions = {
+	/**
+		Directory to store the compile cache.
+		If omitted, uses `NODE_COMPILE_CACHE` or a default under `os.tmpdir()`.
+	**/
+	@:optional var directory:String;
+
+	/**
+		When `true`, enables portable compile cache so cached modules can be
+		reused after the project directory is moved.
+	**/
+	@:optional var portable:Bool;
+}
+
+/**
+	Result returned by `Module.enableCompileCache`.
+**/
+typedef ModuleEnableCompileCacheResult = {
+	/**
+		One of `Module.constants.compileCacheStatus`.
+	**/
+	var status:Int;
+
+	/**
+		Error message when `status` is `FAILED`.
+	**/
+	@:optional var message:String;
+
+	/**
+		Compile cache directory when `status` is `ENABLED` or `ALREADY_ENABLED`.
+	**/
+	@:optional var directory:String;
+}
+
+/**
+	Mode for `Module.stripTypeScriptTypes`.
+**/
+enum abstract ModuleStripTypeScriptTypesMode(String) from String to String {
+	/**
+		Only strip type annotations without transforming TypeScript features.
+	**/
+	var Strip = "strip";
+
+	/**
+		Strip type annotations and transform TypeScript features to JavaScript.
+	**/
+	var Transform = "transform";
 }
 
 /**
@@ -185,17 +336,18 @@ extern class Module {
 **/
 typedef ModuleStripTypeScriptTypesOptions = {
 	/**
-		Mode of stripping. Default: `'strip'`.
+		Mode of stripping. Default: `Strip`.
 	**/
-	@:optional var mode:String;
+	@:optional var mode:ModuleStripTypeScriptTypesMode;
 
 	/**
-		Whether to produce source maps. Default: `false`.
+		Whether to produce source maps. Only valid when `mode` is `Transform`.
+		Default: `false`.
 	**/
 	@:optional var sourceMap:Bool;
 
 	/**
-		The filename used when generating source maps.
+		The filename used when generating source maps / sourceURL comments.
 	**/
 	@:optional var sourceUrl:String;
 }
@@ -205,8 +357,8 @@ typedef ModuleStripTypeScriptTypesOptions = {
 **/
 typedef ModuleRegisterOptions = {
 	/**
-		Base URL used to resolve relative `specifier` values when `parentURL` is not
-		passed as a separate argument. Default: `'data:'`.
+		Base URL used to resolve relative `specifier` values when `parentURL` is
+		not passed as a separate argument. Default: `"data:"`.
 	**/
 	@:optional var parentURL:EitherType<String, URL>;
 
@@ -217,9 +369,8 @@ typedef ModuleRegisterOptions = {
 
 	/**
 		Transferable objects passed into the initialize hook.
-		// TODO(section-5): tighten once worker_threads transferable typing is settled.
 	**/
-	@:optional var transferList:Array<Dynamic>;
+	@:optional var transferList:Array<Transferable>;
 }
 
 /**

--- a/src/js/node/module/SourceMap.hx
+++ b/src/js/node/module/SourceMap.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -22,6 +22,8 @@
 
 package js.node.module;
 
+import haxe.extern.EitherType;
+
 /**
 	Raw Source Map v3 payload used to construct a `SourceMap`.
 
@@ -29,7 +31,7 @@ package js.node.module;
 **/
 typedef SourceMapPayload = {
 	var file:String;
-	var version:Float;
+	var version:Int;
 	var sources:Array<String>;
 	var sourcesContent:Array<String>;
 	var names:Array<String>;
@@ -44,28 +46,35 @@ typedef SourceMapConstructorOptions = {
 	/**
 		Optional line lengths used when the payload omits them.
 	**/
-	@:optional var lineLengths:Array<Float>;
+	@:optional var lineLengths:Array<Int>;
 }
 
 /**
-	Zero-indexed Source Map range in the original file.
+	Zero-indexed Source Map range in the original file, as returned by
+	`SourceMap.findEntry` when a mapping is found.
 **/
 typedef SourceMapping = {
-	var generatedLine:Float;
-	var generatedColumn:Float;
+	var generatedLine:Int;
+	var generatedColumn:Int;
 	var originalSource:String;
-	var originalLine:Float;
-	var originalColumn:Float;
+	var originalLine:Int;
+	var originalColumn:Int;
+
+	/**
+		Name of the range in the source map, when provided.
+	**/
+	@:optional var name:String;
 }
 
 /**
-	1-indexed call-site location in the original source.
+	1-indexed call-site location in the original source, as returned by
+	`SourceMap.findOrigin` when a mapping is found.
 **/
 typedef SourceOrigin = {
 	var name:Null<String>;
 	var fileName:String;
-	var lineNumber:Float;
-	var columnNumber:Float;
+	var lineNumber:Int;
+	var columnNumber:Int;
 }
 
 /**
@@ -75,22 +84,33 @@ typedef SourceOrigin = {
 **/
 @:jsRequire("module", "SourceMap")
 extern class SourceMap {
+	/**
+		Creates a new `SourceMap` instance from a Source Map v3 payload.
+
+		@see https://nodejs.org/api/module.html#new-sourcemappayload-linelengths
+	**/
 	function new(payload:SourceMapPayload, ?options:SourceMapConstructorOptions);
 
 	/**
 		Payload used to construct this `SourceMap` instance.
+
+		@see https://nodejs.org/api/module.html#sourcemappayload
 	**/
 	var payload(default, null):SourceMapPayload;
 
 	/**
 		Given zero-indexed offsets in the generated source, returns the corresponding
 		Source Map range, or an empty object when not found.
+
+		@see https://nodejs.org/api/module.html#sourcemapfindentrylineoffset-columnoffset
 	**/
-	function findEntry(lineOffset:Float, columnOffset:Float):Dynamic;
+	function findEntry(lineOffset:Int, columnOffset:Int):EitherType<SourceMapping, {}>;
 
 	/**
 		Given 1-indexed line/column from a call site in the generated source, returns
 		the corresponding original location, or an empty object when not found.
+
+		@see https://nodejs.org/api/module.html#sourcemapfindorigallinenumber-columnnumber
 	**/
-	function findOrigin(lineNumber:Float, columnNumber:Float):Dynamic;
+	function findOrigin(lineNumber:Int, columnNumber:Int):EitherType<SourceOrigin, {}>;
 }


### PR DESCRIPTION
## Summary
- Audit `Module.hx` and `module/SourceMap.hx` against Node.js 24 `node:module` API.
- Add `Module.constants.compileCacheStatus`, typed `enableCompileCache` options/`portable`/`directory` result, and `Transferable` `transferList`.
- Mark deprecated `module.parent` and `Module.register`; tighten SourceMap entry/origin return types; refresh `@see` anchors and copyright to 2014–2026.

## Test plan
- [x] `haxe build.hxml` succeeds on this branch
- [ ] CI: Haxe 4.0.5 / 4.3.7 / latest
- [ ] Spot-check `Module.enableCompileCache({ portable: true })` and `Module.constants.compileCacheStatus`
- [ ] Spot-check `SourceMap.findEntry` / `findOrigin` return typing


Made with [Cursor](https://cursor.com)