### PR TITLE
Audit js.node.http2 for Node 24 + Haxe 4

### DIFF
--- a/src/js/node/Http2.hx
+++ b/src/js/node/Http2.hx
@@ -31,7 +31,7 @@ import js.node.http2.Http2Server;
 import js.node.http2.Http2ServerRequest;
 import js.node.http2.Http2ServerResponse;
 import js.node.http2.ServerHttp2Session;
-import js.node.stream.Duplex;
+import js.node.stream.Duplex.IDuplex;
 import js.node.tls.SecureContext.SecureContextOptions;
 import js.node.url.URL;
 import js.node.web.AbortSignal;

--- a/src/js/node/Http2.hx
+++ b/src/js/node/Http2.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -276,6 +276,13 @@ typedef Http2ClientSessionRequestOptions = {
 	@:optional var endStream:Bool;
 	@:optional var exclusive:Bool;
 	@:optional var parent:Int;
+
+	/**
+		Priority signaling is deprecated (RFC 9113). Ignored with a runtime warning since Node.js v24.2.0.
+	**/
+	@:deprecated("Priority signaling is no longer supported in Node.js")
+	@:optional var weight:Int;
+
 	@:optional var waitForTrailers:Bool;
 	@:optional var signal:AbortSignal;
 }
@@ -325,6 +332,8 @@ typedef Http2ServerStreamFileResponseOptions = {
 
 /**
 	The `node:http2` module provides an implementation of the HTTP/2 protocol.
+
+	@see https://nodejs.org/api/http2.html
 **/
 @:jsRequire("http2")
 extern class Http2 {
@@ -351,9 +360,10 @@ extern class Http2 {
 	static function getPackedSettings(settings:Http2Settings):Buffer;
 
 	/**
-		Returns an HTTP/2 settings object containing the deserialized settings from the given buffer.
+		Returns an HTTP/2 settings object containing the deserialized settings from the given buffer
+		(or `TypedArray` / `DataView`).
 	**/
-	static function getUnpackedSettings(buf:Buffer):Http2Settings;
+	static function getUnpackedSettings(buf:js.lib.ArrayBufferView):Http2Settings;
 
 	/**
 		Returns a `net.Server` instance that creates and manages `Http2Session` instances.

--- a/src/js/node/http2/ClientHttp2Session.hx
+++ b/src/js/node/http2/ClientHttp2Session.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/http2/ClientHttp2Session.hx
+++ b/src/js/node/http2/ClientHttp2Session.hx
@@ -44,7 +44,7 @@ enum abstract ClientHttp2SessionEvent<T:haxe.Constraints.Function>(Event<T>) to 
 	/**
 		Emitted when an `ORIGIN` frame is received.
 	**/
-	var Origin:ClientHttp2SessionEvent<Array<String>->Void> = "origin";
+	var Origin:ClientHttp2SessionEvent<(origins:Array<String>) -> Void> = "origin";
 
 	/**
 		Emitted when a new client stream is created.

--- a/src/js/node/http2/ClientHttp2Stream.hx
+++ b/src/js/node/http2/ClientHttp2Stream.hx
@@ -32,7 +32,7 @@ enum abstract ClientHttp2StreamEvent<T:haxe.Constraints.Function>(Event<T>) to E
 	/**
 		Emitted when the server sends a `100 Continue` response.
 	**/
-	var Continue:ClientHttp2StreamEvent<Void->Void> = "continue";
+	var Continue:ClientHttp2StreamEvent<() -> Void> = "continue";
 
 	/**
 		Emitted when additional headers are received for an open stream.

--- a/src/js/node/http2/ClientHttp2Stream.hx
+++ b/src/js/node/http2/ClientHttp2Stream.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -42,7 +42,7 @@ enum abstract ClientHttp2StreamEvent<T:haxe.Constraints.Function>(Event<T>) to E
 	/**
 		Emitted when the server pushes a stream.
 	**/
-	var Push:ClientHttp2StreamEvent<(headers:Http2Headers, flags:Int) -> Void> = "push";
+	var Push:ClientHttp2StreamEvent<(headers:Http2Headers, flags:Int, rawHeaders:Array<String>) -> Void> = "push";
 
 	/**
 		Emitted when a response `HEADERS` frame has been received.

--- a/src/js/node/http2/Http2Constants.hx
+++ b/src/js/node/http2/Http2Constants.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -23,7 +23,7 @@
 package js.node.http2;
 
 /**
-	Constants exposed by the `http2` module.
+	Constants exposed by the `http2` module (`http2.constants`).
 
 	@see https://nodejs.org/api/http2.html#http2constants
 **/

--- a/src/js/node/http2/Http2SecureServer.hx
+++ b/src/js/node/http2/Http2SecureServer.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/http2/Http2SecureServer.hx
+++ b/src/js/node/http2/Http2SecureServer.hx
@@ -40,7 +40,7 @@ enum abstract Http2SecureServerEvent<T:haxe.Constraints.Function>(Event<T>) to E
 	/**
 		Emitted when a new TCP stream is established, before the TLS handshake begins.
 	**/
-	var Connection:Http2SecureServerEvent<IDuplex->Void> = "connection";
+	var Connection:Http2SecureServerEvent<(socket:IDuplex) -> Void> = "connection";
 
 	/**
 		Emitted each time there is a request. See the Compatibility API.
@@ -50,7 +50,7 @@ enum abstract Http2SecureServerEvent<T:haxe.Constraints.Function>(Event<T>) to E
 	/**
 		Emitted when a new `Http2Session` is created by the `Http2SecureServer`.
 	**/
-	var Session:Http2SecureServerEvent<ServerHttp2Session->Void> = "session";
+	var Session:Http2SecureServerEvent<(session:ServerHttp2Session) -> Void> = "session";
 
 	/**
 		Emitted when an `'error'` event is emitted by an `Http2Session` associated with the server.
@@ -65,12 +65,12 @@ enum abstract Http2SecureServerEvent<T:haxe.Constraints.Function>(Event<T>) to E
 	/**
 		Emitted when there is no activity on the Server for a given number of milliseconds.
 	**/
-	var Timeout:Http2SecureServerEvent<Void->Void> = "timeout";
+	var Timeout:Http2SecureServerEvent<() -> Void> = "timeout";
 
 	/**
 		Emitted when a connecting client fails to negotiate an allowed protocol (HTTP/2 or HTTP/1.1).
 	**/
-	var UnknownProtocol:Http2SecureServerEvent<IDuplex->Void> = "unknownProtocol";
+	var UnknownProtocol:Http2SecureServerEvent<(socket:IDuplex) -> Void> = "unknownProtocol";
 }
 
 /**
@@ -83,8 +83,8 @@ extern class Http2SecureServer extends js.node.tls.Server {
 	/**
 		Used to set the timeout value for http2 secure server requests.
 	**/
-	@:overload(function(?callback:Void->Void):Http2SecureServer {})
-	function setTimeout(?msecs:Int, ?callback:Void->Void):Http2SecureServer;
+	@:overload(function(?callback:() -> Void):Http2SecureServer {})
+	function setTimeout(?msecs:Int, ?callback:() -> Void):Http2SecureServer;
 
 	/**
 		The number of milliseconds of inactivity before a socket is presumed to have timed out.

--- a/src/js/node/http2/Http2Server.hx
+++ b/src/js/node/http2/Http2Server.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/http2/Http2Server.hx
+++ b/src/js/node/http2/Http2Server.hx
@@ -40,7 +40,7 @@ enum abstract Http2ServerEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T
 	/**
 		Emitted when a new TCP stream is established.
 	**/
-	var Connection:Http2ServerEvent<IDuplex->Void> = "connection";
+	var Connection:Http2ServerEvent<(socket:IDuplex) -> Void> = "connection";
 
 	/**
 		Emitted each time there is a request. See the Compatibility API.
@@ -50,7 +50,7 @@ enum abstract Http2ServerEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T
 	/**
 		Emitted when a new `Http2Session` is created by the `Http2Server`.
 	**/
-	var Session:Http2ServerEvent<ServerHttp2Session->Void> = "session";
+	var Session:Http2ServerEvent<(session:ServerHttp2Session) -> Void> = "session";
 
 	/**
 		Emitted when an `'error'` event is emitted by an `Http2Session` associated with the server.
@@ -65,7 +65,7 @@ enum abstract Http2ServerEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T
 	/**
 		Emitted when there is no activity on the Server for a given number of milliseconds.
 	**/
-	var Timeout:Http2ServerEvent<Void->Void> = "timeout";
+	var Timeout:Http2ServerEvent<() -> Void> = "timeout";
 }
 
 /**
@@ -78,8 +78,8 @@ extern class Http2Server extends js.node.net.Server {
 	/**
 		Used to set the timeout value for http2 server requests.
 	**/
-	@:overload(function(?callback:Void->Void):Http2Server {})
-	function setTimeout(?msecs:Int, ?callback:Void->Void):Http2Server;
+	@:overload(function(?callback:() -> Void):Http2Server {})
+	function setTimeout(?msecs:Int, ?callback:() -> Void):Http2Server;
 
 	/**
 		The number of milliseconds of inactivity before a socket is presumed to have timed out.

--- a/src/js/node/http2/Http2ServerRequest.hx
+++ b/src/js/node/http2/Http2ServerRequest.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/http2/Http2ServerRequest.hx
+++ b/src/js/node/http2/Http2ServerRequest.hx
@@ -37,12 +37,12 @@ enum abstract Http2ServerRequestEvent<T:haxe.Constraints.Function>(Event<T>) to 
 	/**
 		Emitted whenever a `Http2ServerRequest` instance is abnormally aborted in mid-communication.
 	**/
-	var Aborted:Http2ServerRequestEvent<Void->Void> = "aborted";
+	var Aborted:Http2ServerRequestEvent<() -> Void> = "aborted";
 
 	/**
 		Indicates that the underlying `Http2Stream` was closed.
 	**/
-	var Close:Http2ServerRequestEvent<Void->Void> = "close";
+	var Close:Http2ServerRequestEvent<() -> Void> = "close";
 }
 
 /**
@@ -122,7 +122,7 @@ extern class Http2ServerRequest extends Readable<Http2ServerRequest> {
 	/**
 		Sets the `Http2Stream`'s timeout value to `msecs`.
 	**/
-	function setTimeout(msecs:Int, ?callback:Void->Void):Http2ServerRequest;
+	function setTimeout(msecs:Int, ?callback:() -> Void):Http2ServerRequest;
 
 	/**
 		Returns a `Proxy` object that acts as a `net.Socket` (or `tls.TLSSocket`)

--- a/src/js/node/http2/Http2ServerResponse.hx
+++ b/src/js/node/http2/Http2ServerResponse.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -179,14 +179,15 @@ extern class Http2ServerResponse extends Writable<Http2ServerResponse> {
 
 	/**
 		Sends an arbitrary HTTP 1xx informational response.
+		After final response headers are sent this is a no-op and returns `false`.
 		Added in Node.js v24.18.0 (Active LTS); not available on Maintenance LTS 22.x.
 	**/
 	function writeInformation(statusCode:Int, ?headers:Http2Headers):Bool;
 
 	/**
-		Sends a response header to the request.
+		Sends a response header to the request. Returns `this` for chaining with `end()`.
 	**/
-	@:overload(function(statusCode:Int, ?headers:Http2Headers):Void {})
-	@:overload(function(statusCode:Int, statusMessage:String, ?headers:Http2Headers):Void {})
-	function writeHead(statusCode:Int, ?headers:DynamicAccess<EitherType<String, Array<String>>>):Void;
+	@:overload(function(statusCode:Int, ?headers:Http2Headers):Http2ServerResponse {})
+	@:overload(function(statusCode:Int, statusMessage:String, ?headers:Http2Headers):Http2ServerResponse {})
+	function writeHead(statusCode:Int, ?headers:DynamicAccess<EitherType<String, Array<String>>>):Http2ServerResponse;
 }

--- a/src/js/node/http2/Http2ServerResponse.hx
+++ b/src/js/node/http2/Http2ServerResponse.hx
@@ -38,12 +38,12 @@ enum abstract Http2ServerResponseEvent<T:haxe.Constraints.Function>(Event<T>) to
 	/**
 		Indicates that the underlying `Http2Stream` was terminated before `response.end()` was called or able to flush.
 	**/
-	var Close:Http2ServerResponseEvent<Void->Void> = "close";
+	var Close:Http2ServerResponseEvent<() -> Void> = "close";
 
 	/**
 		Emitted when the response has been sent.
 	**/
-	var Finish:Http2ServerResponseEvent<Void->Void> = "finish";
+	var Finish:Http2ServerResponseEvent<() -> Void> = "finish";
 }
 
 /**
@@ -144,7 +144,7 @@ extern class Http2ServerResponse extends Writable<Http2ServerResponse> {
 	/**
 		Sets the `Http2Stream`'s timeout value to `msecs`.
 	**/
-	function setTimeout(msecs:Int, ?callback:Void->Void):Http2ServerResponse;
+	function setTimeout(msecs:Int, ?callback:() -> Void):Http2ServerResponse;
 
 	/**
 		Returns a `Proxy` object that acts as a `net.Socket` (or `tls.TLSSocket`)

--- a/src/js/node/http2/Http2Session.hx
+++ b/src/js/node/http2/Http2Session.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -22,7 +22,8 @@
 
 package js.node.http2;
 
-import haxe.extern.EitherType;
+import js.lib.ArrayBufferView;
+import js.lib.Error;
 import js.node.Buffer;
 import js.node.Http2.Http2Headers;
 import js.node.Http2.Http2SessionState;
@@ -30,7 +31,6 @@ import js.node.Http2.Http2Settings;
 import js.node.events.EventEmitter;
 import js.node.events.EventEmitter.Event;
 import js.node.net.Socket;
-import js.lib.Error;
 
 /**
 	Enumeration of events emitted by `Http2Session` in addition to its parent class events.
@@ -59,7 +59,7 @@ enum abstract Http2SessionEvent<T:haxe.Constraints.Function>(Event<T>) to Event<
 	/**
 		Emitted when a `GOAWAY` frame is received.
 	**/
-	var Goaway:Http2SessionEvent<(errorCode:Int, lastStreamID:Int, opaqueData:Buffer) -> Void> = "goaway";
+	var Goaway:Http2SessionEvent<(errorCode:Int, lastStreamID:Int, opaqueData:Null<Buffer>) -> Void> = "goaway";
 
 	/**
 		Emitted when an acknowledgment `SETTINGS` frame has been received.
@@ -170,12 +170,13 @@ extern class Http2Session extends EventEmitter<Http2Session> {
 	/**
 		Transmits a `GOAWAY` frame without shutting down the session.
 	**/
-	function goaway(?code:Int, ?lastStreamID:Int, ?opaqueData:Buffer):Void;
+	function goaway(?code:Int, ?lastStreamID:Int, ?opaqueData:ArrayBufferView):Void;
 
 	/**
 		Sends a `PING` frame to the connected HTTP/2 peer.
+		Optional `payload` must be 8 bytes (`Buffer`, `TypedArray`, or `DataView`).
 	**/
-	@:overload(function(payload:Buffer, callback:(err:Null<Error>, duration:Float, payload:Buffer) -> Void):Bool {})
+	@:overload(function(payload:ArrayBufferView, callback:(err:Null<Error>, duration:Float, payload:Buffer) -> Void):Bool {})
 	function ping(callback:(err:Null<Error>, duration:Float, payload:Buffer) -> Void):Bool;
 
 	/**

--- a/src/js/node/http2/Http2Session.hx
+++ b/src/js/node/http2/Http2Session.hx
@@ -39,7 +39,7 @@ enum abstract Http2SessionEvent<T:haxe.Constraints.Function>(Event<T>) to Event<
 	/**
 		Emitted once the `Http2Session` has been destroyed.
 	**/
-	var Close:Http2SessionEvent<Void->Void> = "close";
+	var Close:Http2SessionEvent<() -> Void> = "close";
 
 	/**
 		Emitted once the `Http2Session` has been successfully connected to the remote peer.
@@ -49,7 +49,7 @@ enum abstract Http2SessionEvent<T:haxe.Constraints.Function>(Event<T>) to Event<
 	/**
 		Emitted when an error occurs during processing of an `Http2Session`.
 	**/
-	var Error:Http2SessionEvent<Error->Void> = "error";
+	var Error:Http2SessionEvent<(error:Error) -> Void> = "error";
 
 	/**
 		Emitted when an error occurs while attempting to send a frame on the session.
@@ -64,17 +64,17 @@ enum abstract Http2SessionEvent<T:haxe.Constraints.Function>(Event<T>) to Event<
 	/**
 		Emitted when an acknowledgment `SETTINGS` frame has been received.
 	**/
-	var LocalSettings:Http2SessionEvent<Http2Settings->Void> = "localSettings";
+	var LocalSettings:Http2SessionEvent<(settings:Http2Settings) -> Void> = "localSettings";
 
 	/**
 		Emitted whenever a `PING` frame is received from the connected peer.
 	**/
-	var Ping:Http2SessionEvent<Buffer->Void> = "ping";
+	var Ping:Http2SessionEvent<(payload:Buffer) -> Void> = "ping";
 
 	/**
 		Emitted when a new `SETTINGS` frame is received from the connected peer.
 	**/
-	var RemoteSettings:Http2SessionEvent<Http2Settings->Void> = "remoteSettings";
+	var RemoteSettings:Http2SessionEvent<(settings:Http2Settings) -> Void> = "remoteSettings";
 
 	/**
 		Emitted when a new `Http2Stream` is created.
@@ -84,7 +84,7 @@ enum abstract Http2SessionEvent<T:haxe.Constraints.Function>(Event<T>) to Event<
 	/**
 		Emitted after the `Http2Session` times out due to inactivity.
 	**/
-	var Timeout:Http2SessionEvent<Void->Void> = "timeout";
+	var Timeout:Http2SessionEvent<() -> Void> = "timeout";
 }
 
 /**
@@ -160,7 +160,7 @@ extern class Http2Session extends EventEmitter<Http2Session> {
 	/**
 		Gracefully closes the `Http2Session`, allowing existing streams to complete.
 	**/
-	function close(?callback:Void->Void):Void;
+	function close(?callback:() -> Void):Void;
 
 	/**
 		Immediately terminates the `Http2Session` and the associated socket.
@@ -192,7 +192,7 @@ extern class Http2Session extends EventEmitter<Http2Session> {
 	/**
 		Sets a callback invoked when there is no activity on the session after `msecs` milliseconds.
 	**/
-	function setTimeout(msecs:Int, ?callback:Void->Void):Void;
+	function setTimeout(msecs:Int, ?callback:() -> Void):Void;
 
 	/**
 		Updates the current local settings and sends a new `SETTINGS` frame.

--- a/src/js/node/http2/Http2Stream.hx
+++ b/src/js/node/http2/Http2Stream.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -61,7 +61,7 @@ enum abstract Http2StreamEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T
 	/**
 		Emitted when trailing headers are received.
 	**/
-	var Trailers:Http2StreamEvent<(trailers:Http2Headers, flags:Int) -> Void> = "trailers";
+	var Trailers:Http2StreamEvent<(trailers:Http2Headers, flags:Int, rawHeaders:Array<String>) -> Void> = "trailers";
 
 	/**
 		Emitted when the stream is ready for trailing headers to be sent.
@@ -144,9 +144,8 @@ extern class Http2Stream extends Duplex<Http2Stream> {
 	function close(?code:Int, ?callback:Void->Void):Void;
 
 	/**
-		Priority signaling is no longer supported in Node.js.
-
-		// TODO(section-3): remove once callers migrate off deprecated stream.priority
+		Empty method retained for compatibility. Priority signaling is no longer supported
+		(RFC 9113); calling this triggers a runtime warning since Node.js v24.2.0.
 	**/
 	@:deprecated("Priority signaling is no longer supported in Node.js")
 	function priority(options:Any):Void;

--- a/src/js/node/http2/Http2Stream.hx
+++ b/src/js/node/http2/Http2Stream.hx
@@ -34,7 +34,7 @@ enum abstract Http2StreamEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T
 	/**
 		Emitted when the `Http2Stream` instance is aborted abnormally.
 	**/
-	var Aborted:Http2StreamEvent<Void->Void> = "aborted";
+	var Aborted:Http2StreamEvent<() -> Void> = "aborted";
 
 	/**
 		Emitted when an error occurs while attempting to send a frame.
@@ -44,19 +44,19 @@ enum abstract Http2StreamEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T
 	/**
 		Emitted when the `Http2Stream` has been opened and is ready for use.
 	**/
-	var Ready:Http2StreamEvent<Void->Void> = "ready";
+	var Ready:Http2StreamEvent<() -> Void> = "ready";
 
 	/**
 		Emitted when the `Http2Stream` is destroyed (Duplex `'close'`).
 		No listener arguments; use `stream.rstCode` for the `RST_STREAM` error code.
 		(The legacy `'streamClosed'` event is no longer emitted on Node.js LTS.)
 	**/
-	var Close:Http2StreamEvent<Void->Void> = "close";
+	var Close:Http2StreamEvent<() -> Void> = "close";
 
 	/**
 		Emitted after the stream times out due to inactivity.
 	**/
-	var Timeout:Http2StreamEvent<Void->Void> = "timeout";
+	var Timeout:Http2StreamEvent<() -> Void> = "timeout";
 
 	/**
 		Emitted when trailing headers are received.
@@ -66,7 +66,7 @@ enum abstract Http2StreamEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T
 	/**
 		Emitted when the stream is ready for trailing headers to be sent.
 	**/
-	var WantTrailers:Http2StreamEvent<Void->Void> = "wantTrailers";
+	var WantTrailers:Http2StreamEvent<() -> Void> = "wantTrailers";
 }
 
 /**
@@ -141,7 +141,7 @@ extern class Http2Stream extends Duplex<Http2Stream> {
 	/**
 		Closes the stream by sending an `RST_STREAM` frame.
 	**/
-	function close(?code:Int, ?callback:Void->Void):Void;
+	function close(?code:Int, ?callback:() -> Void):Void;
 
 	/**
 		Empty method retained for compatibility. Priority signaling is no longer supported
@@ -153,7 +153,7 @@ extern class Http2Stream extends Duplex<Http2Stream> {
 	/**
 		Sets the stream timeout value.
 	**/
-	function setTimeout(msecs:Int, ?callback:Void->Void):Void;
+	function setTimeout(msecs:Int, ?callback:() -> Void):Void;
 
 	/**
 		Sends a trailing `HEADERS` frame. Must be called after `'wantTrailers'`.

--- a/src/js/node/http2/ServerHttp2Session.hx
+++ b/src/js/node/http2/ServerHttp2Session.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/http2/ServerHttp2Stream.hx
+++ b/src/js/node/http2/ServerHttp2Stream.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -22,11 +22,13 @@
 
 package js.node.http2;
 
+import haxe.extern.EitherType;
+import js.lib.Error;
 import js.node.Http2.Http2Headers;
 import js.node.Http2.Http2PushStreamOptions;
 import js.node.Http2.Http2ServerStreamFileResponseOptions;
 import js.node.Http2.Http2ServerStreamResponseOptions;
-import js.lib.Error;
+import js.node.fs.FileHandle;
 
 /**
 	An `Http2Stream` for use on an HTTP/2 server.
@@ -70,8 +72,8 @@ extern class ServerHttp2Stream extends Http2Stream {
 	function respondWithFile(path:String, ?headers:Http2Headers, ?options:Http2ServerStreamFileResponseOptions):Void;
 
 	/**
-		Sends a regular file as the response using an open file descriptor.
+		Sends a regular file as the response using an open file descriptor or `FileHandle`.
 	**/
-	@:overload(function(fd:Int, ?options:Http2ServerStreamFileResponseOptions):Void {})
-	function respondWithFD(fd:Int, ?headers:Http2Headers, ?options:Http2ServerStreamFileResponseOptions):Void;
+	@:overload(function(fd:EitherType<Int, FileHandle>, ?options:Http2ServerStreamFileResponseOptions):Void {})
+	function respondWithFD(fd:EitherType<Int, FileHandle>, ?headers:Http2Headers, ?options:Http2ServerStreamFileResponseOptions):Void;
 }


### PR DESCRIPTION
## Summary
- Aligns `Http2` / `http2/*` externs with Node.js 24 Active LTS: deprecated request `weight`, `ArrayBufferView` for settings/`goaway`/`ping`, `rawHeaders` on `trailers`/`push`, `FileHandle` for `respondWithFD`, and `writeHead` chaining return type.
- Documents priority/`writeInformation` behavior for Node 24; bumps copyright headers to 2014–2026.
- API surface was largely complete from #217 / #226; this pass closes remaining typing/docs gaps.

## Test plan
- [x] `haxe build.hxml` succeeds
- [ ] Spot-check `Http2.connect` / `ClientHttp2Session.request` / `ServerHttp2Stream.respondWithFD` call sites still typecheck
- [ ] Confirm `getUnpackedSettings` accepts `Uint8Array` and `ping` accepts typed-array payloads


Made with [Cursor](https://cursor.com)