### PR TITLE
Audit js.node.web for Node 24 + Haxe 4 polish

### DIFF
--- a/src/js/node/web/AbortController.hx
+++ b/src/js/node/web/AbortController.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/web/AbortSignal.hx
+++ b/src/js/node/web/AbortSignal.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/web/Blob.hx
+++ b/src/js/node/web/Blob.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/web/BroadcastChannel.hx
+++ b/src/js/node/web/BroadcastChannel.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/web/ByteLengthQueuingStrategy.hx
+++ b/src/js/node/web/ByteLengthQueuingStrategy.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/web/CloseEvent.hx
+++ b/src/js/node/web/CloseEvent.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/web/CompressionStream.hx
+++ b/src/js/node/web/CompressionStream.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -23,7 +23,7 @@
 package js.node.web;
 
 /**
-	A transform stream that performs compression (`gzip`, `deflate`, or `deflate-raw`).
+	A transform stream that performs compression (`deflate`, `deflate-raw`, `gzip`, or `brotli`).
 
 	@see https://nodejs.org/api/globals.html#class-compressionstream
 	@see https://nodejs.org/api/webstreams.html#class-compressionstream
@@ -34,7 +34,7 @@ extern class CompressionStream {
 	var writable(default, null):WritableStream;
 
 	/**
-		@param format One of `'gzip'`, `'deflate'`, or `'deflate-raw'`.
+		@param format One of `'deflate'`, `'deflate-raw'`, `'gzip'`, or `'brotli'`.
 	**/
 	function new(format:String):Void;
 }

--- a/src/js/node/web/CountQueuingStrategy.hx
+++ b/src/js/node/web/CountQueuingStrategy.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/web/CustomEvent.hx
+++ b/src/js/node/web/CustomEvent.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/web/DOMException.hx
+++ b/src/js/node/web/DOMException.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/web/DecompressionStream.hx
+++ b/src/js/node/web/DecompressionStream.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -23,7 +23,7 @@
 package js.node.web;
 
 /**
-	A transform stream that performs decompression (`gzip`, `deflate`, or `deflate-raw`).
+	A transform stream that performs decompression (`deflate`, `deflate-raw`, `gzip`, or `brotli`).
 
 	@see https://nodejs.org/api/globals.html#class-decompressionstream
 	@see https://nodejs.org/api/webstreams.html#class-decompressionstream
@@ -34,7 +34,7 @@ extern class DecompressionStream {
 	var writable(default, null):WritableStream;
 
 	/**
-		@param format One of `'gzip'`, `'deflate'`, or `'deflate-raw'`.
+		@param format One of `'deflate'`, `'deflate-raw'`, `'gzip'`, or `'brotli'`.
 	**/
 	function new(format:String):Void;
 }

--- a/src/js/node/web/Event.hx
+++ b/src/js/node/web/Event.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -67,10 +67,11 @@ extern class Event {
 	var cancelable(default, null):Bool;
 
 	/**
-		Stability: 3 - Legacy: Use `defaultPrevented` instead.
-
 		True if the event has not been canceled.
+
+		Stability: 3 - Legacy.
 	**/
+	@:deprecated("Use defaultPrevented instead")
 	var returnValue:Bool;
 
 	/**
@@ -95,17 +96,19 @@ extern class Event {
 	var timeStamp(default, null):Float;
 
 	/**
-		Stability: 3 - Legacy: Use `stopPropagation()` instead.
-
 		Alias for `stopPropagation()` if set to `true`.
+
+		Stability: 3 - Legacy.
 	**/
+	@:deprecated("Use stopPropagation() instead")
 	var cancelBubble:Bool;
 
 	/**
-		Stability: 3 - Legacy: Use `target` instead.
-
 		Alias for `target`.
+
+		Stability: 3 - Legacy.
 	**/
+	@:deprecated("Use target instead")
 	var srcElement(default, null):EventTarget;
 
 	function new(type:String, ?eventInitDict:EventInit):Void;
@@ -133,10 +136,11 @@ extern class Event {
 	function stopPropagation():Void;
 
 	/**
-		Stability: 3 - Legacy: The WHATWG spec considers it deprecated.
-
 		Redundant with event constructors and incapable of setting `composed`.
+
+		Stability: 3 - Legacy. The WHATWG spec considers it deprecated.
 	**/
+	@:deprecated("Use the Event constructor instead")
 	function initEvent(type:String, ?bubbles:Bool, ?cancelable:Bool):Void;
 }
 

--- a/src/js/node/web/EventSource.hx
+++ b/src/js/node/web/EventSource.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/web/EventSource.hx
+++ b/src/js/node/web/EventSource.hx
@@ -27,7 +27,7 @@ import js.node.url.URL;
 /**
 	A browser-compatible `EventSource` (Server-Sent Events) implementation.
 
-	Stability: 1 - Experimental. May require `--experimental-eventsource` depending on Node version.
+	Stability: 1 - Experimental. Enable with the `--experimental-eventsource` CLI flag.
 
 	@see https://nodejs.org/api/globals.html#class-eventsource
 **/
@@ -56,6 +56,8 @@ extern class EventSource extends EventTarget {
 **/
 typedef EventSourceInit = {
 	@:optional var withCredentials:Bool;
-	// TODO(section-6): type undici dispatcher options when available.
+	/**
+		Undici-specific custom dispatcher. Left as `Any` until an undici `Dispatcher` extern exists.
+	**/
 	@:optional var dispatcher:Any;
 }

--- a/src/js/node/web/EventTarget.hx
+++ b/src/js/node/web/EventTarget.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/web/Fetch.hx
+++ b/src/js/node/web/Fetch.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/web/Fetch.hx
+++ b/src/js/node/web/Fetch.hx
@@ -29,7 +29,8 @@ import js.node.web.Request.RequestInit;
 /**
 	Browser-compatible `fetch()` (undici), exposed as a static on `globalThis`.
 
-	Usage: `Fetch.fetch(url)` / `Fetch.fetch(url, init)`, or `js.Node.fetch(url)`.
+	Stable since Node.js v21.0.0. Usage: `Fetch.fetch(url)` / `Fetch.fetch(url, init)`,
+	or `js.Node.fetch(url)`.
 
 	@see https://nodejs.org/api/globals.html#fetch
 **/

--- a/src/js/node/web/File.hx
+++ b/src/js/node/web/File.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/web/FormData.hx
+++ b/src/js/node/web/FormData.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/web/Headers.hx
+++ b/src/js/node/web/Headers.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/web/LockManager.hx
+++ b/src/js/node/web/LockManager.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/web/MessageChannel.hx
+++ b/src/js/node/web/MessageChannel.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/web/MessageEvent.hx
+++ b/src/js/node/web/MessageEvent.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -57,8 +57,11 @@ extern class MessageEvent extends Event {
 	function new(type:String, ?eventInitDict:MessageEventInit):Void;
 
 	/**
-		Stability: 3 - Legacy. Initializes a `MessageEvent`. Prefer the constructor.
+		Initializes a `MessageEvent`.
+
+		Stability: 3 - Legacy.
 	**/
+	@:deprecated("Use the MessageEvent constructor instead")
 	function initMessageEvent(type:String, ?bubbles:Bool, ?cancelable:Bool, ?data:Any, ?origin:String, ?lastEventId:String,
 		?source:Null<MessagePort>, ?ports:Array<MessagePort>):Void;
 }

--- a/src/js/node/web/MessagePort.hx
+++ b/src/js/node/web/MessagePort.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/web/Navigator.hx
+++ b/src/js/node/web/Navigator.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/web/QueuingStrategy.hx
+++ b/src/js/node/web/QueuingStrategy.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/web/QueuingStrategy.hx
+++ b/src/js/node/web/QueuingStrategy.hx
@@ -23,9 +23,10 @@
 package js.node.web;
 
 /**
-	A queuing strategy for web streams.
+	A queuing strategy dictionary used by web stream constructors
+	(`ReadableStream`, `WritableStream`, `TransformStream`, etc.).
 
-	@see https://nodejs.org/api/webstreams.html#class-bytelengthqueuingstrategy
+	@see https://nodejs.org/api/webstreams.html
 **/
 typedef QueuingStrategy = {
 	/**

--- a/src/js/node/web/ReadableByteStreamController.hx
+++ b/src/js/node/web/ReadableByteStreamController.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/web/ReadableStream.hx
+++ b/src/js/node/web/ReadableStream.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/web/ReadableStreamBYOBReader.hx
+++ b/src/js/node/web/ReadableStreamBYOBReader.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/web/ReadableStreamBYOBRequest.hx
+++ b/src/js/node/web/ReadableStreamBYOBRequest.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/web/ReadableStreamDefaultController.hx
+++ b/src/js/node/web/ReadableStreamDefaultController.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/web/ReadableStreamDefaultReader.hx
+++ b/src/js/node/web/ReadableStreamDefaultReader.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/web/ReadableStreamReadResult.hx
+++ b/src/js/node/web/ReadableStreamReadResult.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/web/Request.hx
+++ b/src/js/node/web/Request.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/web/Request.hx
+++ b/src/js/node/web/Request.hx
@@ -102,9 +102,8 @@ typedef RequestInit = {
 	@:optional var duplex:String;
 
 	/**
-		Undici-specific: custom dispatcher for the request.
-
-		TODO(section-6): type as undici `Dispatcher` if a module extern is added.
+		Undici-specific custom dispatcher for the request.
+		Left as `Any` until an undici `Dispatcher` extern exists.
 	**/
 	@:optional var dispatcher:Any;
 }

--- a/src/js/node/web/Response.hx
+++ b/src/js/node/web/Response.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/web/Response.hx
+++ b/src/js/node/web/Response.hx
@@ -27,6 +27,7 @@ import haxe.extern.EitherType;
 import js.lib.ArrayBuffer;
 import js.lib.Promise;
 import js.lib.Uint8Array;
+import js.node.url.URL;
 import js.node.web.Request.BodyInit;
 
 /**
@@ -44,6 +45,7 @@ extern class Response {
 	/**
 		Creates a new response with a different URL.
 	**/
+	@:overload(function(url:URL, ?status:Int):Response {})
 	static function redirect(url:String, ?status:Int):Response;
 
 	/**

--- a/src/js/node/web/Storage.hx
+++ b/src/js/node/web/Storage.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/web/TextDecoder.hx
+++ b/src/js/node/web/TextDecoder.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/web/TextDecoderStream.hx
+++ b/src/js/node/web/TextDecoderStream.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/web/TextEncoder.hx
+++ b/src/js/node/web/TextEncoder.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/web/TextEncoderStream.hx
+++ b/src/js/node/web/TextEncoderStream.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/web/TransformStream.hx
+++ b/src/js/node/web/TransformStream.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/web/TransformStreamDefaultController.hx
+++ b/src/js/node/web/TransformStreamDefaultController.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/web/WebSocket.hx
+++ b/src/js/node/web/WebSocket.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/web/WebSocket.hx
+++ b/src/js/node/web/WebSocket.hx
@@ -22,6 +22,7 @@
 
 package js.node.web;
 
+import haxe.DynamicAccess;
 import haxe.extern.EitherType;
 import js.lib.ArrayBuffer;
 import js.lib.ArrayBufferView;
@@ -29,6 +30,8 @@ import js.node.url.URL;
 
 /**
 	A browser-compatible `WebSocket` implementation (undici).
+
+	Stable since Node.js v22.4.0. Disable with `--no-experimental-websocket`.
 
 	@see https://nodejs.org/api/globals.html#class-websocket
 **/
@@ -69,7 +72,9 @@ extern class WebSocket extends EventTarget {
 **/
 typedef WebSocketInit = {
 	@:optional var protocols:EitherType<String, Array<String>>;
-	@:optional var headers:EitherType<Headers, Any>;
-	// TODO(section-6): type undici dispatcher options when available.
+	@:optional var headers:EitherType<Headers, EitherType<Array<Array<String>>, DynamicAccess<String>>>;
+	/**
+		Undici-specific custom dispatcher. Left as `Any` until an undici `Dispatcher` extern exists.
+	**/
 	@:optional var dispatcher:Any;
 }

--- a/src/js/node/web/WritableStream.hx
+++ b/src/js/node/web/WritableStream.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/web/WritableStreamDefaultController.hx
+++ b/src/js/node/web/WritableStreamDefaultController.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/web/WritableStreamDefaultWriter.hx
+++ b/src/js/node/web/WritableStreamDefaultWriter.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/web/WritableStreamDefaultWriter.hx
+++ b/src/js/node/web/WritableStreamDefaultWriter.hx
@@ -41,5 +41,5 @@ extern class WritableStreamDefaultWriter {
 	function abort(?reason:Any):Promise<Void>;
 	function close():Promise<Void>;
 	function releaseLock():Void;
-	function write(chunk:Any):Promise<Void>;
+	function write(?chunk:Any):Promise<Void>;
 }


### PR DESCRIPTION
## Summary
- Follow-up polish of `src/js/node/web/**` against Node.js 24 Active LTS (after #230 coverage expansion).
- Bump copyright headers to `2014-2026`; document Node 24 status for `fetch`, `WebSocket`, and `EventSource`.
- Compression/Decompression streams docs now include Node 24.7+ `'brotli'` format alongside `deflate` / `deflate-raw` / `gzip`.
- Mark Stability-3 Event / MessageEvent legacy APIs with `@:deprecated` replacement strings; tighten `WebSocketInit.headers`; accept `URL` in `Response.redirect`; make `WritableStreamDefaultWriter.write` chunk optional.

## Out of scope / follow-ups
- Undici `Dispatcher` typing for `RequestInit` / `WebSocket` / `EventSource` (still `Any`).
- `URLPattern` (URL package), WebCrypto / Performance* (other packages), `stream/consumers` module.

## Test plan
- [x] `haxe build.hxml` (ImportAll + examples) succeeds
- [ ] Spot-check `CompressionStream('brotli')` on Node ≥ 24.7
- [ ] Confirm deprecated Event fields warn as expected under Haxe 4.3+