### PR TITLE
Audit diagnostics_channel for Node 24 + Haxe 4

### DIFF
--- a/src/js/node/DiagnosticsChannel.hx
+++ b/src/js/node/DiagnosticsChannel.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -30,7 +30,7 @@ import js.node.diagnostics_channel.TracingChannel;
 import js.node.diagnostics_channel.TracingChannel.TracingChannelChannels;
 
 /**
-	The `diagnostics_channel` module provides an API to create named channels
+	The `node:diagnostics_channel` module provides an API to create named channels
 	to report arbitrary message data for diagnostics purposes.
 
 	@see https://nodejs.org/docs/latest-v24.x/api/diagnostics_channel.html

--- a/src/js/node/diagnostics_channel/Channel.hx
+++ b/src/js/node/diagnostics_channel/Channel.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -40,17 +40,19 @@ typedef ChannelName = EitherType<String, Symbol>;
 		* `message` - The message data
 		* `name` - The name of the channel
 **/
-typedef ChannelListener = Dynamic->ChannelName->Void;
+typedef ChannelListener = (message:Dynamic, name:ChannelName) -> Void;
 
 /**
 	Transform function used by `Channel.bindStore` to convert published context
 	data into the value stored in an `AsyncLocalStorage` instance.
 **/
-typedef ChannelStoreTransform = Dynamic->Dynamic;
+typedef ChannelStoreTransform = (context:Dynamic) -> Dynamic;
 
 /**
 	The class `Channel` represents an individual named channel within the data pipeline.
 	It is used to track subscribers and to publish messages when there are subscribers present.
+	It exists as a separate object to avoid channel lookups at publish time, enabling very fast
+	publish speeds and allowing for heavy use while incurring very minimal cost.
 
 	Channels are created with `DiagnosticsChannel.channel(name)`; constructing a channel
 	directly with `new Channel(name)` is not supported.
@@ -64,7 +66,7 @@ extern class Channel {
 	/**
 		The channel name.
 	**/
-	var name(default, never):ChannelName;
+	final name:ChannelName;
 
 	/**
 		Check if there are active subscribers to this channel.
@@ -72,7 +74,7 @@ extern class Channel {
 
 		@see https://nodejs.org/docs/latest-v24.x/api/diagnostics_channel.html#channelhassubscribers
 	**/
-	var hasSubscribers(default, never):Bool;
+	final hasSubscribers:Bool;
 
 	/**
 		Publish a message to any subscribers to the channel.
@@ -89,6 +91,9 @@ extern class Channel {
 		to the channel. Any errors thrown in the message handler will trigger an
 		`'uncaughtException'`.
 
+		Deprecation of this method was revoked in Node.js v24.8.0; prefer
+		`DiagnosticsChannel.subscribe(name, onMessage)` for module-level subscribe when convenient.
+
 		@see https://nodejs.org/docs/latest-v24.x/api/diagnostics_channel.html#channelsubscribeonmessage
 	**/
 	function subscribe(onMessage:ChannelListener):Void;
@@ -98,6 +103,9 @@ extern class Channel {
 		`channel.subscribe(onMessage)`.
 
 		Returns `true` if the handler was found, `false` otherwise.
+
+		Deprecation of this method was revoked in Node.js v24.8.0; prefer
+		`DiagnosticsChannel.unsubscribe(name, onMessage)` for module-level unsubscribe when convenient.
 
 		@see https://nodejs.org/docs/latest-v24.x/api/diagnostics_channel.html#channelunsubscribeonmessage
 	**/

--- a/src/js/node/diagnostics_channel/TracingChannel.hx
+++ b/src/js/node/diagnostics_channel/TracingChannel.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -41,7 +41,7 @@ typedef TracingChannelChannels = {
 /**
 	Handler for a tracing channel message.
 **/
-typedef TracingChannelMessageHandler = Dynamic->Void;
+typedef TracingChannelMessageHandler = (message:Dynamic) -> Void;
 
 /**
 	Set of TracingChannel Channels subscribers.
@@ -93,27 +93,27 @@ extern class TracingChannel {
 	/**
 		Channel for the `start` event (`tracing:${name}:start`).
 	**/
-	var start(default, never):Channel;
+	final start:Channel;
 
 	/**
 		Channel for the `end` event (`tracing:${name}:end`).
 	**/
-	var end(default, never):Channel;
+	final end:Channel;
 
 	/**
 		Channel for the `asyncStart` event (`tracing:${name}:asyncStart`).
 	**/
-	var asyncStart(default, never):Channel;
+	final asyncStart:Channel;
 
 	/**
 		Channel for the `asyncEnd` event (`tracing:${name}:asyncEnd`).
 	**/
-	var asyncEnd(default, never):Channel;
+	final asyncEnd:Channel;
 
 	/**
 		Channel for the `error` event (`tracing:${name}:error`).
 	**/
-	var error(default, never):Channel;
+	final error:Channel;
 
 	/**
 		This is a helper to check if any of the TracingChannel Channels have subscribers.
@@ -121,7 +121,7 @@ extern class TracingChannel {
 
 		@see https://nodejs.org/docs/latest-v24.x/api/diagnostics_channel.html#tracingchannelhassubscribers
 	**/
-	var hasSubscribers(default, never):Bool;
+	final hasSubscribers:Bool;
 
 	/**
 		Helper to subscribe a collection of functions to the corresponding channels.


### PR DESCRIPTION
## Summary
- Align `diagnostics_channel` externs with Node.js 24 API surface (no new APIs missing vs v24 docs; `boundedChannel` / `withStoreScope` deferred as Node 26+).
- Modernize for Haxe 4: `final` readonly fields, named-argument callback typedefs, copyright `2014-2026`.
- Comment updates: `node:diagnostics_channel` naming, Channel publish-cost docs, and note that `channel.subscribe` / `unsubscribe` deprecation was revoked in v24.8.0.

## Test plan
- [x] `haxe build.hxml` with Haxe **4.0.5**
- [ ] Reviewer smoke: CI matrix on the PR


Made with [Cursor](https://cursor.com)