### PR TITLE
Audit tty externs for Node 24 + Haxe 4

### DIFF
--- a/src/js/node/Tty.hx
+++ b/src/js/node/Tty.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -23,20 +23,31 @@
 package js.node;
 
 /**
-	The tty module houses the tty.ReadStream and tty.WriteStream classes.
-	In most cases, you will not need to use this module directly.
+	The `node:tty` module provides the `tty.ReadStream` and `tty.WriteStream` classes.
+	In most cases, it will not be necessary or possible to use this module directly.
 
-	When node detects that it is being run inside a TTY context, then process.stdin will be a tty.ReadStream
-	instance and process.stdout will be a tty.WriteStream instance. The preferred way to check if node is being
-	run in a TTY context is to check process.stdout.isTTY.
+	When Node.js detects that it is being run with a text terminal ("TTY") attached,
+	`process.stdin` will, by default, be initialized as an instance of `tty.ReadStream`
+	and both `process.stdout` and `process.stderr` will, by default, be instances of
+	`tty.WriteStream`. The preferred method of determining whether Node.js is being run
+	within a TTY context is to check that the value of the `process.stdout.isTTY`
+	property is `true`.
+
+	@see https://nodejs.org/api/tty.html
 **/
 @:jsRequire("tty")
 extern class Tty {
 	/**
-		Returns true or false depending on if the `fd` is associated with a terminal.
+		Returns `true` if the given `fd` is associated with a TTY and `false` if it is not,
+		including whenever `fd` is not a non-negative integer.
+
+		@see https://nodejs.org/api/tty.html#ttyisattyfd
 	**/
 	static function isatty(fd:Int):Bool;
 
-	@:deprecated("Use tty.ReadStream#setRawMode() instead.")
+	/**
+		Removed from Node.js. Use `js.node.tty.ReadStream.setRawMode` instead.
+	**/
+	@:deprecated("Use js.node.tty.ReadStream.setRawMode instead")
 	static function setRawMode(mode:Bool):Void;
 }

--- a/src/js/node/tty/ReadStream.hx
+++ b/src/js/node/tty/ReadStream.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -23,24 +23,42 @@
 package js.node.tty;
 
 /**
-	A net.Socket subclass that represents the readable portion of a tty.
-	In normal circumstances, process.stdin will be the only tty.ReadStream instance
-	in any node program (only when isatty(0) is true).
+	Represents the readable side of a TTY. In normal circumstances `process.stdin`
+	will be the only `tty.ReadStream` instance in a Node.js process and there should
+	be no reason to create additional instances.
+
+	`isTTY` is always `true` for `tty.ReadStream` instances (inherited from the stream hierarchy).
+
+	@see https://nodejs.org/api/tty.html#class-ttyreadstream
 **/
 @:jsRequire("tty", "ReadStream")
 extern class ReadStream extends js.node.net.Socket {
+	/**
+		Creates a `ReadStream` for `fd` associated with a TTY.
+
+		@see https://nodejs.org/api/tty.html#new-ttyreadstreamfd-options
+	**/
 	function new(fd:Int, ?options:js.node.net.Socket.SocketOptions);
 
 	/**
-		A boolean that is initialized to false.
-		It represents the current "raw" state of the tty.ReadStream instance.
+		A `Bool` that is `true` if the TTY is currently configured to operate as a raw device.
+
+		This flag is always `false` when a process starts, even if the terminal is operating
+		in raw mode. Its value will change with subsequent calls to `setRawMode`.
+
+		@see https://nodejs.org/api/tty.html#readstreamisraw
 	**/
 	var isRaw(default, null):Bool;
 
 	/**
-		`mode` should be true or false.
-		This sets the properties of the tty.ReadStream to act either as a raw device or default.
-		`isRaw` will be set to the resulting mode.
+		Allows configuration of `tty.ReadStream` so that it operates as a raw device.
+
+		When in raw mode, input is always available character-by-character, not including
+		modifiers. Additionally, all special processing of characters by the terminal is
+		disabled, including echoing input characters. Ctrl+C will no longer cause a `SIGINT`
+		when in this mode.
+
+		@see https://nodejs.org/api/tty.html#readstreamsetrawmodemode
 	**/
 	function setRawMode(mode:Bool):ReadStream;
 }

--- a/src/js/node/tty/WriteStream.hx
+++ b/src/js/node/tty/WriteStream.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,86 +24,138 @@ package js.node.tty;
 
 import haxe.DynamicAccess;
 import haxe.extern.EitherType;
-import js.node.events.EventEmitter;
+import js.node.events.EventEmitter.Event;
 
 /**
 	Enumeration of events emitted by `WriteStream` objects in addition to its parents.
 **/
 enum abstract WriteStreamEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 	/**
-		Emitted by refreshSize() when either of the columns or rows properties has changed.
+		Emitted whenever either of the `columns` or `rows` properties has changed.
+		No arguments are passed to the listener callback when called.
+
+		@see https://nodejs.org/api/tty.html#event-resize
 	**/
 	var Resize:WriteStreamEvent<Void->Void> = "resize";
 }
 
 /**
 	Direction for `WriteStream.clearLine`.
+
+	@see https://nodejs.org/api/tty.html#writestreamclearlinedir-callback
 **/
 enum abstract WriteStreamClearLineDirection(Int) from Int to Int {
+	/** To the left from the cursor. **/
 	var Left = -1;
+	/** To the right from the cursor. **/
 	var Right = 1;
+	/** The entire line. **/
 	var EntireLine = 0;
 }
 
 /**
-	A net.Socket subclass that represents the writable portion of a tty.
-	In normal circumstances, process.stdout will be the only tty.WriteStream instance
-	ever created (and only when isatty(1) is true).
+	Represents the writable side of a TTY. In normal circumstances, `process.stdout`
+	and `process.stderr` will be the only `tty.WriteStream` instances created for a
+	Node.js process and there should be no reason to create additional instances.
+
+	`isTTY` is always `true` for `tty.WriteStream` instances (inherited from the stream hierarchy).
+
+	@see https://nodejs.org/api/tty.html#class-ttywritestream
 **/
 @:jsRequire("tty", "WriteStream")
 extern class WriteStream extends js.node.net.Socket {
+	/**
+		Creates a `WriteStream` for `fd` associated with a TTY.
+
+		@see https://nodejs.org/api/tty.html#new-ttywritestreamfd
+	**/
 	function new(fd:Int);
 
 	/**
-		The number of columns the TTY currently has.
-		This property gets updated on "resize" events.
+		A number specifying the number of columns the TTY currently has.
+		This property is updated whenever the `'resize'` event is emitted.
+
+		@see https://nodejs.org/api/tty.html#writestreamcolumns
 	**/
 	var columns(default, null):Int;
 
 	/**
-		The number of rows the TTY currently has.
-		This property gets updated on "resize" events.
+		A number specifying the number of rows the TTY currently has.
+		This property is updated whenever the `'resize'` event is emitted.
+
+		@see https://nodejs.org/api/tty.html#writestreamrows
 	**/
 	var rows(default, null):Int;
 
 	/**
-		`writeStream.clearLine()` clears the current line of this `WriteStream` in a direction identified by `dir`.
+		Clears the current line of this `WriteStream` in a direction identified by `dir`.
+
+		Returns `false` if the stream wishes for the calling code to wait for the `'drain'`
+		event to be emitted before continuing to write additional data; otherwise `true`.
+
+		@see https://nodejs.org/api/tty.html#writestreamclearlinedir-callback
 	**/
 	function clearLine(dir:WriteStreamClearLineDirection, ?callback:Void->Void):Bool;
 
 	/**
-		`writeStream.clearScreenDown()` clears this `WriteStream` from the current cursor down.
+		Clears this `WriteStream` from the current cursor down.
+
+		Returns `false` if the stream wishes for the calling code to wait for the `'drain'`
+		event to be emitted before continuing to write additional data; otherwise `true`.
+
+		@see https://nodejs.org/api/tty.html#writestreamclearscreendowncallback
 	**/
 	function clearScreenDown(?callback:Void->Void):Bool;
 
 	/**
-		`writeStream.cursorTo()` moves this `WriteStream`'s cursor to the specified position.
+		Moves this `WriteStream`'s cursor to the specified position.
+
+		Returns `false` if the stream wishes for the calling code to wait for the `'drain'`
+		event to be emitted before continuing to write additional data; otherwise `true`.
+
+		@see https://nodejs.org/api/tty.html#writestreamcursortox-y-callback
 	**/
 	@:overload(function(x:Int, callback:Void->Void):Bool {})
 	function cursorTo(x:Int, ?y:Int, ?callback:Void->Void):Bool;
 
 	/**
-		`writeStream.moveCursor()` moves this `WriteStream`'s cursor relative to its current position.
+		Moves this `WriteStream`'s cursor relative to its current position.
+
+		Returns `false` if the stream wishes for the calling code to wait for the `'drain'`
+		event to be emitted before continuing to write additional data; otherwise `true`.
+
+		@see https://nodejs.org/api/tty.html#writestreammovecursordx-dy-callback
 	**/
 	function moveCursor(dx:Int, dy:Int, ?callback:Void->Void):Bool;
 
 	/**
-		Returns:
+		Returns the color depth supported by the terminal:
+
 		- `1` for 2,
 		- `4` for 16,
 		- `8` for 256,
 		- `24` for 16,777,216 colors supported.
+
+		Pass `env` to simulate the usage of a specific terminal (defaults to `process.env`).
+
+		@see https://nodejs.org/api/tty.html#writestreamgetcolordepthenv
 	**/
 	function getColorDepth(?env:DynamicAccess<String>):Int;
 
 	/**
-		`writeStream.getWindowSize()` returns the size of the TTY corresponding to this `WriteStream`
-		as `[numColumns, numRows]`.
+		Returns the size of the TTY corresponding to this `WriteStream` as `[numColumns, numRows]`.
+
+		@see https://nodejs.org/api/tty.html#writestreamgetwindowsize
 	**/
 	function getWindowSize():Array<Int>;
 
 	/**
 		Returns `true` if the `writeStream` supports at least as many colors as provided in `count`.
+		Minimum support is 2 (black and white). Default `count` is 16.
+
+		Pass `env` to simulate the usage of a specific terminal (defaults to `process.env`).
+
+		@see https://nodejs.org/api/tty.html#writestreamhascolorscount-env
 	**/
 	@:overload(function(env:DynamicAccess<String>):Bool {})
 	@:overload(function(count:Int, ?env:DynamicAccess<String>):Bool {})


### PR DESCRIPTION
## Summary
- Aligns `js.node.Tty` / `js.node.tty.ReadStream` / `js.node.tty.WriteStream` docs and `@see` links with the Node.js 24 `node:tty` API.
- Updates copyright headers to 2014–2026 and clarifies that module-level `tty.setRawMode` is removed (deprecated stub retained for callers).
- Documents that `isTTY` is always true via the inherited stream hierarchy; notes `stderr` as a `WriteStream` like `stdout`.

## Test plan
- [x] `haxe -cp src --no-output -js /tmp/tty_check.js js.node.Tty js.node.tty.ReadStream js.node.tty.WriteStream`
- [ ] Spot-check code using `process.stdin.setRawMode` / `process.stdout.columns` still typechecks


Made with [Cursor](https://cursor.com)