### PR TITLE
Audit net externs for Node 24 + Haxe 4

### DIFF
--- a/src/js/node/Net.hx
+++ b/src/js/node/Net.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,48 +25,16 @@ package js.node;
 import haxe.extern.EitherType;
 import js.node.net.BlockList as BlockListObject;
 import js.node.net.Server;
+import js.node.net.Server.ServerOptions;
 import js.node.net.Socket;
 import js.node.net.SocketAddress as SocketAddressObject;
 
-typedef NetCreateServerOptions = {
-	> SocketOptionsBase,
+/**
+	Options for `Net.createServer` / `new Server()`.
 
-	/**
-		If true, then the socket associated with each incoming connection will be paused,
-		and no data will be read from its handle.
-
-		This allows connections to be passed between processes without any data being read by the original process.
-		To begin reading data from a paused socket, call `resume`.
-
-		Default: false
-	**/
-	@:optional var pauseOnConnect:Bool;
-
-	/**
-		If set to `true`, it enables keep-alive functionality on the socket immediately after the connection is established.
-	**/
-	@:optional var keepAlive:Bool;
-
-	/**
-		If set to a positive number, it sets the initial delay before the first keepalive probe is sent on an idle socket.
-	**/
-	@:optional var keepAliveInitialDelay:Int;
-
-	/**
-		If set to `true`, it disables the use of Nagle's algorithm immediately after a connection is established.
-	**/
-	@:optional var noDelay:Bool;
-
-	/**
-		Optionally overrides all `net.Socket`s' `readableHighWaterMark` and `writableHighWaterMark`.
-	**/
-	@:optional var highWaterMark:Int;
-
-	/**
-		`net.BlockList` used as an IP allow/deny list for incoming connections.
-	**/
-	@:optional var blockList:BlockListObject;
-}
+	Alias of `js.node.net.Server.ServerOptions`.
+**/
+typedef NetCreateServerOptions = ServerOptions;
 
 /**
 	Options for the `Net.connect` method (TCP version).
@@ -94,15 +62,15 @@ enum abstract NetIsIPResult(Int) to Int {
 }
 
 /**
-	The net module provides you with an asynchronous network wrapper.
-	It contains methods for creating both servers and clients (called streams).
+	The net module provides an asynchronous network API for creating stream-based
+	TCP or IPC servers (`createServer`) and clients (`createConnection`).
 **/
 @:jsRequire("net")
 extern class Net {
 	/**
-		Creates a new TCP server.
+		Creates a new TCP or IPC server.
 
-		The `connectionListener` argument is automatically set as a listener for the 'connection' event.
+		The `connectionListener` argument is automatically set as a listener for the `'connection'` event.
 	**/
 	@:overload(function(options:NetCreateServerOptions, ?connectionListener:Socket->Void):Server {})
 	static function createServer(?connectionListener:Socket->Void):Server;

--- a/src/js/node/net/BlockList.hx
+++ b/src/js/node/net/BlockList.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,6 +25,14 @@ package js.node.net;
 import haxe.extern.EitherType;
 
 /**
+	IP version used by `BlockList` add/check methods.
+**/
+enum abstract BlockListAddressType(String) from String to String {
+	var IPv4 = "ipv4";
+	var IPv6 = "ipv6";
+}
+
+/**
 	The `BlockList` object can be used with some network APIs to specify rules
 	for disabling inbound or outbound access to specific IP addresses, IP ranges, or IP subnets.
 **/
@@ -42,16 +50,16 @@ extern class BlockList {
 	/**
 		Adds a rule to block the given IP address.
 
-		`type` is either `'ipv4'` or `'ipv6'`. Default: `'ipv4'`.
+		`type` defaults to `'ipv4'`.
 	**/
-	function addAddress(address:EitherType<String, SocketAddress>, ?type:String):Void;
+	function addAddress(address:EitherType<String, SocketAddress>, ?type:BlockListAddressType):Void;
 
 	/**
 		Adds a rule to block a range of IP addresses from `start` (inclusive) to `end` (inclusive).
 
-		`type` is either `'ipv4'` or `'ipv6'`. Default: `'ipv4'`.
+		`type` defaults to `'ipv4'`.
 	**/
-	function addRange(start:EitherType<String, SocketAddress>, end:EitherType<String, SocketAddress>, ?type:String):Void;
+	function addRange(start:EitherType<String, SocketAddress>, end:EitherType<String, SocketAddress>, ?type:BlockListAddressType):Void;
 
 	/**
 		Adds a rule to block a range of IP addresses specified as a subnet mask.
@@ -59,16 +67,16 @@ extern class BlockList {
 		`prefix` is the number of CIDR prefix bits. For IPv4, this must be between 0 and 32.
 		For IPv6, this must be between 0 and 128.
 
-		`type` is either `'ipv4'` or `'ipv6'`. Default: `'ipv4'`.
+		`type` defaults to `'ipv4'`.
 	**/
-	function addSubnet(net:EitherType<String, SocketAddress>, prefix:Int, ?type:String):Void;
+	function addSubnet(net:EitherType<String, SocketAddress>, prefix:Int, ?type:BlockListAddressType):Void;
 
 	/**
 		Returns `true` if the given IP address matches any of the rules added to the `BlockList`.
 
-		`type` is either `'ipv4'` or `'ipv6'`. Default: `'ipv4'`.
+		`type` defaults to `'ipv4'`.
 	**/
-	function check(address:EitherType<String, SocketAddress>, ?type:String):Bool;
+	function check(address:EitherType<String, SocketAddress>, ?type:BlockListAddressType):Bool;
 
 	/**
 		The list of rules added to the blocklist.

--- a/src/js/node/net/Server.hx
+++ b/src/js/node/net/Server.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -23,9 +23,70 @@
 package js.node.net;
 
 import haxe.extern.EitherType;
-import js.node.events.EventEmitter;
-import js.node.net.Socket.SocketAdress;
 import js.lib.Error;
+import js.node.events.EventEmitter;
+import js.node.net.BlockList;
+import js.node.net.Socket.SocketAdress;
+import js.node.net.Socket.SocketOptionsBase;
+import js.node.web.AbortSignal;
+
+/**
+	Options for `new Server()` / `Net.createServer`.
+**/
+typedef ServerOptions = {
+	> SocketOptionsBase,
+
+	/**
+		If true, then the socket associated with each incoming connection will be paused,
+		and no data will be read from its handle.
+
+		This allows connections to be passed between processes without any data being read by the original process.
+		To begin reading data from a paused socket, call `resume`.
+
+		Default: false
+	**/
+	@:optional var pauseOnConnect:Bool;
+
+	/**
+		If set to `true`, it enables keep-alive functionality on the socket immediately after the connection is established.
+	**/
+	@:optional var keepAlive:Bool;
+
+	/**
+		If set to a positive number, it sets the initial delay before the first keepalive probe is sent on an idle socket.
+	**/
+	@:optional var keepAliveInitialDelay:Int;
+
+	/**
+		If set to `true`, it disables the use of Nagle's algorithm immediately after a connection is established.
+	**/
+	@:optional var noDelay:Bool;
+
+	/**
+		Optionally overrides all `net.Socket`s' `readableHighWaterMark` and `writableHighWaterMark`.
+	**/
+	@:optional var highWaterMark:Int;
+
+	/**
+		`net.BlockList` used as an IP allow/deny list for incoming connections.
+	**/
+	@:optional var blockList:BlockList;
+}
+
+/**
+	Argument passed to the `'drop'` event for TCP servers when `maxConnections` is reached.
+	For IPC servers the argument is `undefined`.
+
+	@see https://nodejs.org/api/net.html#event-drop
+**/
+typedef ServerDropArgument = {
+	@:optional var localAddress:String;
+	@:optional var localPort:Int;
+	@:optional var localFamily:String;
+	@:optional var remoteAddress:String;
+	@:optional var remotePort:Int;
+	@:optional var remoteFamily:String;
+}
 
 /**
 	Enumeration of events emitted by the `Server` objects
@@ -55,14 +116,29 @@ enum abstract ServerEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 
 	/**
 		Emitted when a connection is dropped because of `maxConnections` being reached.
+		For TCP servers, the listener receives connection metadata; for IPC servers it is `undefined`.
 
 		@see https://nodejs.org/api/net.html#event-drop
 	**/
-	var Drop:ServerEvent<Null<Socket>->Void> = "drop";
+	var Drop:ServerEvent<Null<ServerDropArgument>->Void> = "drop";
 }
 
 private typedef ServerListenOptionsBase = {
+	/**
+		Common parameter of `server.listen()` functions.
+	**/
+	@:optional var backlog:Int;
+
+	/**
+		When `false` (default), cluster workers share the same underlying handle.
+		When `true`, the handle is not shared.
+	**/
 	@:optional var exclusive:Bool;
+
+	/**
+		An `AbortSignal` that may be used to close a listening server.
+	**/
+	@:optional var signal:AbortSignal;
 }
 
 /**
@@ -72,15 +148,38 @@ typedef ServerListenOptionsTcp = {
 	> ServerListenOptionsBase,
 	@:optional var port:Int;
 	@:optional var host:String;
-	@:optional var backlog:Int;
+
+	/**
+		For TCP servers, setting `ipv6Only` to `true` disables dual-stack support
+		(binding to `::` will not also bind `0.0.0.0`). Default: `false`.
+	**/
+	@:optional var ipv6Only:Bool;
+
+	/**
+		For TCP servers, setting `reusePort` to `true` allows multiple sockets on the same host
+		to bind to the same port (platform-dependent). Default: `false`.
+
+		@see https://nodejs.org/api/net.html#serverlistenoptions-callback
+	**/
+	@:optional var reusePort:Bool;
 }
 
 /**
-	Options for the `Server.listen` method (UNIX version).
+	Options for the `Server.listen` method (UNIX / IPC version).
 **/
 typedef ServerListenOptionsUnix = {
 	> ServerListenOptionsBase,
 	@:optional var path:String;
+
+	/**
+		For IPC servers, makes the pipe readable for all users. Default: `false`.
+	**/
+	@:optional var readableAll:Bool;
+
+	/**
+		For IPC servers, makes the pipe writable for all users. Default: `false`.
+	**/
+	@:optional var writableAll:Bool;
 }
 
 /**
@@ -88,6 +187,16 @@ typedef ServerListenOptionsUnix = {
 **/
 @:jsRequire("net", "Server")
 extern class Server extends EventEmitter<Server> {
+	/**
+		Creates a new TCP or IPC server.
+
+		The `connectionListener` argument is automatically set as a listener for the `'connection'` event.
+
+		@see https://nodejs.org/api/net.html#new-netserveroptions-connectionlistener
+	**/
+	@:overload(function(?connectionListener:Socket->Void):Void {})
+	function new(?options:ServerOptions, ?connectionListener:Socket->Void):Void;
+
 	/**
 		Begin accepting connections on the specified `port` and `hostname`.
 
@@ -108,14 +217,16 @@ extern class Server extends EventEmitter<Server> {
 
 		This function is asynchronous. When the server has been bound, 'listening' event will be emitted.
 		The last parameter `callback` will be added as an listener for the 'listening' event.
+
+		Returns `this` for chaining.
 	**/
-	@:overload(function(path:String, ?callback:Void->Void):Void {})
-	@:overload(function(handle:EitherType<Server, EitherType<Socket, {fd:Int}>>, ?callback:Void->Void):Void {})
-	@:overload(function(port:Int, ?callback:Void->Void):Void {})
-	@:overload(function(port:Int, backlog:Int, ?callback:Void->Void):Void {})
-	@:overload(function(port:Int, hostname:String, ?callback:Void->Void):Void {})
-	@:overload(function(port:Int, hostname:String, backlog:Int, ?callback:Void->Void):Void {})
-	function listen(options:EitherType<ServerListenOptionsTcp, ServerListenOptionsUnix>, ?callback:Void->Void):Void;
+	@:overload(function(path:String, ?callback:Void->Void):Server {})
+	@:overload(function(handle:EitherType<Server, EitherType<Socket, {fd:Int}>>, ?callback:Void->Void):Server {})
+	@:overload(function(port:Int, ?callback:Void->Void):Server {})
+	@:overload(function(port:Int, backlog:Int, ?callback:Void->Void):Server {})
+	@:overload(function(port:Int, hostname:String, ?callback:Void->Void):Server {})
+	@:overload(function(port:Int, hostname:String, backlog:Int, ?callback:Void->Void):Server {})
+	function listen(options:EitherType<ServerListenOptionsTcp, ServerListenOptionsUnix>, ?callback:Void->Void):Server;
 
 	/**
 		Stops the server from accepting new connections and keeps existing connections.
@@ -124,21 +235,26 @@ extern class Server extends EventEmitter<Server> {
 
 		The optional callback will be called once the 'close' event occurs. Unlike that event,
 		it will be called with an Error as its only argument if the server was not open when it was closed.
+
+		Returns `this` for chaining.
 	**/
-	@:overload(function(callback:Error->Void):Void {})
-	function close(?callback:Void->Void):Void;
+	@:overload(function(callback:Error->Void):Server {})
+	function close(?callback:Void->Void):Server;
 
 	/**
 		Returns the bound address, the address family name and port of the server as reported by the operating system.
 		Useful to find which port was assigned when giving getting an OS-assigned address.
+
+		For a server listening on a pipe or Unix domain socket, the name is returned as a string.
+		Returns `null` before the `'listening'` event has been emitted or after calling `close`.
 	**/
-	function address():SocketAdress;
+	function address():Null<EitherType<SocketAdress, String>>;
 
 	/**
 		Calling `unref` on a server will allow the program to exit if this is the only active server in the event system.
 		If the server is already `unref`d calling `unref` again will have no effect.
 	**/
-	function unref():Void;
+	function unref():Server;
 
 	/**
 		Opposite of `unref`, calling `ref` on a previously `unref`d server
@@ -146,7 +262,7 @@ extern class Server extends EventEmitter<Server> {
 
 		If the server is `ref`d calling `ref` again will have no effect.
 	**/
-	function ref():Void;
+	function ref():Server;
 
 	/**
 		A boolean indicating whether or not the server is listening for connections.
@@ -180,5 +296,5 @@ extern class Server extends EventEmitter<Server> {
 		Asynchronously get the number of concurrent connections on the server.
 		Works when sockets were sent to forks.
 	**/
-	function getConnections(callback:Error->Int->Void):Void;
+	function getConnections(callback:Error->Int->Void):Server;
 }

--- a/src/js/node/net/Server.hx
+++ b/src/js/node/net/Server.hx
@@ -245,10 +245,12 @@ extern class Server extends EventEmitter<Server> {
 		Returns the bound address, the address family name and port of the server as reported by the operating system.
 		Useful to find which port was assigned when giving getting an OS-assigned address.
 
-		For a server listening on a pipe or Unix domain socket, the name is returned as a string.
 		Returns `null` before the `'listening'` event has been emitted or after calling `close`.
+
+		For a server listening on a pipe or Unix domain socket, Node returns the path as a `String` at runtime;
+		that case is omitted here so TCP callers can access `.port` / `.address` / `.family` without casting.
 	**/
-	function address():Null<EitherType<SocketAdress, String>>;
+	function address():Null<SocketAdress>;
 
 	/**
 		Calling `unref` on a server will allow the program to exit if this is the only active server in the event system.

--- a/src/js/node/net/Socket.hx
+++ b/src/js/node/net/Socket.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -23,9 +23,10 @@
 package js.node.net;
 
 import haxe.extern.EitherType;
+import js.lib.Error;
 import js.node.Dns;
 import js.node.events.EventEmitter.Event;
-import js.lib.Error;
+import js.node.web.AbortSignal;
 
 /**
 	Enumeration of events for `Socket` objects.
@@ -34,8 +35,10 @@ enum abstract SocketEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 	/**
 		Emitted after resolving the hostname but before connecting.
 		Not applicable to UNIX sockets.
+
+		Listener arguments: `err`, `address`, `family`, `host`.
 	**/
-	var Lookup:SocketEvent<Null<Error>->String->DnsAddressFamily->Void> = "lookup";
+	var Lookup:SocketEvent<(err:Null<Error>, address:String, family:Null<DnsAddressFamily>, host:String) -> Void> = "lookup";
 
 	/**
 		Emitted when a socket connection is successfully established. See `Socket.connect`.
@@ -141,37 +144,78 @@ typedef SocketOptions = {
 	> SocketOptionsBase,
 
 	/**
-		allows you to specify the existing file descriptor of socket.
+		If specified, wrap around an existing socket with the given file descriptor,
+		otherwise a new socket will be created.
 	**/
 	@:optional var fd:Null<Int>;
 
 	/**
-		allow reads on this socket (NOTE: Works only when `fd` is passed)
+		Allow reads on this socket (NOTE: Works only when `fd` is passed). Default: `false`.
 	**/
 	@:optional var readable:Bool;
 
 	/**
-		allow writes on this socket (NOTE: Works only when `fd` is passed)
+		Allow writes on this socket (NOTE: Works only when `fd` is passed). Default: `false`.
 	**/
 	@:optional var writable:Bool;
 
 	/**
-		If set to `false`, then the socket will automatically end the stream when the other end of the socket sends a FIN packet.
-		See `allowHalfOpen` for more information. Default: `false`.
+		If specified, incoming data is stored in a single `buffer` and passed to the supplied `callback`
+		when data arrives on the socket. This disables normal streaming `data` events.
+
+		@see https://nodejs.org/api/net.html#new-netsocketoptions
 	**/
 	@:optional var onread:SocketOnReadOptions;
 
 	/**
-		AbortSignal used to abort an ongoing connect / read.
+		AbortSignal that may be used to destroy the socket.
 	**/
-	@:optional var signal:js.node.web.AbortSignal;
+	@:optional var signal:AbortSignal;
+
+	/**
+		If set to `true`, enables keep-alive functionality on the socket immediately after the connection is established.
+		Default: `false`.
+	**/
+	@:optional var keepAlive:Bool;
+
+	/**
+		If set to a positive number, sets the initial delay before the first keepalive probe is sent on an idle socket.
+		Default: `0`.
+	**/
+	@:optional var keepAliveInitialDelay:Int;
+
+	/**
+		If set to `true`, disables the use of Nagle's algorithm immediately after the socket is established.
+		Default: `false`.
+	**/
+	@:optional var noDelay:Bool;
+
+	/**
+		`net.BlockList` for disabling outbound access to specific IP addresses, ranges, or subnets.
+	**/
+	@:optional var blockList:BlockList;
+
+	/**
+		The initial Type of Service (TOS) value (0-255).
+
+		@see https://nodejs.org/api/net.html#new-netsocketoptions
+	**/
+	@:optional var typeOfService:Int;
 }
 
 /**
 	Optional `onread` callback options for `Socket`.
 **/
 typedef SocketOnReadOptions = {
+	/**
+		Either a reusable chunk of memory to use for storing incoming data, or a function that returns such.
+	**/
 	var buffer:EitherType<js.node.Buffer, () -> js.node.Buffer>;
+
+	/**
+		Called for every chunk of incoming data with the number of bytes written and a reference to `buffer`.
+		Return `false` to implicitly `pause()` the socket.
+	**/
 	var callback:(bytesWritten:Int, buffer:js.node.Buffer) -> Bool;
 }
 
@@ -201,8 +245,9 @@ typedef SocketConnectOptionsTcp = {
 	@:optional var localPort:Int;
 
 	/**
-		Version of IP stack. Defaults to 4.
-		Use `0` for dual-stack / auto family selection.
+		Version of IP stack. Must be `4`, `6`, or `0`.
+		The value `0` indicates that both IPv4 and IPv6 addresses are allowed.
+		Default: `0`.
 	**/
 	@:optional var family:DnsAddressFamily;
 
@@ -232,12 +277,15 @@ typedef SocketConnectOptionsTcp = {
 	@:optional var noDelay:Bool;
 
 	/**
-		If set to `true`, enables TCP_KEEPALIVE on the connection.
+		If set to `true`, enables a family autodetection algorithm (RFC 8305 §5).
+		Ignored if `family` is not `0` or if `localAddress` is set.
+		Default: `Net.getDefaultAutoSelectFamily()`.
 	**/
 	@:optional var autoSelectFamily:Bool;
 
 	/**
 		Timeout in milliseconds for autoSelectFamily connection attempts.
+		Default: `Net.getDefaultAutoSelectFamilyAttemptTimeout()`.
 	**/
 	@:optional var autoSelectFamilyAttemptTimeout:Int;
 
@@ -249,7 +297,7 @@ typedef SocketConnectOptionsTcp = {
 	/**
 		AbortSignal used to abort an ongoing connect.
 	**/
-	@:optional var signal:js.node.web.AbortSignal;
+	@:optional var signal:AbortSignal;
 }
 
 /**
@@ -264,7 +312,7 @@ typedef SocketConnectOptionsUnix = {
 	/**
 		AbortSignal used to abort an ongoing connect.
 	**/
-	@:optional var signal:js.node.web.AbortSignal;
+	@:optional var signal:AbortSignal;
 }
 
 /**
@@ -334,19 +382,17 @@ extern class Socket extends js.node.stream.Duplex<Socket> {
 	function connect(options:EitherType<SocketConnectOptionsTcp, SocketConnectOptionsUnix>, ?connectListener:Void->Void):Socket;
 
 	/**
-		`Socket` has the property that `socket.write` always works. This is to help users get up and running quickly.
-		The computer cannot always keep up with the amount of data that is written to a socket - the network connection
-		simply might be too slow. Node will internally queue up the data written to a socket and send it out over the
-		wire when it is possible. (Internally it is polling on the socket's file descriptor for being writable).
-
-		The consequence of this internal buffering is that memory may grow. This property shows the number of characters
-		currently buffered to be written. (Number of characters is approximately equal to the number of bytes to be written,
-		but the buffer may contain strings, and the strings are lazily encoded, so the exact number of bytes is not known.)
+		This property shows the number of characters buffered for writing.
+		The buffer may contain strings whose length after encoding is not yet known,
+		so this number is only an approximation of the number of bytes in the buffer.
 
 		Users who experience large or growing `bufferSize` should attempt to "throttle" the data flows
 		in their program with `pause` and `resume`.
+
+		@deprecated Since v14.6.0 — use `writableLength` instead.
 	**/
-	var bufferSize:Int;
+	@:deprecated("Use writableLength instead")
+	var bufferSize(default, null):Int;
 
 	/**
 		A boolean value that indicates if the connection is destroyed or not.
@@ -363,7 +409,7 @@ extern class Socket extends js.node.stream.Duplex<Socket> {
 		If `exception` is specified, an 'error' event will be emitted and
 		any listeners for that event will receive exception as an argument.
 	**/
-	function destroy(?exception:Error):Void;
+	function destroy(?exception:Error):Socket;
 
 	/**
 		Destroys the socket after all data has been written.
@@ -388,7 +434,7 @@ extern class Socket extends js.node.stream.Duplex<Socket> {
 
 		The optional `callback` parameter will be added as a one time listener for the 'timeout' event.
 	**/
-	function setTimeout(timeout:Int, ?callback:Void->Void):Void;
+	function setTimeout(timeout:Int, ?callback:Void->Void):Socket;
 
 	/**
 		Disables the Nagle algorithm.
@@ -396,7 +442,7 @@ extern class Socket extends js.node.stream.Duplex<Socket> {
 		Setting true for `noDelay` will immediately fire off data each time `write` is called.
 		`noDelay` defaults to true.
 	**/
-	function setNoDelay(?noDelay:Bool):Void;
+	function setNoDelay(?noDelay:Bool):Socket;
 
 	/**
 		Enable/disable keep-alive functionality, and optionally set the initial delay
@@ -410,8 +456,26 @@ extern class Socket extends js.node.stream.Duplex<Socket> {
 		Setting 0 for `initialDelay` will leave the value unchanged from the default (or previous) setting.
 		Defaults to 0.
 	**/
-	@:overload(function(?initialDelay:Int):Void {})
-	function setKeepAlive(enable:Bool, ?initialDelay:Int):Void;
+	@:overload(function(?initialDelay:Int):Socket {})
+	function setKeepAlive(enable:Bool, ?initialDelay:Int):Socket;
+
+	/**
+		Returns the current Type of Service (TOS) field for IPv4 packets or Traffic Class for IPv6 packets.
+
+		`setTypeOfService` may be called before the socket is connected; the value will be cached and applied
+		when the socket establishes a connection. `getTypeOfService` returns the currently set value even before connection.
+
+		@see https://nodejs.org/api/net.html#socketgettypeofservice
+	**/
+	function getTypeOfService():Int;
+
+	/**
+		Sets the Type of Service (TOS) field for IPv4 packets or Traffic Class for IPv6 packets sent from this socket.
+		`tos` must be in the range 0-255.
+
+		@see https://nodejs.org/api/net.html#socketsettypeservicetos
+	**/
+	function setTypeOfService(tos:Int):Socket;
 
 	/**
 		Returns the bound address, the address family name and port of the socket as reported by the operating system.
@@ -434,36 +498,39 @@ extern class Socket extends js.node.stream.Duplex<Socket> {
 	/**
 		The string representation of the remote IP address.
 		For example, '74.125.127.100' or '2001:4860:a005::68'.
+		May be `undefined` if the socket is destroyed.
 	**/
-	var remoteAddress(default, null):String;
+	var remoteAddress(default, null):Null<String>;
 
 	/**
 		The string representation of the remote IP family.
 		'IPv4' or 'IPv6'.
+		May be `undefined` if the socket is destroyed.
 	**/
-	var remoteFamily(default, null):SocketAdressFamily;
+	var remoteFamily(default, null):Null<SocketAdressFamily>;
 
 	/**
 		The numeric representation of the remote port. For example, 80 or 21.
+		May be `undefined` if the socket is destroyed.
 	**/
-	var remotePort(default, null):Int;
+	var remotePort(default, null):Null<Int>;
 
 	/**
 		The string representation of the local IP address the remote client is connecting on.
 		For example, if you are listening on '0.0.0.0' and the client connects on '192.168.1.1',
 		the value would be '192.168.1.1'.
 	**/
-	var localAddress(default, null):String;
+	var localAddress(default, null):Null<String>;
 
 	/**
 		The numeric representation of the local port. For example, 80 or 21.
 	**/
-	var localPort(default, null):Int;
+	var localPort(default, null):Null<Int>;
 
 	/**
 		The string representation of the local IP family. `'IPv4'` or `'IPv6'`.
 	**/
-	var localFamily(default, null):SocketAdressFamily;
+	var localFamily(default, null):Null<SocketAdressFamily>;
 
 	/**
 		This property is only present when using `autoSelectFamily` and represents attempted addresses.

--- a/src/js/node/net/SocketAddress.hx
+++ b/src/js/node/net/SocketAddress.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -23,6 +23,40 @@
 package js.node.net;
 
 /**
+	IP version for `SocketAddress` construction.
+**/
+enum abstract SocketAddressFamily(String) from String to String {
+	var IPv4 = "ipv4";
+	var IPv6 = "ipv6";
+}
+
+/**
+	Options for `new SocketAddress()`.
+**/
+typedef SocketAddressOptions = {
+	/**
+		The network address as either an IPv4 or IPv6 string.
+		Default: `'127.0.0.1'` if `family` is `'ipv4'`; `'::'` if `family` is `'ipv6'`.
+	**/
+	@:optional var address:String;
+
+	/**
+		Either `'ipv4'` or `'ipv6'`. Default: `'ipv4'`.
+	**/
+	@:optional var family:SocketAddressFamily;
+
+	/**
+		An IPv6 flow-label used only if `family` is `'ipv6'`.
+	**/
+	@:optional var flowlabel:Int;
+
+	/**
+		An IP port.
+	**/
+	@:optional var port:Int;
+}
+
+/**
 	Represents a network endpoint as an IP address and port pair.
 
 	@see https://nodejs.org/api/net.html#class-netsocketaddress
@@ -32,16 +66,9 @@ extern class SocketAddress {
 	/**
 		Creates a new `SocketAddress`.
 
-		`family` is either `'ipv4'` or `'ipv6'`. Default: `'ipv4'`.
-
 		@see https://nodejs.org/api/net.html#new-netsocketaddressoptions
 	**/
-	function new(?options:{
-		?address:String,
-		?family:String,
-		?flowlabel:Int,
-		?port:Int
-	}):Void;
+	function new(?options:SocketAddressOptions):Void;
 
 	/**
 		Parses an IP address and optional port string into a `SocketAddress`.
@@ -61,7 +88,7 @@ extern class SocketAddress {
 	/**
 		Either `'ipv4'` or `'ipv6'`.
 	**/
-	var family(default, null):String;
+	var family(default, null):SocketAddressFamily;
 
 	/**
 		An IP port.


### PR DESCRIPTION
## Summary
- Align `js.node.Net` / `js.node.net.*` with Node.js 24 `net` API: Server constructor + listen options (`ipv6Only`, `reusePort`, `readableAll`/`writableAll`, `signal`), Socket TOS (`typeOfService` / `getTypeOfService` / `setTypeOfService`), corrected `'drop'` event payload, and chaining return types.
- Share `ServerOptions` with `Net.createServer`; deprecate `bufferSize` in favor of `writableLength`; add lookup `host` arg; tighten BlockList/SocketAddress family enums.
- Refresh comments and copyright headers to 2014–2026.

## Test plan
- [x] `haxe build.hxml` succeeds (ImportAll + examples)
- [ ] CI: Haxe 4.0.5 / 4.3.7 / latest
- [ ] Spot-check `Server.listen` options, `'drop'` listener typing, and Socket TOS APIs

Made with [Cursor](https://cursor.com)