### PR TITLE
Audit dns / dns/promises for Node 24 and Haxe 4

### DIFF
--- a/src/js/node/Dns.hx
+++ b/src/js/node/Dns.hx
@@ -305,10 +305,25 @@ typedef DnsAnyRecord = EitherType<DnsAnyARecord,
 									EitherType<DnsAnySrvRecord, EitherType<DnsAnyTlsaRecord, DnsAnyTxtRecord>>>>>>>>>>>;
 
 typedef DnsResolvedAddress = EitherType<String,
-	EitherType<DnsResolvedAddressMX,
-		EitherType<DnsResolvedAddressSOA,
-			EitherType<DnsResolvedAddressSRV,
-				EitherType<DnsResolvedAddressCAA, EitherType<DnsResolvedAddressNAPTR, DnsResolvedAddressTLSA>>>>>>;
+	EitherType<Array<String>,
+		EitherType<DnsResolvedAddressMX,
+			EitherType<DnsResolvedAddressSOA,
+				EitherType<DnsResolvedAddressSRV,
+					EitherType<DnsResolvedAddressCAA, EitherType<DnsResolvedAddressNAPTR, DnsResolvedAddressTLSA>>>>>>>;
+
+/**
+	Records returned by `Dns.resolve` / `DnsPromises.resolve`, depending on `rrtype`.
+	Note: `SOA` resolves to a single object (not an array); `TXT` resolves to `Array<Array<String>>`.
+**/
+typedef DnsResolveRecords = EitherType<Array<String>,
+	EitherType<Array<DnsAnyRecord>,
+		EitherType<Array<DnsResolvedAddressCAA>,
+			EitherType<Array<DnsResolvedAddressMX>,
+				EitherType<Array<DnsResolvedAddressNAPTR>,
+					EitherType<DnsResolvedAddressSOA,
+						EitherType<Array<DnsResolvedAddressSRV>,
+							EitherType<Array<DnsResolvedAddressTLSA>,
+								EitherType<Array<Array<String>>, Array<DnsResolvedAddress>>>>>>>>>>;
 
 /**
 	Error objects returned by dns lookups are of this type
@@ -507,6 +522,7 @@ extern class Dns {
 		`lookup` doesn't necessarily have anything to do with the DNS protocol. It's only an operating system facility
 		that can associate name with addresses, and vice versa.
 	**/
+	@:overload(function(hostname:String, options:DnsLookupAllOptions, callback:DnsLookupCallbackAll):Void {})
 	@:overload(function(hostname:String, options:EitherType<DnsAddressFamily, DnsLookupOptions>,
 		callback:EitherType<DnsLookupCallbackSingle, DnsLookupCallbackAll>):Void {})
 	static function lookup(hostname:String, callback:DnsLookupCallbackSingle):Void;
@@ -546,16 +562,17 @@ extern class Dns {
 	static function lookupService(address:String, port:Int, callback:DnsLookupServiceCallback):Void;
 
 	/**
-		Resolves a `hostname` (e.g. `'google.com'`) into an array of the record types specified by `rrtype`.
+		Resolves a `hostname` (e.g. `'google.com'`) into the record types specified by `rrtype` (default `'A'`).
 
-		The `callback` has arguments `(err, addresses)`.
-		The type of each item in `addresses` is determined by the record type,
+		The `callback` has arguments `(err, records)`.
+		The type of `records` is determined by the record type,
 		and described in the documentation for the corresponding lookup methods below.
+		In particular, `SOA` yields a single object and `TXT` yields `Array<Array<String>>`.
 
 		On error, `err` is an `Error` object, where `err.code` is the error code.
 	**/
-	@:overload(function(hostname:String, callback:DnsResolveCallback<Array<DnsResolvedAddress>>):Void {})
-	static function resolve(hostname:String, rrtype:DnsRrtype, callback:DnsResolveCallback<Array<DnsResolvedAddress>>):Void;
+	@:overload(function(hostname:String, callback:DnsResolveCallback<Array<String>>):Void {})
+	static function resolve(hostname:String, rrtype:DnsRrtype, callback:DnsResolveCallback<DnsResolveRecords>):Void;
 
 	/**
 		The same as `resolve`, but only for IPv4 queries (A records).

--- a/src/js/node/Dns.hx
+++ b/src/js/node/Dns.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -28,9 +28,14 @@ import js.lib.ArrayBuffer;
 import js.lib.Error;
 
 /**
-	Enumeration of possible Int `options` values for `Dns.lookup`.
+	Enumeration of possible Int `options` / callback `family` values for `Dns.lookup`.
 **/
 enum abstract DnsAddressFamily(Int) from Int to Int {
+	/**
+		Either an IPv4 or IPv6 address may be returned (default when omitted).
+		Also used in lookup results when the address is not IPv4/IPv6.
+	**/
+	var Unspecified = 0;
 	var IPv4 = 4;
 	var IPv6 = 6;
 }
@@ -82,6 +87,7 @@ typedef DnsLookupOptions = {
 
 		Deprecated in favor of `order`. When both are specified, `order` has higher precedence.
 	**/
+	@:deprecated("Use order instead")
 	@:optional var verbatim:Bool;
 }
 
@@ -440,13 +446,26 @@ extern enum abstract DnsErrorCode(String) {
 	var CANCELLED;
 }
 
-typedef DnsLookupCallbackSingle = (err:DnsError, address:String,
-		family:DnsAddressFamily) -> Void;
+typedef DnsLookupCallbackSingle = (err:DnsError, address:String, family:DnsAddressFamily) -> Void;
 
-typedef DnsLookupCallbackAll = (err:DnsError,
-		addresses:Array<DnsLookupCallbackAllEntry>) -> Void;
+typedef DnsLookupCallbackAll = (err:DnsError, addresses:Array<DnsLookupCallbackAllEntry>) -> Void;
 
-typedef DnsLookupCallbackAllEntry = {address:String, family:DnsAddressFamily};
+typedef DnsLookupCallbackAllEntry = {
+	var address:String;
+	var family:DnsAddressFamily;
+};
+
+/**
+	`Dns.lookup` / `DnsPromises.lookup` options with `all: true`.
+**/
+typedef DnsLookupAllOptions = {
+	> DnsLookupOptions,
+	var all:Bool;
+};
+
+typedef DnsLookupServiceCallback = (err:DnsError, hostname:String, service:String) -> Void;
+
+typedef DnsResolveCallback<T> = (err:DnsError, records:T) -> Void;
 
 /**
 	This module contains functions that belong to two different categories:
@@ -467,21 +486,22 @@ typedef DnsLookupCallbackAllEntry = {address:String, family:DnsAddressFamily};
 @:jsRequire("dns")
 extern class Dns {
 	/**
-		Resolves a `hostname` (e.g. 'google.com') into the first found A (IPv4) or AAAA (IPv6) record.
+		Resolves a `hostname` (e.g. `'google.com'`) into the first found A (IPv4) or AAAA (IPv6) record.
 
-		If `options` is not provided, then IP v4 and v6 addresses are both valid.
+		If `options` is not provided, then either IPv4 or IPv6 addresses, or both, are returned if found.
 
-		The `family` can be the integer 4 or 6. Defaults to null that indicates both Ip v4 and v6 address family.
+		The `family` can be `4`, `6`, or `0` (either). String forms `'IPv4'` / `'IPv6'` are also accepted.
+		Defaults to `0`.
 
-		The `callback` has arguments (err, address, family).
-		The `address` argument is a string representation of a IP v4 or v6 address.
-		The `family` argument is either the integer 4 or 6 and denotes the family
-		of address (not necessarily the value initially passed to lookup).
+		The `callback` has arguments `(err, address, family)`.
+		The `address` argument is a string representation of an IPv4 or IPv6 address.
+		The `family` argument is `4` or `6` and denotes the family of `address`
+		(not necessarily the value initially passed to lookup), or `0` if the address is not IPv4/IPv6.
 
-		With the `all` option set, the arguments change to (err, addresses), with addresses being an array of objects
+		With the `all` option set, the arguments change to `(err, addresses)`, with addresses being an array of objects
 		with the properties `address` and `family`.
 
-		Keep in mind that `err.code` will be set to 'ENOENT' not only when the hostname does not exist but
+		Keep in mind that `err.code` will be set to `'ENOTFOUND'` not only when the hostname does not exist but
 		also when the lookup fails in other ways such as no available file descriptors.
 
 		`lookup` doesn't necessarily have anything to do with the DNS protocol. It's only an operating system facility
@@ -498,7 +518,7 @@ extern class Dns {
 		For example, IPv4 addresses are only returned if the current system has at least one IPv4 address configured.
 		Loopback addresses are not considered.
 	**/
-	static var ADDRCONFIG(default, null):Int;
+	static final ADDRCONFIG:Int;
 
 	/**
 		A flag passed in the `hints` argument of `lookup` method.
@@ -506,46 +526,46 @@ extern class Dns {
 		If the IPv6 family was specified, but no IPv6 addresses were found, then return IPv4 mapped IPv6 addresses.
 		Note that it is not supported on some operating systems (e.g FreeBSD 10.1).
 	**/
-	static var V4MAPPED(default, null):Int;
+	static final V4MAPPED:Int;
 
 	/**
 		A flag passed in the `hints` argument of `lookup` method.
 
 		If `V4MAPPED` is specified, return resolved IPv6 addresses as well as IPv4 mapped IPv6 addresses.
 	**/
-	static var ALL(default, null):Int;
+	static final ALL:Int;
 
 	/**
 		Resolves the given `address` and `port` into a hostname and service using `getnameinfo`.
 
-		The `callback` has arguments (err, hostname, service).
-		The `hostname` and `service` arguments are strings (e.g. 'localhost' and 'http' respectively).
+		The `callback` has arguments `(err, hostname, service)`.
+		The `hostname` and `service` arguments are strings (e.g. `'localhost'` and `'http'` respectively).
 
-		On error, `err` is an Error object, where `err.code` is the error code.
+		On error, `err` is an `Error` object, where `err.code` is the error code.
 	**/
-	static function lookupService(address:String, port:Int, callback:DnsError->String->String->Void):Void;
+	static function lookupService(address:String, port:Int, callback:DnsLookupServiceCallback):Void;
 
 	/**
-		Resolves a `hostname` (e.g. 'google.com') into an array of the record types specified by `rrtype`.
+		Resolves a `hostname` (e.g. `'google.com'`) into an array of the record types specified by `rrtype`.
 
-		The `callback` has arguments (err, addresses).
+		The `callback` has arguments `(err, addresses)`.
 		The type of each item in `addresses` is determined by the record type,
 		and described in the documentation for the corresponding lookup methods below.
 
-		On error, `err` is an Error object, where `err.code` is the error code.
+		On error, `err` is an `Error` object, where `err.code` is the error code.
 	**/
-	@:overload(function(hostname:String, callback:DnsError->Array<DnsResolvedAddress>->Void):Void {})
-	static function resolve(hostname:String, rrtype:DnsRrtype, callback:DnsError->Array<DnsResolvedAddress>->Void):Void;
+	@:overload(function(hostname:String, callback:DnsResolveCallback<Array<DnsResolvedAddress>>):Void {})
+	static function resolve(hostname:String, rrtype:DnsRrtype, callback:DnsResolveCallback<Array<DnsResolvedAddress>>):Void;
 
 	/**
 		The same as `resolve`, but only for IPv4 queries (A records).
-		`addresses` is an array of IPv4 addresses (e.g. ['74.125.79.104', '74.125.79.105', '74.125.79.106']).
+		`addresses` is an array of IPv4 addresses (e.g. `['74.125.79.104', '74.125.79.105', '74.125.79.106']`).
 
 		When `options.ttl` is `true`, each entry is `{ address, ttl }` instead of a string.
 	**/
 	@:overload(function(hostname:String, options:DnsResolveOptions,
-		callback:DnsError->EitherType<Array<String>, Array<DnsRecordWithTtl>>->Void):Void {})
-	static function resolve4(hostname:String, callback:DnsError->Array<String>->Void):Void;
+		callback:DnsResolveCallback<EitherType<Array<String>, Array<DnsRecordWithTtl>>>):Void {})
+	static function resolve4(hostname:String, callback:DnsResolveCallback<Array<String>>):Void;
 
 	/**
 		The same as `resolve4` except for IPv6 queries (an AAAA query).
@@ -553,62 +573,65 @@ extern class Dns {
 		When `options.ttl` is `true`, each entry is `{ address, ttl }` instead of a string.
 	**/
 	@:overload(function(hostname:String, options:DnsResolveOptions,
-		callback:DnsError->EitherType<Array<String>, Array<DnsRecordWithTtl>>->Void):Void {})
-	static function resolve6(hostname:String, callback:DnsError->Array<String>->Void):Void;
+		callback:DnsResolveCallback<EitherType<Array<String>, Array<DnsRecordWithTtl>>>):Void {})
+	static function resolve6(hostname:String, callback:DnsResolveCallback<Array<String>>):Void;
 
 	/**
 		Uses the DNS protocol to resolve all records (also known as `ANY` or `*` query).
+
+		DNS server operators may choose not to respond to `ANY` queries; prefer specific `resolve*` methods when possible.
 	**/
-	static function resolveAny(hostname:String, callback:DnsError->Array<DnsAnyRecord>->Void):Void;
+	static function resolveAny(hostname:String, callback:DnsResolveCallback<Array<DnsAnyRecord>>):Void;
 
 	/**
 		Uses the DNS protocol to resolve `CAA` records for the `hostname`.
 	**/
-	static function resolveCaa(hostname:String, callback:DnsError->Array<DnsResolvedAddressCAA>->Void):Void;
+	static function resolveCaa(hostname:String, callback:DnsResolveCallback<Array<DnsResolvedAddressCAA>>):Void;
 
 	/**
 		The same as `resolve`, but only for mail exchange queries (MX records).
 		`addresses` is an array of MX records, each with a priority
-		and an exchange attribute (e.g. [{'priority': 10, 'exchange': 'mx.example.com'},...]).
+		and an exchange attribute (e.g. `[{priority: 10, exchange: 'mx.example.com'}, ...]`).
 	**/
-	static function resolveMx(hostname:String, callback:DnsError->Array<DnsResolvedAddressMX>->Void):Void;
+	static function resolveMx(hostname:String, callback:DnsResolveCallback<Array<DnsResolvedAddressMX>>):Void;
 
 	/**
 		Uses the DNS protocol to resolve regular expression-based records (`NAPTR` records) for the `hostname`.
 	**/
-	static function resolveNaptr(hostname:String, callback:DnsError->Array<DnsResolvedAddressNAPTR>->Void):Void;
+	static function resolveNaptr(hostname:String, callback:DnsResolveCallback<Array<DnsResolvedAddressNAPTR>>):Void;
 
 	/**
 		The same as `resolve`, but only for text queries (TXT records).
-		`addresses` is a 2-d array of the text records available for hostname (e.g., [ ['v=spf1 ip4:0.0.0.0 ', '~all' ] ]).
-		Each sub-array contains TXT chunks of one record. Depending on the use case, the could be either joined together
+		`addresses` is a 2-d array of the text records available for hostname (e.g., `[ ['v=spf1 ip4:0.0.0.0 ', '~all' ] ]`).
+		Each sub-array contains TXT chunks of one record. Depending on the use case, these could be either joined together
 		or treated separately.
 	**/
-	static function resolveTxt(hostname:String, callback:DnsError->Array<Array<String>>->Void):Void;
+	static function resolveTxt(hostname:String, callback:DnsResolveCallback<Array<Array<String>>>):Void;
 
 	/**
 		The same as `resolve`, but only for service records (SRV records).
 		`addresses` is an array of the SRV records available for `hostname`.
 		Properties of SRV records are priority, weight, port, and name
-		(e.g., [{'priority': 10, 'weight': 5, 'port': 21223, 'name': 'service.example.com'}, ...]).
+		(e.g., `[{priority: 10, weight: 5, port: 21223, name: 'service.example.com'}, ...]`).
 	**/
-	static function resolveSrv(hostname:String, callback:DnsError->Array<DnsResolvedAddressSRV>->Void):Void;
+	static function resolveSrv(hostname:String, callback:DnsResolveCallback<Array<DnsResolvedAddressSRV>>):Void;
 
 	/**
 		Uses the DNS protocol to resolve certificate associations (`TLSA` records) for the `hostname`.
 	**/
-	static function resolveTlsa(hostname:String, callback:DnsError->Array<DnsResolvedAddressTLSA>->Void):Void;
+	static function resolveTlsa(hostname:String, callback:DnsResolveCallback<Array<DnsResolvedAddressTLSA>>):Void;
 
 	/**
 		Uses the DNS protocol to resolve pointer records (PTR records) for the `hostname`.
 		The addresses argument passed to the callback function will be an array of strings containing the reply records.
 	**/
-	static function resolvePtr(hostname:String, callback:DnsError->Array<String>->Void):Void;
+	static function resolvePtr(hostname:String, callback:DnsResolveCallback<Array<String>>):Void;
 
 	/**
 		The same as `resolve`, but only for start of authority record queries (SOA record).
 
 		`addresses` is an object with the following structure:
+		```
 		{
 		  nsname: 'ns.example.com',
 		  hostmaster: 'root.example.com',
@@ -618,36 +641,39 @@ extern class Dns {
 		  expire: 604800,
 		  minttl: 3600
 		}
+		```
 	**/
-	static function resolveSoa(hostname:String, callback:DnsError->DnsResolvedAddressSOA->Void):Void;
+	static function resolveSoa(hostname:String, callback:DnsResolveCallback<DnsResolvedAddressSOA>):Void;
 
 	/**
 		The same as `resolve`, but only for name server records (NS records).
-		`addresses` is an array of the name server records available for hostname (e.g., ['ns1.example.com', 'ns2.example.com']).
+		`addresses` is an array of the name server records available for hostname (e.g., `['ns1.example.com', 'ns2.example.com']`).
 	**/
-	static function resolveNs(hostname:String, callback:DnsError->Array<String>->Void):Void;
+	static function resolveNs(hostname:String, callback:DnsResolveCallback<Array<String>>):Void;
 
 	/**
 		The same as `resolve`, but only for canonical name records (CNAME records).
-		`addresses` is an array of the canonical name records available for hostname (e.g., ['bar.example.com']).
+		`addresses` is an array of the canonical name records available for hostname (e.g., `['bar.example.com']`).
 	**/
-	static function resolveCname(hostname:String, callback:DnsError->Array<String>->Void):Void;
+	static function resolveCname(hostname:String, callback:DnsResolveCallback<Array<String>>):Void;
 
 	/**
 		Reverse resolves an `ip` address to an array of hostnames.
-		The `callback` has arguments (err, hostname).
+		The `callback` has arguments `(err, hostnames)`.
 	**/
-	static function reverse(ip:String, callback:DnsError->Array<String>->Void):Void;
+	static function reverse(ip:String, callback:DnsResolveCallback<Array<String>>):Void;
 
 	/**
-		Returns an array of IP addresses as strings that are currently being used for resolution.
+		Returns an array of IP address strings, formatted according to RFC 5952,
+		that are currently configured for DNS resolution.
+		A string will include a port section if a custom port is used.
 	**/
 	static function getServers():Array<String>;
 
 	/**
-		Given an array of IP addresses as strings, set them as the servers to use for resolving.
-
-		If you specify a port with the address it will be stripped, as the underlying library doesn't support that.
+		Sets the IP address and port of servers to be used when performing DNS resolution.
+		The `servers` argument is an array of RFC 5952 formatted addresses.
+		If the port is the IANA default DNS port (53) it can be omitted.
 
 		This will throw if you pass invalid input.
 	**/
@@ -660,13 +686,21 @@ extern class Dns {
 
 	/**
 		Set the default value of `order` in `Dns.lookup` and `DnsPromises.lookup`.
+		The default is `verbatim`. This call has higher priority than `--dns-result-order`.
 	**/
 	static function setDefaultResultOrder(order:DnsResultOrder):Void;
+
+	/**
+		Promise-based DNS methods (`require('dns').promises` / `require('dns/promises')`).
+
+		@see https://nodejs.org/docs/latest-v24.x/api/dns.html#dns-promises-api
+	**/
+	static final promises:DnsPromises;
 
 	/**
 		`Resolver` class constructor for an independent DNS resolver.
 
 		@see https://nodejs.org/docs/latest-v24.x/api/dns.html#class-dnsresolver
 	**/
-	static var Resolver:Class<ResolverObject>;
+	static final Resolver:Class<ResolverObject>;
 }

--- a/src/js/node/DnsPromises.hx
+++ b/src/js/node/DnsPromises.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -23,9 +23,9 @@
 package js.node;
 
 import haxe.extern.EitherType;
+import js.lib.Promise;
 import js.node.Dns;
 import js.node.dns.PromisesResolver as PromisesResolverObject;
-import js.lib.Promise;
 
 /**
 	The `dns/promises` API provides an alternative set of asynchronous DNS methods
@@ -36,6 +36,8 @@ import js.lib.Promise;
 	`ADDRCONFIG`, `V4MAPPED`, and `ALL` are not exported by `dns/promises` (they are `undefined`
 	there). For lookup `hints`, use `Dns.ADDRCONFIG`, `Dns.V4MAPPED`, and `Dns.ALL`.
 
+	Error codes (`NODATA`, `NOTFOUND`, …) are also exported by this module; their values match `DnsErrorCode`.
+
 	@see https://nodejs.org/docs/latest-v24.x/api/dns.html#dns-promises-api
 **/
 @:jsRequire("dns/promises")
@@ -43,6 +45,7 @@ extern class DnsPromises {
 	/**
 		Returns an array of IP address strings, formatted according to
 		[RFC 5952](https://tools.ietf.org/html/rfc5952), that are currently configured for DNS resolution.
+		A string will include a port section if a custom port is used.
 	**/
 	static function getServers():Array<String>;
 
@@ -54,8 +57,9 @@ extern class DnsPromises {
 	**/
 	@:overload(function(hostname:String):Promise<DnsPromisesLookupResult> {})
 	@:overload(function(hostname:String, options:DnsAddressFamily):Promise<DnsPromisesLookupResult> {})
-	@:overload(function(hostname:String, options:{family:EitherType<DnsAddressFamily, String>, ?hints:Int, all:Bool, ?order:DnsResultOrder, ?verbatim:Bool}):Promise<Array<DnsLookupCallbackAllEntry>> {})
-	static function lookup(hostname:String, options:EitherType<DnsAddressFamily, DnsLookupOptions>):Promise<EitherType<DnsPromisesLookupResult, Array<DnsLookupCallbackAllEntry>>>;
+	@:overload(function(hostname:String, options:DnsLookupAllOptions):Promise<Array<DnsLookupCallbackAllEntry>> {})
+	static function lookup(hostname:String,
+		options:EitherType<DnsAddressFamily, DnsLookupOptions>):Promise<EitherType<DnsPromisesLookupResult, Array<DnsLookupCallbackAllEntry>>>;
 
 	/**
 		Resolves the given `address` and `port` into a hostname and service using `getnameinfo`.
@@ -86,6 +90,8 @@ extern class DnsPromises {
 
 	/**
 		Uses the DNS protocol to resolve all records (also known as `ANY` or `*` query).
+
+		DNS server operators may choose not to respond to `ANY` queries; prefer specific `resolve*` methods when possible.
 	**/
 	static function resolveAny(hostname:String):Promise<Array<DnsAnyRecord>>;
 
@@ -146,6 +152,8 @@ extern class DnsPromises {
 
 	/**
 		Sets the IP address and port of servers to be used when performing DNS resolution.
+		The `servers` argument is an array of RFC 5952 formatted addresses.
+		If the port is the IANA default DNS port (53) it can be omitted.
 	**/
 	static function setServers(servers:Array<String>):Void;
 
@@ -156,15 +164,136 @@ extern class DnsPromises {
 
 	/**
 		Set the default value of `order` in `Dns.lookup` and `DnsPromises.lookup`.
+		The default is `verbatim`. This call has higher priority than `--dns-result-order`.
 	**/
 	static function setDefaultResultOrder(order:DnsResultOrder):Void;
+
+	/**
+		DNS server returned answer with no data.
+	**/
+	static final NODATA:DnsErrorCode;
+
+	/**
+		DNS server claims query was misformatted.
+	**/
+	static final FORMERR:DnsErrorCode;
+
+	/**
+		DNS server returned general failure.
+	**/
+	static final SERVFAIL:DnsErrorCode;
+
+	/**
+		Domain name not found.
+	**/
+	static final NOTFOUND:DnsErrorCode;
+
+	/**
+		DNS server does not implement requested operation.
+	**/
+	static final NOTIMP:DnsErrorCode;
+
+	/**
+		DNS server refused query.
+	**/
+	static final REFUSED:DnsErrorCode;
+
+	/**
+		Misformatted DNS query.
+	**/
+	static final BADQUERY:DnsErrorCode;
+
+	/**
+		Misformatted domain name.
+	**/
+	static final BADNAME:DnsErrorCode;
+
+	/**
+		Unsupported address family.
+	**/
+	static final BADFAMILY:DnsErrorCode;
+
+	/**
+		Misformatted DNS reply.
+	**/
+	static final BADRESP:DnsErrorCode;
+
+	/**
+		Could not contact DNS servers.
+	**/
+	static final CONNREFUSED:DnsErrorCode;
+
+	/**
+		Timeout while contacting DNS servers.
+	**/
+	static final TIMEOUT:DnsErrorCode;
+
+	/**
+		End of file.
+	**/
+	static final EOF:DnsErrorCode;
+
+	/**
+		Error reading file.
+	**/
+	static final FILE:DnsErrorCode;
+
+	/**
+		Out of memory.
+	**/
+	static final NOMEM:DnsErrorCode;
+
+	/**
+		Channel is being destroyed.
+	**/
+	static final DESTRUCTION:DnsErrorCode;
+
+	/**
+		Misformatted string.
+	**/
+	static final BADSTR:DnsErrorCode;
+
+	/**
+		Illegal flags specified.
+	**/
+	static final BADFLAGS:DnsErrorCode;
+
+	/**
+		Given hostname is not numeric.
+	**/
+	static final NONAME:DnsErrorCode;
+
+	/**
+		Illegal hints flags specified.
+	**/
+	static final BADHINTS:DnsErrorCode;
+
+	/**
+		c-ares library initialization not yet performed.
+	**/
+	static final NOTINITIALIZED:DnsErrorCode;
+
+	/**
+		Error loading iphlpapi.dll.
+	**/
+	static final LOADIPHLPAPI:DnsErrorCode;
+
+	/**
+		Could not find GetNetworkParams function.
+	**/
+	static final ADDRGETNETWORKPARAMS:DnsErrorCode;
+
+	/**
+		DNS query cancelled.
+	**/
+	static final CANCELLED:DnsErrorCode;
 
 	/**
 		`Resolver` class constructor for an independent promise-based DNS resolver.
 
 		@see https://nodejs.org/docs/latest-v24.x/api/dns.html#class-dnspromisesresolver
 	**/
-	static var Resolver:Class<PromisesResolverObject>;
+	static final Resolver:Class<PromisesResolverObject>;
 }
 
 /**

--- a/src/js/node/DnsPromises.hx
+++ b/src/js/node/DnsPromises.hx
@@ -67,10 +67,11 @@ extern class DnsPromises {
 	static function lookupService(address:String, port:Int):Promise<DnsPromisesLookupServiceResult>;
 
 	/**
-		Uses the DNS protocol to resolve a hostname into an array of the record types specified by `rrtype`.
+		Uses the DNS protocol to resolve a hostname into the record types specified by `rrtype` (default `'A'`).
+		`SOA` fulfills with a single object; `TXT` with `Array<Array<String>>`.
 	**/
-	@:overload(function(hostname:String):Promise<Array<DnsResolvedAddress>> {})
-	static function resolve(hostname:String, rrtype:DnsRrtype):Promise<Array<DnsResolvedAddress>>;
+	@:overload(function(hostname:String):Promise<Array<String>> {})
+	static function resolve(hostname:String, rrtype:DnsRrtype):Promise<DnsResolveRecords>;
 
 	/**
 		Uses the DNS protocol to resolve IPv4 addresses (`A` records) for the `hostname`.

--- a/src/js/node/dns/PromisesResolver.hx
+++ b/src/js/node/dns/PromisesResolver.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -23,8 +23,8 @@
 package js.node.dns;
 
 import haxe.extern.EitherType;
-import js.node.Dns;
 import js.lib.Promise;
+import js.node.Dns;
 
 /**
 	Promise-based independent resolver for DNS requests (`dns/promises.Resolver`).
@@ -44,10 +44,22 @@ extern class PromisesResolver {
 	/**
 		The resolver instance will send its requests from the specified IP address.
 		This allows programs to specify outbound interfaces when used on multi-homed systems.
+
+		Uses the v4 local address when making requests to IPv4 DNS servers,
+		and the v6 local address when making requests to IPv6 DNS servers.
 	**/
 	function setLocalAddress(?ipv4:String, ?ipv6:String):Void;
 
+	/**
+		Returns an array of IP address strings, formatted according to RFC 5952,
+		that are currently configured for this resolver.
+	**/
 	function getServers():Array<String>;
+
+	/**
+		Sets the IP address and port of servers to be used by this resolver.
+		The `servers` argument is an array of RFC 5952 formatted addresses.
+	**/
 	function setServers(servers:Array<String>):Void;
 
 	@:overload(function(hostname:String):Promise<Array<DnsResolvedAddress>> {})

--- a/src/js/node/dns/PromisesResolver.hx
+++ b/src/js/node/dns/PromisesResolver.hx
@@ -62,8 +62,8 @@ extern class PromisesResolver {
 	**/
 	function setServers(servers:Array<String>):Void;
 
-	@:overload(function(hostname:String):Promise<Array<DnsResolvedAddress>> {})
-	function resolve(hostname:String, rrtype:DnsRrtype):Promise<Array<DnsResolvedAddress>>;
+	@:overload(function(hostname:String):Promise<Array<String>> {})
+	function resolve(hostname:String, rrtype:DnsRrtype):Promise<DnsResolveRecords>;
 
 	@:overload(function(hostname:String, options:DnsResolveOptions):Promise<EitherType<Array<String>, Array<DnsRecordWithTtl>>> {})
 	function resolve4(hostname:String):Promise<Array<String>>;

--- a/src/js/node/dns/Resolver.hx
+++ b/src/js/node/dns/Resolver.hx
@@ -64,8 +64,8 @@ extern class Resolver {
 	**/
 	function setServers(servers:Array<String>):Void;
 
-	@:overload(function(hostname:String, callback:DnsResolveCallback<Array<DnsResolvedAddress>>):Void {})
-	function resolve(hostname:String, rrtype:DnsRrtype, callback:DnsResolveCallback<Array<DnsResolvedAddress>>):Void;
+	@:overload(function(hostname:String, callback:DnsResolveCallback<Array<String>>):Void {})
+	function resolve(hostname:String, rrtype:DnsRrtype, callback:DnsResolveCallback<DnsResolveRecords>):Void;
 
 	@:overload(function(hostname:String, options:DnsResolveOptions,
 		callback:DnsResolveCallback<EitherType<Array<String>, Array<DnsRecordWithTtl>>>):Void {})

--- a/src/js/node/dns/Resolver.hx
+++ b/src/js/node/dns/Resolver.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -46,33 +46,45 @@ extern class Resolver {
 	/**
 		The resolver instance will send its requests from the specified IP address.
 		This allows programs to specify outbound interfaces when used on multi-homed systems.
+
+		Uses the v4 local address when making requests to IPv4 DNS servers,
+		and the v6 local address when making requests to IPv6 DNS servers.
 	**/
 	function setLocalAddress(?ipv4:String, ?ipv6:String):Void;
 
+	/**
+		Returns an array of IP address strings, formatted according to RFC 5952,
+		that are currently configured for this resolver.
+	**/
 	function getServers():Array<String>;
+
+	/**
+		Sets the IP address and port of servers to be used by this resolver.
+		The `servers` argument is an array of RFC 5952 formatted addresses.
+	**/
 	function setServers(servers:Array<String>):Void;
 
-	@:overload(function(hostname:String, callback:DnsError->Array<DnsResolvedAddress>->Void):Void {})
-	function resolve(hostname:String, rrtype:DnsRrtype, callback:DnsError->Array<DnsResolvedAddress>->Void):Void;
+	@:overload(function(hostname:String, callback:DnsResolveCallback<Array<DnsResolvedAddress>>):Void {})
+	function resolve(hostname:String, rrtype:DnsRrtype, callback:DnsResolveCallback<Array<DnsResolvedAddress>>):Void;
 
 	@:overload(function(hostname:String, options:DnsResolveOptions,
-		callback:DnsError->EitherType<Array<String>, Array<DnsRecordWithTtl>>->Void):Void {})
-	function resolve4(hostname:String, callback:DnsError->Array<String>->Void):Void;
+		callback:DnsResolveCallback<EitherType<Array<String>, Array<DnsRecordWithTtl>>>):Void {})
+	function resolve4(hostname:String, callback:DnsResolveCallback<Array<String>>):Void;
 
 	@:overload(function(hostname:String, options:DnsResolveOptions,
-		callback:DnsError->EitherType<Array<String>, Array<DnsRecordWithTtl>>->Void):Void {})
-	function resolve6(hostname:String, callback:DnsError->Array<String>->Void):Void;
+		callback:DnsResolveCallback<EitherType<Array<String>, Array<DnsRecordWithTtl>>>):Void {})
+	function resolve6(hostname:String, callback:DnsResolveCallback<Array<String>>):Void;
 
-	function resolveAny(hostname:String, callback:DnsError->Array<DnsAnyRecord>->Void):Void;
-	function resolveCaa(hostname:String, callback:DnsError->Array<DnsResolvedAddressCAA>->Void):Void;
-	function resolveCname(hostname:String, callback:DnsError->Array<String>->Void):Void;
-	function resolveMx(hostname:String, callback:DnsError->Array<DnsResolvedAddressMX>->Void):Void;
-	function resolveNaptr(hostname:String, callback:DnsError->Array<DnsResolvedAddressNAPTR>->Void):Void;
-	function resolveNs(hostname:String, callback:DnsError->Array<String>->Void):Void;
-	function resolvePtr(hostname:String, callback:DnsError->Array<String>->Void):Void;
-	function resolveSoa(hostname:String, callback:DnsError->DnsResolvedAddressSOA->Void):Void;
-	function resolveSrv(hostname:String, callback:DnsError->Array<DnsResolvedAddressSRV>->Void):Void;
-	function resolveTlsa(hostname:String, callback:DnsError->Array<DnsResolvedAddressTLSA>->Void):Void;
-	function resolveTxt(hostname:String, callback:DnsError->Array<Array<String>>->Void):Void;
-	function reverse(ip:String, callback:DnsError->Array<String>->Void):Void;
+	function resolveAny(hostname:String, callback:DnsResolveCallback<Array<DnsAnyRecord>>):Void;
+	function resolveCaa(hostname:String, callback:DnsResolveCallback<Array<DnsResolvedAddressCAA>>):Void;
+	function resolveCname(hostname:String, callback:DnsResolveCallback<Array<String>>):Void;
+	function resolveMx(hostname:String, callback:DnsResolveCallback<Array<DnsResolvedAddressMX>>):Void;
+	function resolveNaptr(hostname:String, callback:DnsResolveCallback<Array<DnsResolvedAddressNAPTR>>):Void;
+	function resolveNs(hostname:String, callback:DnsResolveCallback<Array<String>>):Void;
+	function resolvePtr(hostname:String, callback:DnsResolveCallback<Array<String>>):Void;
+	function resolveSoa(hostname:String, callback:DnsResolveCallback<DnsResolvedAddressSOA>):Void;
+	function resolveSrv(hostname:String, callback:DnsResolveCallback<Array<DnsResolvedAddressSRV>>):Void;
+	function resolveTlsa(hostname:String, callback:DnsResolveCallback<Array<DnsResolvedAddressTLSA>>):Void;
+	function resolveTxt(hostname:String, callback:DnsResolveCallback<Array<Array<String>>>):Void;
+	function reverse(ip:String, callback:DnsResolveCallback<Array<String>>):Void;
 }


### PR DESCRIPTION
## Summary
- Align `js.node.Dns` / `DnsPromises` / resolvers with Node.js 24: `Dns.promises`, lookup `family`/`order` docs, deprecated `verbatim`, RFC 5952 server strings, and `dns/promises` error-code exports
- Haxe 4 modernization: named-arg callback typedefs (`DnsResolveCallback`, lookup callbacks), `static final` for constants/`Resolver`/`promises`, `DnsAddressFamily.Unspecified` (`0`); copyrights → 2014–2026
- Tighten `resolve` typing via `DnsResolveRecords` (`SOA` is a single object; `TXT` is `Array<Array<String>>`) and add an `all: true` lookup overload

## Test plan
- [x] `haxe build.hxml` succeeds
- [x] Spot-checked `dns` / `dns/promises` keys against local Node
- [ ] Reviewers: skim lookup / `setServers` / resolve shapes vs [Node 24 dns docs](https://nodejs.org/docs/latest-v24.x/api/dns.html)