### PR TITLE
Audit readline externs for Node 24 and Haxe 4

### DIFF
--- a/src/js/node/Readline.hx
+++ b/src/js/node/Readline.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -23,13 +23,14 @@
 package js.node;
 
 import haxe.extern.EitherType;
+import js.lib.Error;
 import js.node.readline.*;
 import js.node.stream.Readable.IReadable;
 import js.node.stream.Writable.IWritable;
 import js.node.web.AbortSignal;
 
 /**
-	The readline module provides an interface for reading data from a `Readable` stream (such as `process.stdin`) one
+	The `readline` module provides an interface for reading data from a `Readable` stream (such as `process.stdin`) one
 	line at a time.
 
 	@see https://nodejs.org/docs/latest-v24.x/api/readline.html
@@ -37,7 +38,7 @@ import js.node.web.AbortSignal;
 @:jsRequire("readline")
 extern class Readline {
 	/**
-		The `readline.clearLine()` method Clears current line of given `TTY` stream
+		The `readline.clearLine()` method clears the current line of given `TTY` stream
 		in a specified direction identified by `dir`.
 	**/
 	static function clearLine(stream:IWritable, dir:ClearLineDirection, ?callback:Void->Void):Bool;
@@ -51,7 +52,7 @@ extern class Readline {
 	/**
 		The `readline.createInterface()` method creates a new `readline.Interface` instance.
 	**/
-	@:overload(function(input:IReadable, ?output:IWritable, ?completer:ReadlineCompleterCallback, ?terminal:Bool):Interface {})
+	@:overload(function(input:IReadable, ?output:IWritable, ?completer:ReadlineCompleter, ?terminal:Bool):Interface {})
 	static function createInterface(options:ReadlineOptions):Interface;
 
 	/**
@@ -89,23 +90,28 @@ typedef ReadlineOptions = {
 
 	/**
 		An optional function used for Tab autocompletion.
+		May be synchronous or asynchronous (two-argument callback form).
 	**/
-	@:optional var completer:ReadlineCompleterCallback;
+	@:optional var completer:ReadlineCompleter;
 
 	/**
 		`true` if the `input` and `output` streams should be treated like a TTY, and have ANSI/VT100 escape codes
 		written to it.
+		Default: checking `isTTY` on the `output` stream upon instantiation.
 	**/
 	@:optional var terminal:Bool;
 
 	/**
 		Initial list of history lines.
+		This option makes sense only if `terminal` is set to `true` by the user or by an internal `output` check.
+		Default: `[]`.
 	**/
 	@:optional var history:Array<String>;
 
 	/**
 		Maximum number of history lines retained.
 		To disable the history set this value to `0`.
+		Default: `30`.
 	**/
 	@:optional var historySize:Int;
 
@@ -117,17 +123,23 @@ typedef ReadlineOptions = {
 	/**
 		If the delay between `\r` and `\n` exceeds `crlfDelay` milliseconds, both `\r` and `\n` will be treated as
 		separate end-of-line input.
+		`crlfDelay` will be coerced to a number no less than `100`.
+		It can be set to `Math.POSITIVE_INFINITY`, in which case `\r` followed by `\n` will always be considered
+		a single newline.
+		Default: `100`.
 	**/
 	@:optional var crlfDelay:Float;
 
 	/**
 		If `true`, when a new input line added to the history list duplicates an older one, this removes the older line
 		from the list.
+		Default: `false`.
 	**/
 	@:optional var removeHistoryDuplicates:Bool;
 
 	/**
 		The duration `readline` will wait for a character (when reading an ambiguous key sequence) in milliseconds.
+		Default: `500`.
 	**/
 	@:optional var escapeCodeTimeout:Int;
 
@@ -143,7 +155,26 @@ typedef ReadlineOptions = {
 	@:optional var signal:AbortSignal;
 }
 
-typedef ReadlineCompleterCallback = (line:String) -> Array<EitherType<Array<String>, String>>;
+/**
+	Completer result: matching entries, then the substring used for matching.
+**/
+typedef ReadlineCompleterResult = Array<EitherType<Array<String>, String>>;
+
+/**
+	Synchronous Tab autocompletion callback.
+**/
+typedef ReadlineCompleterCallback = (line:String) -> ReadlineCompleterResult;
+
+/**
+	Asynchronous Tab autocompletion callback (Node two-argument form).
+**/
+typedef ReadlineAsyncCompleterCallback = (line:String, callback:(?err:Null<Error>,
+	?result:ReadlineCompleterResult) -> Void) -> Void;
+
+/**
+	Tab completer for `readline.createInterface` (sync or async).
+**/
+typedef ReadlineCompleter = EitherType<ReadlineCompleterCallback, ReadlineAsyncCompleterCallback>;
 
 /**
 	Enumeration of possible directions for `Readline.clearLine`.

--- a/src/js/node/Readline.hx
+++ b/src/js/node/Readline.hx
@@ -38,6 +38,13 @@ import js.node.web.AbortSignal;
 @:jsRequire("readline")
 extern class Readline {
 	/**
+		Promise-based readline helpers (`readline/promises`).
+
+		@see https://nodejs.org/docs/latest-v24.x/api/readline.html#promises-api
+	**/
+	static var promises(default, never):ReadlinePromises;
+
+	/**
 		The `readline.clearLine()` method clears the current line of given `TTY` stream
 		in a specified direction identified by `dir`.
 	**/

--- a/src/js/node/ReadlinePromises.hx
+++ b/src/js/node/ReadlinePromises.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,6 +24,7 @@ package js.node;
 
 import haxe.extern.EitherType;
 import js.lib.Promise;
+import js.node.Readline.ReadlineCompleterResult;
 import js.node.readline.PromisesInterface;
 import js.node.stream.Readable.IReadable;
 import js.node.stream.Writable.IWritable;
@@ -32,13 +33,14 @@ import js.node.web.AbortSignal;
 /**
 	Completer result: matching entries, then the substring used for matching.
 **/
-typedef ReadlinePromisesCompleterResult = Array<EitherType<Array<String>, String>>;
+typedef ReadlinePromisesCompleterResult = ReadlineCompleterResult;
 
 /**
 	Tab autocompletion for `readline/promises`.
 	Unlike the callback API, the completer may return a `Promise`.
 **/
-typedef ReadlinePromisesCompleterCallback = (line:String) -> EitherType<ReadlinePromisesCompleterResult, Promise<ReadlinePromisesCompleterResult>>;
+typedef ReadlinePromisesCompleterCallback = (line:String) -> EitherType<ReadlinePromisesCompleterResult,
+	Promise<ReadlinePromisesCompleterResult>>;
 
 /**
 	Options for `ReadlinePromises.createInterface`.
@@ -65,53 +67,66 @@ typedef ReadlinePromisesOptions = {
 	@:optional var completer:ReadlinePromisesCompleterCallback;
 
 	/**
-		`true` if the `input` and `output` streams should be treated like a TTY.
+		`true` if the `input` and `output` streams should be treated like a TTY, and have ANSI/VT100 escape codes
+		written to it.
+		Default: checking `isTTY` on the `output` stream upon instantiation.
 	**/
 	@:optional var terminal:Bool;
 
 	/**
 		Initial list of history lines.
+		This option makes sense only if `terminal` is set to `true` by the user or by an internal `output` check.
+		Default: `[]`.
 	**/
 	@:optional var history:Array<String>;
 
 	/**
 		Maximum number of history lines retained.
+		To disable the history set this value to `0`.
+		Default: `30`.
 	**/
 	@:optional var historySize:Int;
 
 	/**
-		The prompt string to use.
+		The prompt string to use. Default: `'> '`.
 	**/
 	@:optional var prompt:String;
 
 	/**
-		Delay threshold for treating `\r\n` as a single newline.
+		If the delay between `\r` and `\n` exceeds `crlfDelay` milliseconds, both `\r` and `\n` will be treated as
+		separate end-of-line input.
+		Default: `100`.
 	**/
 	@:optional var crlfDelay:Float;
 
 	/**
 		If `true`, remove older duplicate history entries.
+		Default: `false`.
 	**/
 	@:optional var removeHistoryDuplicates:Bool;
 
 	/**
 		Ambiguous key sequence timeout in milliseconds.
+		Default: `500`.
 	**/
 	@:optional var escapeCodeTimeout:Int;
 
 	/**
-		The number of spaces a tab is equal to (minimum 1).
+		The number of spaces a tab is equal to (minimum 1). Default: `8`.
 	**/
 	@:optional var tabSize:Int;
 
 	/**
 		Allows closing the interface using an `AbortSignal`.
+		Aborting the signal will internally call `close` on the interface.
 	**/
 	@:optional var signal:AbortSignal;
 }
 
 /**
 	The `readline/promises` API provides an alternative set of interfaces that return promises.
+
+	Stability: Stable since Node.js v24.0.0.
 
 	@see https://nodejs.org/docs/latest-v24.x/api/readline.html#promises-api
 **/
@@ -120,6 +135,7 @@ extern class ReadlinePromises {
 	/**
 		Creates a new `readlinePromises.Interface` instance.
 	**/
-	@:overload(function(input:IReadable, ?output:IWritable, ?completer:ReadlinePromisesCompleterCallback, ?terminal:Bool):PromisesInterface {})
+	@:overload(function(input:IReadable, ?output:IWritable, ?completer:ReadlinePromisesCompleterCallback,
+		?terminal:Bool):PromisesInterface {})
 	static function createInterface(options:ReadlinePromisesOptions):PromisesInterface;
 }

--- a/src/js/node/ReadlinePromises.hx
+++ b/src/js/node/ReadlinePromises.hx
@@ -126,7 +126,8 @@ typedef ReadlinePromisesOptions = {
 /**
 	The `readline/promises` API provides an alternative set of interfaces that return promises.
 
-	Stability: Stable since Node.js v24.0.0.
+	Accessible via `require('readline/promises')` or `require('readline').promises`.
+	Stability: 2 - Stable (since Node.js v24.0.0).
 
 	@see https://nodejs.org/docs/latest-v24.x/api/readline.html#promises-api
 **/

--- a/src/js/node/readline/Interface.hx
+++ b/src/js/node/readline/Interface.hx
@@ -228,5 +228,5 @@ typedef InterfaceWriteKey = {
 	/**
 		The name of the key.
 	**/
-	var name:String;
+	@:optional var name:String;
 }

--- a/src/js/node/readline/Interface.hx
+++ b/src/js/node/readline/Interface.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -22,6 +22,7 @@
 
 package js.node.readline;
 
+import js.lib.Error;
 import js.node.Buffer;
 import js.node.events.EventEmitter;
 import js.node.web.AbortSignal;
@@ -31,12 +32,23 @@ import js.node.web.AbortSignal;
 **/
 enum abstract InterfaceEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 	/**
-		The `'close'` event is emitted when one of the following occur.
+		The `'close'` event is emitted when one of the following occur:
+
+		- The `rl.close()` method is called and the instance has relinquished control over the streams;
+		- The `input` stream receives its `'end'` event;
+		- The `input` stream receives Ctrl+D to signal end-of-transmission (EOT);
+		- The `input` stream receives Ctrl+C to signal `SIGINT` and there is no `'SIGINT'` listener registered.
 	**/
 	var Close:InterfaceEvent<Void->Void> = "close";
 
 	/**
+		The `'error'` event is emitted when an error occurs on the `input` stream associated with the interface.
+	**/
+	var Error:InterfaceEvent<Error->Void> = "error";
+
+	/**
 		The `'line'` event is emitted whenever the `input` stream receives an end-of-line input (`\n`, `\r`, or `\r\n`).
+		Also emitted if new data has been read from a stream and that stream ends without a final end-of-line marker.
 	**/
 	var Line:InterfaceEvent<String->Void> = "line";
 
@@ -46,7 +58,10 @@ enum abstract InterfaceEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> 
 	var History:InterfaceEvent<Array<String>->Void> = "history";
 
 	/**
-		The `'pause'` event is emitted when one of the following occur.
+		The `'pause'` event is emitted when one of the following occur:
+
+		- The `input` stream is paused;
+		- The `input` stream is not paused and receives the `'SIGCONT'` event.
 	**/
 	var Pause:InterfaceEvent<Void->Void> = "pause";
 
@@ -58,6 +73,8 @@ enum abstract InterfaceEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> 
 	/**
 		The `'SIGCONT'` event is emitted when a Node.js process previously moved into the background using `<ctrl>-Z`
 		(i.e. `SIGTSTP`) is then brought back to the foreground using `fg(1p)`.
+
+		Not supported on Windows.
 	**/
 	var SIGCONT:InterfaceEvent<Void->Void> = "SIGCONT";
 
@@ -70,6 +87,8 @@ enum abstract InterfaceEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> 
 	/**
 		The `'SIGTSTP'` event is emitted when the `input` stream receives a `<ctrl>-Z` input, typically known as
 		`SIGTSTP`.
+
+		Not supported on Windows.
 	**/
 	var SIGTSTP:InterfaceEvent<Void->Void> = "SIGTSTP";
 }
@@ -77,11 +96,16 @@ enum abstract InterfaceEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> 
 /**
 	Instances of the `readline.Interface` class are constructed using the `readline.createInterface()` method.
 
+	Also implements `[Symbol.asyncIterator]()` (line-by-line `for await...of`) and `[Symbol.dispose]()` (alias for
+	`close()`, since Node.js v22.15.0 / v23.10.0).
+
 	@see https://nodejs.org/docs/latest-v24.x/api/readline.html#class-interfaceconstructor
 **/
+@:jsRequire("readline", "Interface")
 extern class Interface extends EventEmitter<Interface> {
 	/**
 		The current input line buffered by `readline` (without a trailing newline).
+		Always a string (never `undefined`) since Node.js v15.8.0 / v14.18.0.
 	**/
 	var line(default, null):String;
 
@@ -91,15 +115,22 @@ extern class Interface extends EventEmitter<Interface> {
 	var cursor(default, null):Int;
 
 	/**
+		Whether this instance treats `input` / `output` as a TTY.
+	**/
+	var terminal(default, null):Bool;
+
+	/**
 		The `rl.close()` method closes the `readline.Interface` instance and relinquishes control over the `input` and
 		`output` streams.
+
+		Also available as `[Symbol.dispose]()`.
 	**/
 	function close():Void;
 
 	/**
 		The `rl.pause()` method pauses the `input` stream, allowing it to be resumed later if necessary.
 	**/
-	function pause():Void;
+	function pause():Interface;
 
 	/**
 		The `rl.prompt()` method writes the `readline.Interface` instances configured `prompt` to a new line in `output`
@@ -110,14 +141,16 @@ extern class Interface extends EventEmitter<Interface> {
 	/**
 		The `rl.question()` method displays the `query` by writing it to the `output`, waits for user `input` to be
 		provided on input, then invokes the `callback` function passing the provided input as the first argument.
+
+		Throws if called after `rl.close()`.
 	**/
 	@:overload(function(query:String, callback:String->Void):Void {})
-	function question(query:String, options:{?signal:AbortSignal}, callback:String->Void):Void;
+	function question(query:String, options:InterfaceQuestionOptions, callback:String->Void):Void;
 
 	/**
 		The `rl.resume()` method resumes the `input` stream if it has been paused.
 	**/
-	function resume():Void;
+	function resume():Interface;
 
 	/**
 		The `rl.setPrompt()` method sets the prompt that will be written to `output` whenever `rl.prompt()` is called.
@@ -131,21 +164,40 @@ extern class Interface extends EventEmitter<Interface> {
 
 	/**
 		Returns the real position of the cursor relative to the input prompt + string.
+		Long input (wrapping) strings and multi-line prompts are included in the calculations.
 	**/
 	function getCursorPos():InterfaceCursorPos;
 
 	/**
-		The `rl.write()` method write either `data` or a key sequence identified by `key` to the `output`.
+		The `rl.write()` method writes either `data` or a key sequence identified by `key` to the `output`.
+		If `key` is specified, `data` is ignored.
 	**/
 	@:overload(function(data:Buffer, ?key:InterfaceWriteKey):Void {})
 	function write(data:Null<String>, ?key:InterfaceWriteKey):Void;
 }
 
 /**
+	Options for `Interface.question` / `PromisesInterface.question`.
+**/
+typedef InterfaceQuestionOptions = {
+	/**
+		Optionally allows the `question()` to be canceled using an `AbortSignal`.
+	**/
+	@:optional var signal:AbortSignal;
+}
+
+/**
 	Cursor position returned by `Interface.getCursorPos`.
 **/
 typedef InterfaceCursorPos = {
+	/**
+		The row of the prompt the cursor currently lands on.
+	**/
 	var rows:Int;
+
+	/**
+		The screen column the cursor currently lands on.
+	**/
 	var cols:Int;
 }
 
@@ -154,22 +206,27 @@ typedef InterfaceCursorPos = {
 **/
 typedef InterfaceWriteKey = {
 	/**
-		`true` to indicate the <ctrl> key.
+		The sequence of characters generated by the keypress.
+	**/
+	@:optional var sequence:String;
+
+	/**
+		`true` to indicate the Ctrl key.
 	**/
 	@:optional var ctrl:Bool;
 
 	/**
-		`true` to indicate the <Meta> key.
+		`true` to indicate the Meta key.
 	**/
 	@:optional var meta:Bool;
 
 	/**
-		`true` to indicate the <Shift> key.
+		`true` to indicate the Shift key.
 	**/
 	@:optional var shift:Bool;
 
 	/**
-		The name of the a key.
+		The name of the key.
 	**/
 	var name:String;
 }

--- a/src/js/node/readline/PromisesInterface.hx
+++ b/src/js/node/readline/PromisesInterface.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,7 +24,6 @@ package js.node.readline;
 
 import js.lib.Promise;
 import js.node.readline.Interface;
-import js.node.web.AbortSignal;
 
 /**
 	Instances of `readlinePromises.Interface` are constructed using
@@ -44,5 +43,5 @@ extern class PromisesInterface extends Interface {
 		If called after `close()`, returns a rejected promise.
 	**/
 	@:overload(function(query:String):Promise<String> {})
-	function question(query:String, options:{?signal:AbortSignal}):Promise<String>;
+	function question(query:String, options:InterfaceQuestionOptions):Promise<String>;
 }

--- a/src/js/node/readline/PromisesReadline.hx
+++ b/src/js/node/readline/PromisesReadline.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
## Summary
- Completes the Node.js v24 + Haxe 4 audit for `js.node.Readline`, `ReadlinePromises`, and `js.node.readline/*`.
- Adds missing Interface surface: `'error'` event, `terminal` property, async (two-arg) completer typing, named `InterfaceQuestionOptions`, `InterfaceWriteKey.sequence`, and `@:jsRequire` on `Interface`.
- Documents `[Symbol.dispose]` / `[Symbol.asyncIterator]`, notes that `readline/promises` is stable in Node 24, and updates copyright headers to 2014–2026.

## Test plan
- [x] `haxe completion.hxml` succeeds after changes
- [x] Spot-check against Node.js v24 readline docs (`error` event, `terminal`, async completer, `Symbol.dispose`)
- [ ] Confirm existing `createInterface` / `question` / promises callers still type-check


Made with [Cursor](https://cursor.com)