### PR TITLE
Audit url externs for Node 24 + Haxe 4

### DIFF
--- a/src/js/node/Url.hx
+++ b/src/js/node/Url.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -22,12 +22,15 @@
 
 package js.node;
 
+import haxe.DynamicAccess;
 import haxe.extern.EitherType;
 import js.node.Buffer;
 import js.node.url.URL;
 
 /**
-	The `url` module provides utilities for URL resolution and parsing.
+	The `node:url` module provides utilities for URL resolution and parsing.
+
+	@see https://nodejs.org/api/url.html
 **/
 @:jsRequire("url")
 extern class Url {
@@ -35,6 +38,8 @@ extern class Url {
 		Returns the Punycode ASCII serialization of the `domain`. If `domain` is an invalid domain, the empty string is returned.
 
 		It performs the inverse operation to `url.domainToUnicode()`.
+
+		@see https://nodejs.org/api/url.html#urldomaintoasciidomain
 	**/
 	static function domainToASCII(domain:String):String;
 
@@ -42,31 +47,39 @@ extern class Url {
 		Returns the Unicode serialization of the `domain`. If `domain` is an invalid domain, the empty string is returned.
 
 		It performs the inverse operation to `url.domainToASCII()`.
+
+		@see https://nodejs.org/api/url.html#urldomaintounicodedomain
 	**/
 	static function domainToUnicode(domain:String):String;
 
 	/**
 		This function ensures the correct decodings of percent-encoded characters as well as ensuring a cross-platform valid absolute path string.
+
+		@see https://nodejs.org/api/url.html#urlfileurltopathurl-options
 	**/
 	@:overload(function(url:String, ?options:FileUrlToPathOptions):String {})
-	@:overload(function(url:URL, ?options:FileUrlToPathOptions):String {})
-	@:overload(function(url:String):String {})
-	static function fileURLToPath(url:URL):String;
+	static function fileURLToPath(url:URL, ?options:FileUrlToPathOptions):String;
 
 	/**
 		Like `fileURLToPath` but returns a `Buffer` containing the path.
+		Useful when the input URL contains percent-encoded segments that are not valid UTF-8 / Unicode sequences.
+
+		@see https://nodejs.org/api/url.html#urlfileurltopathbufferurl-options
 	**/
 	@:overload(function(url:String, ?options:FileUrlToPathOptions):Buffer {})
 	static function fileURLToPathBuffer(url:URL, ?options:FileUrlToPathOptions):Buffer;
 
 	/**
-		Returns a customizable serialization of a URL `String` representation of a [WHATWG URL](https://nodejs.org/api/url.html#url_the_whatwg_url_api) object.
+		Returns a customizable serialization of a URL `String` representation of a [WHATWG URL](https://nodejs.org/api/url.html#the-whatwg-url-api) object.
 
-		The URL object has both a `toString()` method and href property that return string serializations of the URL.
+		The URL object has both a `toString()` method and `href` property that return string serializations of the URL.
 		These are not, however, customizable in any way.
 		The `url.format(URL[, options])` method allows for basic customization of the output.
 
-		`format(urlObject:UrlObject)` and `format(urlObject:String)` are deprecated.
+		Legacy `format(urlObject)` / `format(urlString)` overloads remain for compatibility;
+		`format(urlString)` is application-deprecated since Node.js v24 — prefer the WHATWG `URL` API.
+
+		@see https://nodejs.org/api/url.html#urlformaturl-options
 	**/
 	@:overload(function(urlObject:UrlObject):String {})
 	@:overload(function(urlObject:String):String {})
@@ -75,6 +88,8 @@ extern class Url {
 	/**
 		This function ensures that `path` is resolved absolutely,
 		and that the URL control characters are correctly encoded when converting into a File URL.
+
+		@see https://nodejs.org/api/url.html#urlpathtofileurlpath-options
 	**/
 	static function pathToFileURL(path:String, ?options:PathToFileUrlOptions):URL;
 
@@ -88,6 +103,10 @@ extern class Url {
 		If `slashesDenoteHost` is true, the first token after the literal string `//` and preceding the next `/` will be interpreted as the host.
 		For instance, given `//foo/bar`, the result would be `{host: 'foo', pathname: '/bar'}` rather than `{pathname: '//foo/bar'}`.
 		Defaults to false.
+
+		Stability: Deprecated (application deprecation since Node.js v24). Prefer the WHATWG `URL` API.
+
+		@see https://nodejs.org/api/url.html#urlparseurlstring-parsequerystring-slashesdenotehost
 	**/
 	@:deprecated("Use js.node.url.URL instead")
 	static function parse(urlString:String, ?parseQueryString:Bool, ?slashesDenoteHost:Bool):UrlObject;
@@ -102,6 +121,10 @@ extern class Url {
 		resolve('http://example.com/', '/one')    // 'http://example.com/one'
 		resolve('http://example.com/one', '/two') // 'http://example.com/two'
 		```
+
+		Stability: Deprecated. Prefer the WHATWG `URL` API.
+
+		@see https://nodejs.org/api/url.html#urlresolvefrom-to
 	**/
 	@:deprecated("Use js.node.url.URL instead")
 	static function resolve(from:String, to:String):String;
@@ -175,6 +198,11 @@ typedef UrlHttpOptions = {
 	@:optional var auth:String;
 }
 
+/**
+	Options for WHATWG `Url.format(url, options)`.
+
+	@see https://nodejs.org/api/url.html#urlformaturl-options
+**/
 typedef UrlFormatOptions = {
 	/**
 		`true` if the serialized URL string should include the username and password, `false` otherwise.
@@ -208,20 +236,24 @@ typedef UrlFormatOptions = {
 /**
 	Parsed URL objects have some or all of the following fields, depending on whether or not they exist in the URL string.
 	Any parts that are not in the URL string will not be in the parsed object.
+
+	Legacy URL API — prefer `js.node.url.URL`.
+
+	@see https://nodejs.org/api/url.html#legacy-urlobject
 **/
 @:deprecated("Use js.node.url.URL instead")
 typedef UrlObject = {
 	/**
 		The full URL string that was parsed with both the `protocol` and `host` components converted to lower-case.
 
-		For example: 'http://user:pass@host.com:8080/p/a/t/h?query=string#hash'
+		For example: `'http://user:pass@host.com:8080/p/a/t/h?query=string#hash'`
 	**/
 	@:optional var href:String;
 
 	/**
 		The URL's lower-cased protocol scheme.
 
-		For example: 'http:'
+		For example: `'http:'`
 	**/
 	@:optional var protocol:String;
 
@@ -233,7 +265,7 @@ typedef UrlObject = {
 	/**
 		The full lower-cased host portion of the URL, including the `port` if specified.
 
-		For example: 'host.com:8080'
+		For example: `'host.com:8080'`
 	**/
 	@:optional var host:String;
 
@@ -244,21 +276,21 @@ typedef UrlObject = {
 
 		The format of the string is `{username}[:{password}]`, with the `[:{password}]` portion being optional.
 
-		For example: 'user:pass'
+		For example: `'user:pass'`
 	**/
 	@:optional var auth:String;
 
 	/**
 		The lower-cased host name portion of the `host` component without the `port` included.
 
-		For example: 'host.com'
+		For example: `'host.com'`
 	**/
 	@:optional var hostname:String;
 
 	/**
 		The numeric port portion of the `host` component.
 
-		For example: '8080'
+		For example: `'8080'`
 	**/
 	@:optional var port:String;
 
@@ -267,7 +299,7 @@ typedef UrlObject = {
 		before the start of the `query` or `hash` components, delimited by either the ASCII question mark (`?`) or
 		hash (`#`) characters.
 
-		For example '/p/a/t/h'
+		For example `'/p/a/t/h'`
 
 		No decoding of the path string is performed.
 	**/
@@ -276,7 +308,7 @@ typedef UrlObject = {
 	/**
 		The entire "query string" portion of the URL, including the leading ASCII question mark (`?`) character.
 
-		For example: '?query=string'
+		For example: `'?query=string'`
 
 		No decoding of the query string is performed.
 	**/
@@ -285,7 +317,7 @@ typedef UrlObject = {
 	/**
 		Concatenation of the `pathname` and `search` components.
 
-		For example: '/p/a/t/h?query=string'
+		For example: `'/p/a/t/h?query=string'`
 
 		No decoding of the path is performed.
 	**/
@@ -297,21 +329,21 @@ typedef UrlObject = {
 
 		Whether the `query` property is a string or object is determined by the `parseQueryString` argument passed to `Url.parse`.
 
-		For example: 'query=string' or {'query': 'string'}
+		For example: `'query=string'` or `{'query': 'string'}`
 
 		If returned as a string, no decoding of the query string is performed.
 		If returned as an object, both keys and values are decoded.
 
 		The type of this field can be implicitly converted to `String` or `DynamicAccess<String>`,
 		where either one is expected, so if you know the actual type, just assign it
-		to properly typed variable (e.g. var s:String = url.query)
+		to properly typed variable (e.g. `var s:String = url.query`)
 	**/
-	@:optional var query:haxe.extern.EitherType<String, haxe.DynamicAccess<String>>;
+	@:optional var query:EitherType<String, DynamicAccess<String>>;
 
 	/**
 		The "fragment" portion of the URL including the leading ASCII hash (`#`) character.
 
-		For example: '#hash'
+		For example: `'#hash'`
 	**/
 	@:optional var hash:String;
 }
@@ -321,7 +353,8 @@ typedef UrlObject = {
 **/
 typedef FileUrlToPathOptions = {
 	/**
-		`true` if the path should retain Windows-style separators.
+		`true` if the path should be returned as a Windows filepath, `false` for POSIX,
+		and omit / `undefined` for the system default.
 	**/
 	@:optional var windows:Bool;
 }
@@ -331,7 +364,8 @@ typedef FileUrlToPathOptions = {
 **/
 typedef PathToFileUrlOptions = {
 	/**
-		`true` if the path is a Windows path.
+		`true` if the path should be treated as a Windows filepath, `false` for POSIX,
+		and omit / `undefined` for the system default.
 	**/
 	@:optional var windows:Bool;
 }

--- a/src/js/node/url/URL.hx
+++ b/src/js/node/url/URL.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -22,64 +22,108 @@
 
 package js.node.url;
 
+import js.node.web.Blob;
+
 /**
-	Browser-compatible URL class, implemented by following the WHATWG URL Standard.
-	[Examples of parsed URLs](https://url.spec.whatwg.org/#example-url-parsing) may be found in the Standard itself.
+	Browser-compatible `URL` class, implemented by following the WHATWG URL Standard.
+	Examples of parsed URLs may be found in the Standard itself.
+	The `URL` class is also available on the global object.
+
+	@see https://nodejs.org/api/url.html#class-url
+	@see https://url.spec.whatwg.org/#example-url-parsing
 **/
 @:jsRequire("url", "URL")
 extern class URL {
 	/**
 		Creates a new `URL` object by parsing the `input` relative to the `base`.
 		If `base` is passed as a string, it will be parsed equivalent to `new URL(base)`.
+
+		@see https://nodejs.org/api/url.html#new-urlinput-base
 	**/
 	@:overload(function(input:String, ?base:URL):Void {})
 	function new(input:String, ?base:String):Void;
 
 	/**
 		Checks whether `input` can be successfully parsed as a URL relative to `base`.
+
+		@see https://nodejs.org/api/url.html#urlcanparseinput-base
 	**/
 	@:overload(function(input:String, ?base:URL):Bool {})
 	static function canParse(input:String, ?base:String):Bool;
 
 	/**
 		Parses `input` relative to `base` into a `URL` object, or returns `null` on failure.
+
+		@see https://nodejs.org/api/url.html#urlparseinput-base
 	**/
 	@:overload(function(input:String, ?base:URL):Null<URL> {})
 	static function parse(input:String, ?base:String):Null<URL>;
 
 	/**
+		Creates a `'blob:nodedata:...'` URL string that represents the given `Blob` and can
+		be used to retrieve it later (e.g. via `js.node.buffer.Buffer.resolveObjectURL`).
+
+		The data is retained in memory until `revokeObjectURL` is called.
+
+		@see https://nodejs.org/api/url.html#urlcreateobjecturlblob
+	**/
+	static function createObjectURL(blob:Blob):String;
+
+	/**
+		Removes the `Blob` object identified by a prior `createObjectURL` id.
+		Attempting to revoke an unregistered id silently fails.
+
+		@see https://nodejs.org/api/url.html#urlrevokeobjecturlid
+	**/
+	static function revokeObjectURL(id:String):Void;
+
+	/**
 		Gets and sets the fragment portion of the URL.
+
+		@see https://nodejs.org/api/url.html#urlhash
 	**/
 	var hash:String;
 
 	/**
 		Gets and sets the host portion of the URL.
+
+		@see https://nodejs.org/api/url.html#urlhost
 	**/
 	var host:String;
 
 	/**
-		Gets and sets the hostname portion of the URL
+		Gets and sets the hostname portion of the URL.
 		The key difference between `url.host` and `url.hostname` is that `url.hostname` does not include the port.
+
+		@see https://nodejs.org/api/url.html#urlhostname
 	**/
 	var hostname:String;
 
 	/**
 		Gets and sets the serialized URL.
+
+		@see https://nodejs.org/api/url.html#urlhref
 	**/
 	var href:String;
 
 	/**
 		Gets the read-only serialization of the URL's origin.
+
+		@see https://nodejs.org/api/url.html#urlorigin
 	**/
 	var origin(default, null):String;
 
 	/**
 		Gets and sets the password portion of the URL.
+
+		@see https://nodejs.org/api/url.html#urlpassword
 	**/
 	var password:String;
 
 	/**
 		Gets and sets the path portion of the URL.
+
+		@see https://nodejs.org/api/url.html#urlpathname
 	**/
 	var pathname:String;
 
@@ -88,28 +132,37 @@ extern class URL {
 
 		The port value may be a number or a string containing a number in the range `0` to `65535` (inclusive).
 		Setting the value to the default port of the `URL` objects given `protocol` will result in the port value becoming the empty string (`''`).
+
+		@see https://nodejs.org/api/url.html#urlport
 	**/
 	var port:String;
 
 	/**
 		Gets and sets the protocol portion of the URL.
+
+		@see https://nodejs.org/api/url.html#urlprotocol
 	**/
 	var protocol:String;
 
 	/**
 		Gets and sets the serialized query portion of the URL.
+
+		@see https://nodejs.org/api/url.html#urlsearch
 	**/
 	var search:String;
 
 	/**
 		Gets the `URLSearchParams` object representing the query parameters of the URL.
 		This property is read-only; to replace the entirety of query parameters of the URL, use the `url.search` setter.
-		See [URLSearchParams](https://nodejs.org/api/url.html#url_class_urlsearchparams) documentation for details.
+
+		@see https://nodejs.org/api/url.html#urlsearchparams
 	**/
 	var searchParams(default, null):URLSearchParams;
 
 	/**
 		Gets and sets the username portion of the URL.
+
+		@see https://nodejs.org/api/url.html#urlusername
 	**/
 	var username:String;
 
@@ -118,7 +171,9 @@ extern class URL {
 		The value returned is equivalent to that of `url.href` and `url.toJSON()`.
 
 		Because of the need for standard compliance, this method does not allow users to customize the serialization process of the URL.
-		For more flexibility, `require('url').format()` method might be of interest.
+		For more flexibility, `js.node.Url.format` might be of interest.
+
+		@see https://nodejs.org/api/url.html#urltostring
 	**/
 	function toString():String;
 
@@ -127,6 +182,8 @@ extern class URL {
 		The value returned is equivalent to that of `url.href` and `url.toString()`.
 
 		This method is automatically called when an `URL` object is serialized with `JSON.stringify()`.
+
+		@see https://nodejs.org/api/url.html#urltojson
 	**/
 	function toJSON():String;
 }

--- a/src/js/node/url/URLPattern.hx
+++ b/src/js/node/url/URLPattern.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -22,34 +22,100 @@
 
 package js.node.url;
 
+import haxe.DynamicAccess;
 import haxe.extern.EitherType;
 
 /**
-	The `URLPattern` API provides pattern matching for URLs.
+	The `URLPattern` API provides an interface to match URLs or parts of URLs against a pattern.
+
+	Stability: Experimental (Node.js Stability 1).
 
 	@see https://nodejs.org/api/url.html#class-urlpattern
 **/
 @:jsRequire("url", "URLPattern")
 extern class URLPattern {
+	/**
+		Instantiate a new `URLPattern` from a URL string or pattern init object.
+		When `baseURL` is provided, relative patterns are resolved against it.
+		`options.ignoreCase` enables case-insensitive matching when `true`.
+
+		The constructor can throw a `TypeError` to indicate parsing failure.
+
+		@see https://nodejs.org/api/url.html#new-urlpatternstring-baseurl-options
+		@see https://nodejs.org/api/url.html#new-urlpatternobj-baseurl-options
+	**/
 	@:overload(function(input:EitherType<String, URLPatternInit>, baseURL:String, ?options:URLPatternOptions):Void {})
 	function new(?input:EitherType<String, URLPatternInit>, ?options:URLPatternOptions):Void;
 
+	/**
+		Whether the pattern contains any regular-expression capturing groups.
+	**/
 	final hasRegExpGroups:Bool;
+
+	/**
+		Pattern for the URL hash (fragment) component.
+	**/
 	final hash:String;
+
+	/**
+		Pattern for the URL hostname component.
+	**/
 	final hostname:String;
+
+	/**
+		Pattern for the URL password component.
+	**/
 	final password:String;
+
+	/**
+		Pattern for the URL pathname component.
+	**/
 	final pathname:String;
+
+	/**
+		Pattern for the URL port component.
+	**/
 	final port:String;
+
+	/**
+		Pattern for the URL protocol component.
+	**/
 	final protocol:String;
+
+	/**
+		Pattern for the URL search (query) component.
+	**/
 	final search:String;
+
+	/**
+		Pattern for the URL username component.
+	**/
 	final username:String;
 
+	/**
+		Returns match details when `input` matches this pattern, or `null` otherwise.
+		`input` may be a URL string or an object providing individual URL parts.
+		If `baseURL` is omitted it defaults to `undefined`.
+
+		@see https://nodejs.org/api/url.html#urlpatternexecinput-baseurl
+	**/
 	function exec(?input:EitherType<String, URLPatternInit>, ?baseURL:String):Null<URLPatternResult>;
+
+	/**
+		Returns `true` if `input` matches this pattern.
+		`input` may be a URL string or an object providing individual URL parts.
+		If `baseURL` is omitted it defaults to `undefined`.
+
+		@see https://nodejs.org/api/url.html#urlpatterntestinput-baseurl
+	**/
 	function test(?input:EitherType<String, URLPatternInit>, ?baseURL:String):Bool;
 }
 
 /**
-	Initialization object for `URLPattern`.
+	Initialization object for `URLPattern` construction / matching.
+
+	Members may be any of `protocol`, `username`, `password`, `hostname`, `port`,
+	`pathname`, `search`, `hash`, or `baseURL`.
 **/
 typedef URLPatternInit = {
 	@:optional var protocol:String;
@@ -67,14 +133,21 @@ typedef URLPatternInit = {
 	Options for `URLPattern`.
 **/
 typedef URLPatternOptions = {
+	/**
+		When `true`, enables case-insensitive matching.
+	**/
 	@:optional var ignoreCase:Bool;
 }
 
 /**
-	Result of `URLPattern.exec`.
+	Result of a successful `URLPattern.exec` call.
 **/
 typedef URLPatternResult = {
+	/**
+		The arguments passed into `exec`.
+	**/
 	var inputs:Array<EitherType<String, URLPatternInit>>;
+
 	var protocol:URLPatternComponentResult;
 	var username:URLPatternComponentResult;
 	var password:URLPatternComponentResult;
@@ -89,6 +162,13 @@ typedef URLPatternResult = {
 	A single URL component match result.
 **/
 typedef URLPatternComponentResult = {
+	/**
+		The matched input for this component.
+	**/
 	var input:String;
-	var groups:haxe.DynamicAccess<Null<String>>;
+
+	/**
+		Named / numbered capture groups for this component.
+	**/
+	var groups:DynamicAccess<Null<String>>;
 }

--- a/src/js/node/url/URLSearchParams.hx
+++ b/src/js/node/url/URLSearchParams.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -31,10 +31,16 @@ import js.node.Iterator;
 	The `URLSearchParams` class is also available on the global object.
 
 	The WHATWG `URLSearchParams` interface and the `querystring` module have similar purpose,
-	but the purpose of the querystring module is more general, as it allows the customization of delimiter characters (`&` and` `=`). On the other hand, this API is designed purely for URL query strings.
+	but the purpose of the querystring module is more general, as it allows the customization of
+	delimiter characters (`&` and `=`). On the other hand, this API is designed purely for URL query strings.
+
+	@see https://nodejs.org/api/url.html#class-urlsearchparams
 **/
 @:jsRequire("url", "URLSearchParams")
 extern class URLSearchParams {
+	/**
+		@see https://nodejs.org/api/url.html#new-urlsearchparams
+	**/
 	@:overload(function(init:String):Void {})
 	@:overload(function(obj:DynamicAccess<String>):Void {})
 	@:overload(function(array:Array<URLSearchParamsEntry>):Void {})
@@ -42,24 +48,43 @@ extern class URLSearchParams {
 	function new():Void;
 
 	/**
+		The total number of parameter entries.
+
+		@see https://nodejs.org/api/url.html#urlsearchparamssize
+	**/
+	var size(default, null):Int;
+
+	/**
 		Append a new name-value pair to the query string.
+
+		@see https://nodejs.org/api/url.html#urlsearchparamsappendname-value
 	**/
 	function append(name:String, value:String):Void;
 
 	/**
-		Remove all name-value pairs whose name is `name`.
+		If `value` is provided, removes all name-value pairs where name is `name` and value is `value`.
+		Otherwise, removes all name-value pairs whose name is `name`.
+
+		@see https://nodejs.org/api/url.html#urlsearchparamsdeletename-value
 	**/
+	@:overload(function(name:String, value:String):Void {})
 	function delete(name:String):Void;
 
 	/**
 		Returns an ES6 `Iterator` over each of the name-value pairs in the query.
 		Each item of the iterator is a JavaScript `Array`.
 		The first item of the `Array` is the `name`, the second item of the `Array` is the `value`.
+
+		Alias for `urlSearchParams[Symbol.iterator]()`.
+
+		@see https://nodejs.org/api/url.html#urlsearchparamsentries
 	**/
 	function entries():Iterator<URLSearchParamsEntry>;
 
 	/**
 		Iterates over each name-value pair in the query and invokes the given function.
+
+		@see https://nodejs.org/api/url.html#urlsearchparamsforeachfn-thisarg
 	**/
 	@:overload(function(fn:(value:String) -> Void, ?thisArg:Any):Void {})
 	@:overload(function(fn:(value:String, name:String) -> Void, ?thisArg:Any):Void {})
@@ -68,22 +93,32 @@ extern class URLSearchParams {
 	/**
 		Returns the value of the first name-value pair whose name is `name`.
 		If there are no such pairs, `null` is returned.
+
+		@see https://nodejs.org/api/url.html#urlsearchparamsgetname
 	**/
-	function get(name:String):String;
+	function get(name:String):Null<String>;
 
 	/**
 		Returns the values of all name-value pairs whose name is `name`.
 		If there are no such pairs, an empty array is returned.
+
+		@see https://nodejs.org/api/url.html#urlsearchparamsgetallname
 	**/
 	function getAll(name:String):Array<String>;
 
 	/**
-		Returns `true` if there is at least one name-value pair whose name is `name`.
+		If `value` is provided, returns `true` when a name-value pair with the same `name` and `value` exists.
+		Otherwise, returns `true` if there is at least one name-value pair whose name is `name`.
+
+		@see https://nodejs.org/api/url.html#urlsearchparamshasname-value
 	**/
+	@:overload(function(name:String, value:String):Bool {})
 	function has(name:String):Bool;
 
 	/**
 		Returns an ES6 `Iterator` over the names of each name-value pair.
+
+		@see https://nodejs.org/api/url.html#urlsearchparamskeys
 	**/
 	function keys():Iterator<String>;
 
@@ -91,24 +126,33 @@ extern class URLSearchParams {
 		Sets the value in the `URLSearchParams` object associated with `name` to `value`.
 		If there are any pre-existing name-value pairs whose names are `name`, set the first such pair's value to `value` and remove all others.
 		If not, append the name-value pair to the query string.
+
+		@see https://nodejs.org/api/url.html#urlsearchparamssetname-value
 	**/
 	function set(name:String, value:String):Void;
 
 	/**
-		Sort all existing name-value pairs in-place by their names. Sorting is done with a [stable sorting algorithm](https://en.wikipedia.org/wiki/Sorting_algorithm#Stability),
+		Sort all existing name-value pairs in-place by their names. Sorting is done with a
+		[stable sorting algorithm](https://en.wikipedia.org/wiki/Sorting_algorithm#Stability),
 		so relative order between name-value pairs with the same name is preserved.
 
 		This method can be used, in particular, to increase cache hits.
+
+		@see https://nodejs.org/api/url.html#urlsearchparamssort
 	**/
 	function sort():Void;
 
 	/**
 		Returns the search parameters serialized as a string, with characters percent-encoded where necessary.
+
+		@see https://nodejs.org/api/url.html#urlsearchparamstostring
 	**/
 	function toString():String;
 
 	/**
 		Returns an ES6 `Iterator` over the values of each name-value pair.
+
+		@see https://nodejs.org/api/url.html#urlsearchparamsvalues
 	**/
 	function values():Iterator<String>;
 }


### PR DESCRIPTION
## Summary
- Fill remaining Node.js 24 `url` gaps: `URL.createObjectURL` / `URL.revokeObjectURL`, `URLSearchParams.size`, and optional `value` on `delete` / `has`.
- Tighten types (`get` → `Null<String>`, Blob-typed object URLs) and refresh module docs / `@see` links.
- Bump copyright headers to 2014–2026 across `Url.hx` and `js.node.url.*`.

## Test plan
- [x] `haxe build.hxml` (Haxe 5.0.0-preview.1)
- [x] Spot-checked against Node.js v24.18.0 `url` docs / runtime exports


Made with [Cursor](https://cursor.com)