### PR TITLE
Audit async_hooks externs for Node 24 / Haxe 4

### DIFF
--- a/src/js/node/AsyncHooks.hx
+++ b/src/js/node/AsyncHooks.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -22,11 +22,14 @@
 
 package js.node;
 
+import haxe.DynamicAccess;
+
 /**
 	The `async_hooks` module provides an API to track asynchronous resources.
 
-	Prefer `js.node.async_hooks.AsyncLocalStorage` for most application-level async context tracking.
-	`createHook` remains available but is a lower-level / less recommended API.
+	Stability: 1 - Experimental for `createHook` / `AsyncHook` / `executionAsyncResource`.
+	Prefer `js.node.async_hooks.AsyncLocalStorage` for async context tracking, or
+	`js.node.DiagnosticsChannel` for diagnostics data.
 
 	@see https://nodejs.org/docs/latest-v24.x/api/async_hooks.html
 **/
@@ -34,54 +37,79 @@ package js.node;
 extern class AsyncHooks {
 	/**
 		Registers functions to be called for different lifetime events of each async operation.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/async_hooks.html#async_hookscreatehookoptions
 	**/
 	static function createHook(options:AsyncHookOptions):js.node.async_hooks.AsyncHook;
 
 	/**
 		Returns the `asyncId` of the current execution context.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/async_hooks.html#async_hooksexecutionasyncid
 	**/
 	static function executionAsyncId():Float;
 
 	/**
 		Returns the resource object associated with the topmost async frame.
 		Using undocumented handle APIs on the returned object may crash the process.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/async_hooks.html#async_hooksexecutionasyncresource
 	**/
-	// TODO(section-5): type executionAsyncResource beyond Dynamic when handle shapes are modeled
 	static function executionAsyncResource():Dynamic;
 
 	/**
 		Returns the `asyncId` of the resource that caused (or "triggered") the current execution.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/async_hooks.html#async_hookstriggerasyncid
 	**/
 	static function triggerAsyncId():Float;
+
+	/**
+		Map of provider type names to numeric ids used by `async_hooks` init events.
+		Replaces the deprecated `process.binding('async_wrap').Providers` API.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/async_hooks.html#async_hooksasyncwrapproviders
+	**/
+	static final asyncWrapProviders:DynamicAccess<Int>;
 }
 
 /**
 	Callbacks for `AsyncHooks.createHook`.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/async_hooks.html#hook-callbacks
 **/
 typedef AsyncHookOptions = {
 	/**
 		Called during object construction when the resource is initialized.
-		// TODO(section-5): type resource beyond Dynamic
+		The `resource` argument is the internal handle; its shape is undocumented.
 	**/
-	@:optional var init:Float->String->Float->Dynamic->Void;
+	@:optional var init:(asyncId:Float, type:String, triggerAsyncId:Float, resource:Dynamic) -> Void;
 
 	/**
 		Called just before the resource's callback is called.
 	**/
-	@:optional var before:Float->Void;
+	@:optional var before:(asyncId:Float) -> Void;
 
 	/**
 		Called immediately after the resource's callback has completed.
 	**/
-	@:optional var after:Float->Void;
+	@:optional var after:(asyncId:Float) -> Void;
 
 	/**
 		Called after the resource is destroyed.
 	**/
-	@:optional var destroy:Float->Void;
+	@:optional var destroy:(asyncId:Float) -> Void;
 
 	/**
 		Called when the Promise-related callback is resolved.
 	**/
-	@:optional var promiseResolve:Float->Void;
+	@:optional var promiseResolve:(asyncId:Float) -> Void;
+
+	/**
+		Whether the hook should track `Promise`s.
+		Cannot be `false` if `promiseResolve` is set. Default: `true`.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/async_hooks.html#disabling-promise-execution-tracking
+	**/
+	@:optional var trackPromises:Bool;
 }

--- a/src/js/node/async_hooks/AsyncHook.hx
+++ b/src/js/node/async_hooks/AsyncHook.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -23,16 +23,25 @@
 package js.node.async_hooks;
 
 /**
-	The callbacks registered via `AsyncHooks.createHook` return an `AsyncHook` instance.
+	Instance returned by `AsyncHooks.createHook`, used to enable or disable hook callbacks.
+
+	Stability: 1 - Experimental. Prefer `AsyncLocalStorage` for async context tracking.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/async_hooks.html#class-asynchook
 **/
 extern class AsyncHook {
 	/**
 		Enable the callbacks for a given `AsyncHook` instance.
+		Hooks are disabled by default after creation.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/async_hooks.html#asynchookenable
 	**/
 	function enable():AsyncHook;
 
 	/**
 		Disable the callbacks for a given `AsyncHook` instance.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/async_hooks.html#asynchookdisable
 	**/
 	function disable():AsyncHook;
 }

--- a/src/js/node/async_hooks/AsyncLocalStorage.hx
+++ b/src/js/node/async_hooks/AsyncLocalStorage.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -23,31 +23,105 @@
 package js.node.async_hooks;
 
 import haxe.Constraints.Function;
+import haxe.extern.Rest;
 
 /**
-	Async local storage stores shared context across callbacks / promise chains.
+	Creates stores that stay coherent through asynchronous operations.
 
-	@see https://nodejs.org/docs/latest-v24.x/api/async_hooks.html#class-asynclocalstorage
+	Stability: 2 - Stable. Preferred API for async context tracking over `createHook`.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/async_context.html#class-asynclocalstorage
 **/
 @:jsRequire("async_hooks", "AsyncLocalStorage")
 extern class AsyncLocalStorage<T> {
-	function new():Void;
+	/**
+		Creates a new instance of `AsyncLocalStorage`.
+		Store is only provided within a `run()` call or after an `enterWith()` call.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/async_context.html#new-asynclocalstorageoptions
+	**/
+	function new(?options:AsyncLocalStorageOptions<T>);
+
+	/**
+		The name of the `AsyncLocalStorage` instance if provided via options.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/async_context.html#asynclocalstoragename
+	**/
+	final name:String;
 
 	/**
 		Runs a function synchronously within a context and returns its return value.
-		// TODO(section-5): model variadic args without Rest for broader Haxe 4.0.x coverage
-	**/
-	function run<R>(store:T, callback:Function, ?args:Array<Dynamic>):R;
+		Optional `args` are passed to the callback.
 
+		@see https://nodejs.org/docs/latest-v24.x/api/async_context.html#asynclocalstoragerunstore-callback-args
+	**/
+	function run<R>(store:T, callback:Function, args:Rest<Dynamic>):R;
+
+	/**
+		Transitions into the context for the remainder of the current synchronous
+		execution and then persists the store through following asynchronous calls.
+
+		Stability: 1 - Experimental. Prefer `run()` when possible.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/async_context.html#asynclocalstorageenterwithstore
+	**/
 	function enterWith(store:T):Void;
 
-	function exit<R>(callback:Function, ?args:Array<Dynamic>):R;
+	/**
+		Runs a function synchronously outside of a context and returns its return value.
 
+		Stability: 1 - Experimental.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/async_context.html#asynclocalstorageexitcallback-args
+	**/
+	function exit<R>(callback:Function, args:Rest<Dynamic>):R;
+
+	/**
+		Returns the current store, or `null`/`undefined` outside of an initialized context.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/async_context.html#asynclocalstoragegetstore
+	**/
 	function getStore():Null<T>;
 
+	/**
+		Disables this `AsyncLocalStorage` instance. Required before the instance
+		can be garbage collected when no longer in use.
+
+		Stability: 1 - Experimental.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/async_context.html#asynclocalstoragedisable
+	**/
 	function disable():Void;
 
+	/**
+		Binds the given function to the current execution context.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/async_context.html#asynclocalstoragebindfn
+	**/
 	static function bind<F:Function>(fn:F):F;
 
+	/**
+		Captures the current execution context and returns a function that runs
+		a callback within that captured context.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/async_context.html#asynclocalstoragesnapshot
+	**/
 	static function snapshot():Function;
+}
+
+/**
+	Options for `AsyncLocalStorage` construction.
+
+	`defaultValue` and `name` were added in Node.js 24.0.0.
+**/
+typedef AsyncLocalStorageOptions<T> = {
+	/**
+		The default value used when no store is provided.
+	**/
+	@:optional var defaultValue:T;
+
+	/**
+		A name for the `AsyncLocalStorage` value.
+	**/
+	@:optional var name:String;
 }

--- a/src/js/node/async_hooks/AsyncResource.hx
+++ b/src/js/node/async_hooks/AsyncResource.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,62 +24,88 @@ package js.node.async_hooks;
 
 import haxe.Constraints.Function;
 import haxe.extern.EitherType;
+import haxe.extern.Rest;
 
 /**
-	The class `AsyncResource` is designed to be extended by the embedder's async resources.
-	Using this, users can easily trigger the lifetime events of their own resources.
+	Designed to be extended by embedders' async resources so users can
+	trigger the lifetime events of their own resources.
 
-	@see https://nodejs.org/docs/latest-v24.x/api/async_hooks.html#class-asyncresource
+	Stability: 2 - Stable.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/async_context.html#class-asyncresource
 **/
 @:jsRequire("async_hooks", "AsyncResource")
 extern class AsyncResource {
 	/**
 		Create a new `AsyncResource` object.
+		Instantiating also triggers the `init` hook.
+		If `triggerAsyncId` is omitted, `executionAsyncId()` is used.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/async_context.html#new-asyncresourcetype-options
 	**/
 	function new(type:String, ?options:EitherType<Float, AsyncResourceOptions>);
 
 	/**
-		Call the provided function with the provided arguments in the execution context of the async resource.
-		// TODO(section-5): type Rest args more precisely when binding helpers are standardized
+		Call the provided function with the provided arguments in the execution
+		context of the async resource.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/async_context.html#asyncresourceruninasyncscopefn-thisarg-args
 	**/
-	function runInAsyncScope(fn:Function, ?thisArg:Dynamic, ?args:Array<Dynamic>):Dynamic;
+	function runInAsyncScope(fn:Function, ?thisArg:Dynamic, args:Rest<Dynamic>):Dynamic;
 
 	/**
-		Call `AsyncHooks.emitDestroy()` after binding / pending work is finished.
+		Call all `destroy` hooks. Must be called manually exactly once;
+		an error is thrown if called more than once.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/async_context.html#asyncresourceemitdestroy
 	**/
 	function emitDestroy():AsyncResource;
 
 	/**
 		Returns the unique `asyncId` assigned to the resource.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/async_context.html#asyncresourceasyncid
 	**/
 	function asyncId():Float;
 
 	/**
 		Returns the trigger `asyncId` of the resource.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/async_context.html#asyncresourcetriggerasyncid
 	**/
 	function triggerAsyncId():Float;
 
 	/**
-		Binds the given function to execute within this async resource's stack.
+		Binds the given function to execute within this async resource's scope.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/async_context.html#asyncresourcebindfn-thisarg
 	**/
 	function bind(fn:Function, ?thisArg:Dynamic):Function;
 
 	/**
-		Binds the given function to execute within a given execution context of an async resource.
+		Binds the given function to the current execution context.
+		`type` is an optional name associated with the underlying `AsyncResource`.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/async_context.html#asyncresourcebindfn-type-thisarg
 	**/
 	@:native("bind")
-	static function bindStatic(fn:Function, type:EitherType<String, AsyncResource>, ?thisArg:Dynamic):Function;
+	static function bindStatic(fn:Function, ?type:String, ?thisArg:Dynamic):Function;
 }
 
+/**
+	Options for `AsyncResource` construction.
+**/
 typedef AsyncResourceOptions = {
 	/**
-		The ID of the execution context that created this async event. Default: `executionAsyncId()`.
+		The ID of the execution context that created this async event.
+		Default: `executionAsyncId()`.
 	**/
 	@:optional var triggerAsyncId:Float;
 
 	/**
 		Disables automatic `emitDestroy` when the object is garbage collected.
-		This usually means the resource has to manually call `emitDestroy()`. Default: `false`.
+		This usually means the resource has to manually call `emitDestroy()`.
+		Default: `false`.
 	**/
 	@:optional var requireManualDestroy:Bool;
 }


### PR DESCRIPTION
## Summary
- Align `async_hooks` / async context externs with Node.js 24: `asyncWrapProviders`, `createHook` `trackPromises`, and `AsyncLocalStorage` constructor options (`defaultValue`, `name`).
- Haxe 4 modernization: named-argument hook callback types, `final` for immutable module/instance fields, `Rest` for variadic `run` / `exit` / `runInAsyncScope`, typed `AsyncLocalStorageOptions<T>`.
- Refresh docs/`@see` links (including moved `async_context` pages) and copyright years through 2026; tighten `AsyncResource.bind` static signature to optional `type:String`.

## Test plan
- [ ] Spot-check against https://nodejs.org/docs/latest-v24.x/api/async_hooks.html and https://nodejs.org/docs/latest-v24.x/api/async_context.html
- [ ] Confirm existing callers of `AsyncLocalStorage` / `AsyncResource` / `Channel.bindStore` still type-check
- [ ] Optional: compile a tiny sample using `createHook({ trackPromises: false })` and `new AsyncLocalStorage({ name: "x" })`


Made with [Cursor](https://cursor.com)