### PR TITLE
Audit js.node.zlib for Node 24 + Haxe 4

### DIFF
--- a/src/js/node/Zlib.hx
+++ b/src/js/node/Zlib.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,47 +24,69 @@ package js.node;
 
 import haxe.DynamicAccess;
 import haxe.extern.EitherType;
+import js.lib.ArrayBuffer;
+import js.lib.ArrayBufferView;
+import js.lib.Error;
 import js.node.Buffer;
 import js.node.zlib.*;
-import js.lib.Error;
 
+/**
+	Input accepted by zlib convenience methods and `crc32`.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/zlib.html#convenience-methods
+**/
+typedef ZlibInput = EitherType<String, EitherType<ArrayBuffer, ArrayBufferView>>;
+
+/**
+	Binary dictionary for deflate/inflate and Zstd streams.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/zlib.html#class-options
+**/
+typedef ZlibDictionary = EitherType<ArrayBuffer, ArrayBufferView>;
+
+/**
+	Options for zlib-based streams (`Deflate`, `Inflate`, `Gzip`, etc.).
+
+	@see https://nodejs.org/docs/latest-v24.x/api/zlib.html#class-options
+**/
 typedef ZlibOptions = {
 	/**
-		default: `Zlib.Z_NO_FLUSH`
+		Default: `Zlib.constants.Z_NO_FLUSH`
 	**/
 	@:optional var flush:Int;
 
 	/**
-		default: `Zlib.Z_FINISH`
+		Default: `Zlib.constants.Z_FINISH`
 	**/
 	@:optional var finishFlush:Int;
 
 	/**
-		default: 16*1024
+		Default: 16*1024
 	**/
 	@:optional var chunkSize:Int;
 
 	@:optional var windowBits:Int;
 
 	/**
-		compression only
+		Compression only.
 	**/
 	@:optional var level:Int;
 
 	/**
-		compression only
+		Compression only.
 	**/
 	@:optional var memLevel:Int;
 
 	/**
-		compression only
+		Compression only.
 	**/
 	@:optional var strategy:Int;
 
 	/**
-		deflate/inflate only, empty dictionary by default
+		Deflate/inflate only; empty dictionary by default.
+		Accepts `Buffer`, `TypedArray`, `DataView`, or `ArrayBuffer`.
 	**/
-	@:optional var dictionary:Buffer;
+	@:optional var dictionary:ZlibDictionary;
 
 	/**
 		Limits output size when using convenience methods.
@@ -81,27 +103,30 @@ typedef ZlibOptions = {
 
 /**
 	Options for Brotli compression and decompression.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/zlib.html#class-brotlioptions
 **/
 typedef BrotliOptions = {
 	/**
-		default: `zlib.constants.BROTLI_OPERATION_PROCESS`
+		Default: `Zlib.constants.BROTLI_OPERATION_PROCESS`
 	**/
 	@:optional var flush:Int;
 
 	/**
-		default: `zlib.constants.BROTLI_OPERATION_FINISH`
+		Default: `Zlib.constants.BROTLI_OPERATION_FINISH`
 	**/
 	@:optional var finishFlush:Int;
 
 	/**
-		default: 16*1024
+		Default: 16*1024
 	**/
 	@:optional var chunkSize:Int;
 
 	/**
-		Key-value object containing indexed Brotli parameters.
+		Key-value object containing indexed Brotli parameters
+		(`BROTLI_PARAM_*` keys from `Zlib.constants`).
 	**/
-	@:optional var params:DynamicAccess<Int>;
+	@:optional var params:DynamicAccess<EitherType<Bool, Int>>;
 
 	/**
 		The maximum length of the output that can be produced by zlib streams.
@@ -120,27 +145,30 @@ typedef BrotliOptions = {
 	Options for Zstandard (zstd) compression and decompression.
 
 	Stability: 1 - Experimental
+
+	@see https://nodejs.org/docs/latest-v24.x/api/zlib.html#class-zstdoptions
 **/
 typedef ZstdOptions = {
 	/**
-		default: `zlib.constants.ZSTD_e_continue`
+		Default: `Zlib.constants.ZSTD_e_continue`
 	**/
 	@:optional var flush:Int;
 
 	/**
-		default: `zlib.constants.ZSTD_e_end`
+		Default: `Zlib.constants.ZSTD_e_end`
 	**/
 	@:optional var finishFlush:Int;
 
 	/**
-		default: 16*1024
+		Default: 16*1024
 	**/
 	@:optional var chunkSize:Int;
 
 	/**
-		Key-value object containing indexed Zstd parameters.
+		Key-value object containing indexed Zstd parameters
+		(`ZSTD_c_*` / `ZSTD_d_*` keys from `Zlib.constants`).
 	**/
-	@:optional var params:DynamicAccess<Int>;
+	@:optional var params:DynamicAccess<EitherType<Bool, Int>>;
 
 	/**
 		The maximum length of the output that can be produced by zlib streams.
@@ -157,87 +185,312 @@ typedef ZstdOptions = {
 	/**
 		Optional dictionary used to improve compression efficiency.
 	**/
-	@:optional var dictionary:Buffer;
+	@:optional var dictionary:ZlibDictionary;
+
+	/**
+		Expected total size of the uncompressed input.
+		If the size does not match, compression fails with `ZSTD_error_srcSize_wrong`.
+	**/
+	@:optional var pledgedSrcSize:Float;
 }
 
 /**
-	This provides bindings to Gzip/Gunzip, Deflate/Inflate, DeflateRaw/InflateRaw,
-	BrotliCompress/BrotliDecompress, and ZstdCompress/ZstdDecompress classes.
-	Each class takes options, and is a readable/writable Stream.
+	All zlib constants available on `require("zlib").constants`.
+
+	Prefer these over the deprecated top-level `Z_*` fields on `Zlib`.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/zlib.html#constants
+**/
+typedef ZlibConstants = {
+	/**
+		Zlib (deflate/inflate) constants from zlib.h.
+	**/
+	var Z_BEST_COMPRESSION:Int;
+	var Z_BEST_SPEED:Int;
+	var Z_BLOCK:Int;
+	var Z_BUF_ERROR:Int;
+	var Z_DATA_ERROR:Int;
+	var Z_DEFAULT_CHUNK:Int;
+	var Z_DEFAULT_COMPRESSION:Int;
+	var Z_DEFAULT_LEVEL:Int;
+	var Z_DEFAULT_MEMLEVEL:Int;
+	var Z_DEFAULT_STRATEGY:Int;
+	var Z_DEFAULT_WINDOWBITS:Int;
+	var Z_ERRNO:Int;
+	var Z_FILTERED:Int;
+	var Z_FINISH:Int;
+	var Z_FIXED:Int;
+	var Z_FULL_FLUSH:Int;
+	var Z_HUFFMAN_ONLY:Int;
+	var Z_MAX_CHUNK:Int;
+	var Z_MAX_LEVEL:Int;
+	var Z_MAX_MEMLEVEL:Int;
+	var Z_MAX_WINDOWBITS:Int;
+	var Z_MEM_ERROR:Int;
+	var Z_MIN_CHUNK:Int;
+	var Z_MIN_LEVEL:Int;
+	var Z_MIN_MEMLEVEL:Int;
+	var Z_MIN_WINDOWBITS:Int;
+	var Z_NEED_DICT:Int;
+	var Z_NO_COMPRESSION:Int;
+	var Z_NO_FLUSH:Int;
+	var Z_OK:Int;
+	var Z_PARTIAL_FLUSH:Int;
+	var Z_RLE:Int;
+	var Z_STREAM_END:Int;
+	var Z_STREAM_ERROR:Int;
+	var Z_SYNC_FLUSH:Int;
+	var Z_VERSION_ERROR:Int;
+	var ZLIB_VERNUM:Int;
+
+	/**
+		Brotli constants.
+	**/
+	var BROTLI_DECODE:Int;
+	var BROTLI_DECODER_ERROR_ALLOC_BLOCK_TYPE_TREES:Int;
+	var BROTLI_DECODER_ERROR_ALLOC_CONTEXT_MAP:Int;
+	var BROTLI_DECODER_ERROR_ALLOC_CONTEXT_MODES:Int;
+	var BROTLI_DECODER_ERROR_ALLOC_RING_BUFFER_1:Int;
+	var BROTLI_DECODER_ERROR_ALLOC_RING_BUFFER_2:Int;
+	var BROTLI_DECODER_ERROR_ALLOC_TREE_GROUPS:Int;
+	var BROTLI_DECODER_ERROR_DICTIONARY_NOT_SET:Int;
+	var BROTLI_DECODER_ERROR_FORMAT_BLOCK_LENGTH_1:Int;
+	var BROTLI_DECODER_ERROR_FORMAT_BLOCK_LENGTH_2:Int;
+	var BROTLI_DECODER_ERROR_FORMAT_CL_SPACE:Int;
+	var BROTLI_DECODER_ERROR_FORMAT_CONTEXT_MAP_REPEAT:Int;
+	var BROTLI_DECODER_ERROR_FORMAT_DICTIONARY:Int;
+	var BROTLI_DECODER_ERROR_FORMAT_DISTANCE:Int;
+	var BROTLI_DECODER_ERROR_FORMAT_EXUBERANT_META_NIBBLE:Int;
+	var BROTLI_DECODER_ERROR_FORMAT_EXUBERANT_NIBBLE:Int;
+	var BROTLI_DECODER_ERROR_FORMAT_HUFFMAN_SPACE:Int;
+	var BROTLI_DECODER_ERROR_FORMAT_PADDING_1:Int;
+	var BROTLI_DECODER_ERROR_FORMAT_PADDING_2:Int;
+	var BROTLI_DECODER_ERROR_FORMAT_RESERVED:Int;
+	var BROTLI_DECODER_ERROR_FORMAT_SIMPLE_HUFFMAN_ALPHABET:Int;
+	var BROTLI_DECODER_ERROR_FORMAT_SIMPLE_HUFFMAN_SAME:Int;
+	var BROTLI_DECODER_ERROR_FORMAT_TRANSFORM:Int;
+	var BROTLI_DECODER_ERROR_FORMAT_WINDOW_BITS:Int;
+	var BROTLI_DECODER_ERROR_INVALID_ARGUMENTS:Int;
+	var BROTLI_DECODER_ERROR_UNREACHABLE:Int;
+	var BROTLI_DECODER_NEEDS_MORE_INPUT:Int;
+	var BROTLI_DECODER_NEEDS_MORE_OUTPUT:Int;
+	var BROTLI_DECODER_NO_ERROR:Int;
+	var BROTLI_DECODER_PARAM_DISABLE_RING_BUFFER_REALLOCATION:Int;
+	var BROTLI_DECODER_PARAM_LARGE_WINDOW:Int;
+	var BROTLI_DECODER_RESULT_ERROR:Int;
+	var BROTLI_DECODER_RESULT_NEEDS_MORE_INPUT:Int;
+	var BROTLI_DECODER_RESULT_NEEDS_MORE_OUTPUT:Int;
+	var BROTLI_DECODER_RESULT_SUCCESS:Int;
+	var BROTLI_DECODER_SUCCESS:Int;
+	var BROTLI_DEFAULT_MODE:Int;
+	var BROTLI_DEFAULT_QUALITY:Int;
+	var BROTLI_DEFAULT_WINDOW:Int;
+	var BROTLI_ENCODE:Int;
+	var BROTLI_LARGE_MAX_WINDOW_BITS:Int;
+	var BROTLI_MAX_INPUT_BLOCK_BITS:Int;
+	var BROTLI_MAX_QUALITY:Int;
+	var BROTLI_MAX_WINDOW_BITS:Int;
+	var BROTLI_MIN_INPUT_BLOCK_BITS:Int;
+	var BROTLI_MIN_QUALITY:Int;
+	var BROTLI_MIN_WINDOW_BITS:Int;
+	var BROTLI_MODE_FONT:Int;
+	var BROTLI_MODE_GENERIC:Int;
+	var BROTLI_MODE_TEXT:Int;
+	var BROTLI_OPERATION_EMIT_METADATA:Int;
+	var BROTLI_OPERATION_FINISH:Int;
+	var BROTLI_OPERATION_FLUSH:Int;
+	var BROTLI_OPERATION_PROCESS:Int;
+	var BROTLI_PARAM_DISABLE_LITERAL_CONTEXT_MODELING:Int;
+	var BROTLI_PARAM_LARGE_WINDOW:Int;
+	var BROTLI_PARAM_LGBLOCK:Int;
+	var BROTLI_PARAM_LGWIN:Int;
+	var BROTLI_PARAM_MODE:Int;
+	var BROTLI_PARAM_NDIRECT:Int;
+	var BROTLI_PARAM_NPOSTFIX:Int;
+	var BROTLI_PARAM_QUALITY:Int;
+	var BROTLI_PARAM_SIZE_HINT:Int;
+
+	/**
+		Zstd constants (experimental).
+	**/
+	var ZSTD_btlazy2:Int;
+	var ZSTD_btopt:Int;
+	var ZSTD_btultra:Int;
+	var ZSTD_btultra2:Int;
+	var ZSTD_c_chainLog:Int;
+	var ZSTD_c_checksumFlag:Int;
+	var ZSTD_c_compressionLevel:Int;
+	var ZSTD_c_contentSizeFlag:Int;
+	var ZSTD_c_dictIDFlag:Int;
+	var ZSTD_c_enableLongDistanceMatching:Int;
+	var ZSTD_c_hashLog:Int;
+	var ZSTD_c_jobSize:Int;
+	var ZSTD_c_ldmBucketSizeLog:Int;
+	var ZSTD_c_ldmHashLog:Int;
+	var ZSTD_c_ldmHashRateLog:Int;
+	var ZSTD_c_ldmMinMatch:Int;
+	var ZSTD_c_minMatch:Int;
+	var ZSTD_c_nbWorkers:Int;
+	var ZSTD_c_overlapLog:Int;
+	var ZSTD_c_searchLog:Int;
+	var ZSTD_c_strategy:Int;
+	var ZSTD_c_targetLength:Int;
+	var ZSTD_c_windowLog:Int;
+	var ZSTD_CLEVEL_DEFAULT:Int;
+	var ZSTD_COMPRESS:Int;
+	var ZSTD_d_windowLogMax:Int;
+	var ZSTD_DECOMPRESS:Int;
+	var ZSTD_dfast:Int;
+	var ZSTD_e_continue:Int;
+	var ZSTD_e_end:Int;
+	var ZSTD_e_flush:Int;
+	var ZSTD_error_checksum_wrong:Int;
+	var ZSTD_error_corruption_detected:Int;
+	var ZSTD_error_dictionary_corrupted:Int;
+	var ZSTD_error_dictionary_wrong:Int;
+	var ZSTD_error_dictionaryCreation_failed:Int;
+	var ZSTD_error_dstBuffer_null:Int;
+	var ZSTD_error_dstSize_tooSmall:Int;
+	var ZSTD_error_frameParameter_unsupported:Int;
+	var ZSTD_error_frameParameter_windowTooLarge:Int;
+	var ZSTD_error_GENERIC:Int;
+	var ZSTD_error_init_missing:Int;
+	var ZSTD_error_literals_headerWrong:Int;
+	var ZSTD_error_maxSymbolValue_tooLarge:Int;
+	var ZSTD_error_maxSymbolValue_tooSmall:Int;
+	var ZSTD_error_memory_allocation:Int;
+	var ZSTD_error_no_error:Int;
+	var ZSTD_error_noForwardProgress_destFull:Int;
+	var ZSTD_error_noForwardProgress_inputEmpty:Int;
+	var ZSTD_error_parameter_combination_unsupported:Int;
+	var ZSTD_error_parameter_outOfBound:Int;
+	var ZSTD_error_parameter_unsupported:Int;
+	var ZSTD_error_prefix_unknown:Int;
+	var ZSTD_error_srcSize_wrong:Int;
+	var ZSTD_error_stabilityCondition_notRespected:Int;
+	var ZSTD_error_stage_wrong:Int;
+	var ZSTD_error_tableLog_tooLarge:Int;
+	var ZSTD_error_version_unsupported:Int;
+	var ZSTD_error_workSpace_tooSmall:Int;
+	var ZSTD_fast:Int;
+	var ZSTD_greedy:Int;
+	var ZSTD_lazy:Int;
+	var ZSTD_lazy2:Int;
+
+	/**
+		Internal compression mode identifiers.
+	**/
+	var DEFLATE:Int;
+	var DEFLATERAW:Int;
+	var GUNZIP:Int;
+	var GZIP:Int;
+	var INFLATE:Int;
+	var INFLATERAW:Int;
+	var UNZIP:Int;
+
+}
+
+
+/**
+	Bindings to Gzip/Gunzip, Deflate/Inflate, DeflateRaw/InflateRaw,
+	BrotliCompress/BrotliDecompress, and ZstdCompress/ZstdDecompress.
+	Each class takes options and is a readable/writable Stream.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/zlib.html
 **/
 @:jsRequire("zlib")
 extern class Zlib {
 	/**
+		Object containing zlib, Brotli, and Zstd constants.
+		Prefer this over the deprecated top-level `Z_*` fields.
+	**/
+	static var constants(default, null):ZlibConstants;
+
+	/**
 		Allowed `flush` values.
 	**/
+	@:deprecated("Use Zlib.constants.Z_NO_FLUSH instead")
 	static var Z_NO_FLUSH(default, null):Int;
 
+	@:deprecated("Use Zlib.constants.Z_PARTIAL_FLUSH instead")
 	static var Z_PARTIAL_FLUSH(default, null):Int;
+
+	@:deprecated("Use Zlib.constants.Z_SYNC_FLUSH instead")
 	static var Z_SYNC_FLUSH(default, null):Int;
+
+	@:deprecated("Use Zlib.constants.Z_FULL_FLUSH instead")
 	static var Z_FULL_FLUSH(default, null):Int;
+
+	@:deprecated("Use Zlib.constants.Z_FINISH instead")
 	static var Z_FINISH(default, null):Int;
+
+	@:deprecated("Use Zlib.constants.Z_BLOCK instead")
 	static var Z_BLOCK(default, null):Int;
-	static var Z_TREES(default, null):Int;
 
 	/**
 		Return codes for the compression/decompression functions.
-		Negative values are errors, positive values are used for special but normal events.
+		Negative values are errors; positive values are used for special but normal events.
 	**/
+	@:deprecated("Use Zlib.constants.Z_OK instead")
 	static var Z_OK(default, null):Int;
 
+	@:deprecated("Use Zlib.constants.Z_STREAM_END instead")
 	static var Z_STREAM_END(default, null):Int;
+
+	@:deprecated("Use Zlib.constants.Z_NEED_DICT instead")
 	static var Z_NEED_DICT(default, null):Int;
+
+	@:deprecated("Use Zlib.constants.Z_ERRNO instead")
 	static var Z_ERRNO(default, null):Int;
+
+	@:deprecated("Use Zlib.constants.Z_STREAM_ERROR instead")
 	static var Z_STREAM_ERROR(default, null):Int;
+
+	@:deprecated("Use Zlib.constants.Z_DATA_ERROR instead")
 	static var Z_DATA_ERROR(default, null):Int;
+
+	@:deprecated("Use Zlib.constants.Z_MEM_ERROR instead")
 	static var Z_MEM_ERROR(default, null):Int;
+
+	@:deprecated("Use Zlib.constants.Z_BUF_ERROR instead")
 	static var Z_BUF_ERROR(default, null):Int;
+
+	@:deprecated("Use Zlib.constants.Z_VERSION_ERROR instead")
 	static var Z_VERSION_ERROR(default, null):Int;
 
 	/**
 		Compression levels.
 	**/
+	@:deprecated("Use Zlib.constants.Z_NO_COMPRESSION instead")
 	static var Z_NO_COMPRESSION(default, null):Int;
 
+	@:deprecated("Use Zlib.constants.Z_BEST_SPEED instead")
 	static var Z_BEST_SPEED(default, null):Int;
+
+	@:deprecated("Use Zlib.constants.Z_BEST_COMPRESSION instead")
 	static var Z_BEST_COMPRESSION(default, null):Int;
+
+	@:deprecated("Use Zlib.constants.Z_DEFAULT_COMPRESSION instead")
 	static var Z_DEFAULT_COMPRESSION(default, null):Int;
 
 	/**
 		Compression strategy.
 	**/
+	@:deprecated("Use Zlib.constants.Z_FILTERED instead")
 	static var Z_FILTERED(default, null):Int;
 
+	@:deprecated("Use Zlib.constants.Z_HUFFMAN_ONLY instead")
 	static var Z_HUFFMAN_ONLY(default, null):Int;
+
+	@:deprecated("Use Zlib.constants.Z_RLE instead")
 	static var Z_RLE(default, null):Int;
+
+	@:deprecated("Use Zlib.constants.Z_FIXED instead")
 	static var Z_FIXED(default, null):Int;
+
+	@:deprecated("Use Zlib.constants.Z_DEFAULT_STRATEGY instead")
 	static var Z_DEFAULT_STRATEGY(default, null):Int;
 
-	/**
-		Possible values of the data_type field.
-	**/
-	static var Z_BINARY(default, null):Int;
-
-	static var Z_TEXT(default, null):Int;
-	static var Z_ASCII(default, null):Int;
-	static var Z_UNKNOWN(default, null):Int;
-
-	/**
-		The deflate compression method (the only one supported in this version).
-	**/
-	static var Z_DEFLATED(default, null):Int;
-
-	/**
-		For initializing zalloc, zfree, opaque.
-	**/
-	static var Z_NULL(default, null):Int;
-
-	/**
-		Object containing all zlib constants (including Z_*, BROTLI_*, and ZSTD_*).
-		Prefer this over the legacy top-level `Z_*` fields on this class.
-	**/
-	// TODO(section-2): typed ZlibConstants covering Z_*/BROTLI_*/ZSTD_* instead of DynamicAccess
-	static var constants(default, null):DynamicAccess<Int>;
 
 	/**
 		Returns a new `Gzip` object with an `options`.
@@ -301,135 +554,136 @@ extern class Zlib {
 	/**
 		Computes a 32-bit Cyclic Redundancy Check checksum of `data`.
 		If `value` is given, it is used as the starting value of the checksum.
+		When `data` is a string, it is encoded as UTF-8 before computation.
 	**/
-	static function crc32(data:EitherType<String, Buffer>, ?value:Int):Int;
+	static function crc32(data:ZlibInput, ?value:Int):Int;
 
 	/**
-		Compress a string with `Deflate`.
+		Compress a chunk of data with `Deflate`.
 	**/
-	@:overload(function(buf:EitherType<String, Buffer>, options:ZlibOptions, callback:Error->Buffer->Void):Void {})
-	static function deflate(buf:EitherType<String, Buffer>, callback:Error->Buffer->Void):Void;
+	@:overload(function(buf:ZlibInput, options:ZlibOptions, callback:Error->Buffer->Void):Void {})
+	static function deflate(buf:ZlibInput, callback:Error->Buffer->Void):Void;
 
 	/**
-		Compress a string with `Deflate` (synchronous version).
+		Compress a chunk of data with `Deflate` (synchronous version).
 	**/
-	static function deflateSync(buf:EitherType<String, Buffer>, ?options:ZlibOptions):Buffer;
+	static function deflateSync(buf:ZlibInput, ?options:ZlibOptions):Buffer;
 
 	/**
-		Compress a string with `DeflateRaw`.
+		Compress a chunk of data with `DeflateRaw`.
 	**/
-	@:overload(function(buf:EitherType<String, Buffer>, options:ZlibOptions, callback:Error->Buffer->Void):Void {})
-	static function deflateRaw(buf:EitherType<String, Buffer>, callback:Error->Buffer->Void):Void;
+	@:overload(function(buf:ZlibInput, options:ZlibOptions, callback:Error->Buffer->Void):Void {})
+	static function deflateRaw(buf:ZlibInput, callback:Error->Buffer->Void):Void;
 
 	/**
-		Compress a string with `DeflateRaw` (synchronous version).
+		Compress a chunk of data with `DeflateRaw` (synchronous version).
 	**/
-	static function deflateRawSync(buf:EitherType<String, Buffer>, ?options:ZlibOptions):Buffer;
+	static function deflateRawSync(buf:ZlibInput, ?options:ZlibOptions):Buffer;
 
 	/**
-		Compress a string with `Gzip`.
+		Compress a chunk of data with `Gzip`.
 	**/
-	@:overload(function(buf:EitherType<String, Buffer>, options:ZlibOptions, callback:Error->Buffer->Void):Void {})
-	static function gzip(buf:EitherType<String, Buffer>, callback:Error->Buffer->Void):Void;
+	@:overload(function(buf:ZlibInput, options:ZlibOptions, callback:Error->Buffer->Void):Void {})
+	static function gzip(buf:ZlibInput, callback:Error->Buffer->Void):Void;
 
 	/**
-		Compress a string with `Gzip` (synchronous version).
+		Compress a chunk of data with `Gzip` (synchronous version).
 	**/
-	static function gzipSync(buf:EitherType<String, Buffer>, ?options:ZlibOptions):Buffer;
+	static function gzipSync(buf:ZlibInput, ?options:ZlibOptions):Buffer;
 
 	/**
-		Decompress a raw Buffer with `Gunzip`.
+		Decompress a chunk of data with `Gunzip`.
 	**/
-	@:overload(function(buf:EitherType<String, Buffer>, options:ZlibOptions, callback:Error->Buffer->Void):Void {})
-	static function gunzip(buf:EitherType<String, Buffer>, callback:Error->Buffer->Void):Void;
+	@:overload(function(buf:ZlibInput, options:ZlibOptions, callback:Error->Buffer->Void):Void {})
+	static function gunzip(buf:ZlibInput, callback:Error->Buffer->Void):Void;
 
 	/**
-		Decompress a raw Buffer with `Gunzip` (synchronous version).
+		Decompress a chunk of data with `Gunzip` (synchronous version).
 	**/
-	static function gunzipSync(buf:EitherType<String, Buffer>, ?options:ZlibOptions):Buffer;
+	static function gunzipSync(buf:ZlibInput, ?options:ZlibOptions):Buffer;
 
 	/**
-		Decompress a raw Buffer with `Inflate`.
+		Decompress a chunk of data with `Inflate`.
 	**/
-	@:overload(function(buf:EitherType<String, Buffer>, options:ZlibOptions, callback:Error->Buffer->Void):Void {})
-	static function inflate(buf:EitherType<String, Buffer>, callback:Error->Buffer->Void):Void;
+	@:overload(function(buf:ZlibInput, options:ZlibOptions, callback:Error->Buffer->Void):Void {})
+	static function inflate(buf:ZlibInput, callback:Error->Buffer->Void):Void;
 
 	/**
-		Decompress a raw Buffer with `Inflate` (synchronous version).
+		Decompress a chunk of data with `Inflate` (synchronous version).
 	**/
-	static function inflateSync(buf:EitherType<String, Buffer>, ?options:ZlibOptions):Buffer;
+	static function inflateSync(buf:ZlibInput, ?options:ZlibOptions):Buffer;
 
 	/**
-		Decompress a raw Buffer with `InflateRaw`.
+		Decompress a chunk of data with `InflateRaw`.
 	**/
-	@:overload(function(buf:EitherType<String, Buffer>, options:ZlibOptions, callback:Error->Buffer->Void):Void {})
-	static function inflateRaw(buf:EitherType<String, Buffer>, callback:Error->Buffer->Void):Void;
+	@:overload(function(buf:ZlibInput, options:ZlibOptions, callback:Error->Buffer->Void):Void {})
+	static function inflateRaw(buf:ZlibInput, callback:Error->Buffer->Void):Void;
 
 	/**
-		Decompress a raw Buffer with `InflateRaw` (synchronous version).
+		Decompress a chunk of data with `InflateRaw` (synchronous version).
 	**/
-	static function inflateRawSync(buf:EitherType<String, Buffer>, ?options:ZlibOptions):Buffer;
+	static function inflateRawSync(buf:ZlibInput, ?options:ZlibOptions):Buffer;
 
 	/**
-		Decompress a raw Buffer with `Unzip`.
+		Decompress a chunk of data with `Unzip`.
 	**/
-	@:overload(function(buf:EitherType<String, Buffer>, options:ZlibOptions, callback:Error->Buffer->Void):Void {})
-	static function unzip(buf:EitherType<String, Buffer>, callback:Error->Buffer->Void):Void;
+	@:overload(function(buf:ZlibInput, options:ZlibOptions, callback:Error->Buffer->Void):Void {})
+	static function unzip(buf:ZlibInput, callback:Error->Buffer->Void):Void;
 
 	/**
-		Decompress a raw Buffer with `Unzip` (synchronous version).
+		Decompress a chunk of data with `Unzip` (synchronous version).
 	**/
-	static function unzipSync(buf:EitherType<String, Buffer>, ?options:ZlibOptions):Buffer;
+	static function unzipSync(buf:ZlibInput, ?options:ZlibOptions):Buffer;
 
 	/**
-		Compress a string with `BrotliCompress`.
+		Compress a chunk of data with `BrotliCompress`.
 	**/
-	@:overload(function(buf:EitherType<String, Buffer>, options:BrotliOptions, callback:Error->Buffer->Void):Void {})
-	static function brotliCompress(buf:EitherType<String, Buffer>, callback:Error->Buffer->Void):Void;
+	@:overload(function(buf:ZlibInput, options:BrotliOptions, callback:Error->Buffer->Void):Void {})
+	static function brotliCompress(buf:ZlibInput, callback:Error->Buffer->Void):Void;
 
 	/**
-		Compress a string with `BrotliCompress` (synchronous version).
+		Compress a chunk of data with `BrotliCompress` (synchronous version).
 	**/
-	static function brotliCompressSync(buf:EitherType<String, Buffer>, ?options:BrotliOptions):Buffer;
+	static function brotliCompressSync(buf:ZlibInput, ?options:BrotliOptions):Buffer;
 
 	/**
-		Decompress a Buffer with `BrotliDecompress`.
+		Decompress a chunk of data with `BrotliDecompress`.
 	**/
-	@:overload(function(buf:EitherType<String, Buffer>, options:BrotliOptions, callback:Error->Buffer->Void):Void {})
-	static function brotliDecompress(buf:EitherType<String, Buffer>, callback:Error->Buffer->Void):Void;
+	@:overload(function(buf:ZlibInput, options:BrotliOptions, callback:Error->Buffer->Void):Void {})
+	static function brotliDecompress(buf:ZlibInput, callback:Error->Buffer->Void):Void;
 
 	/**
-		Decompress a Buffer with `BrotliDecompress` (synchronous version).
+		Decompress a chunk of data with `BrotliDecompress` (synchronous version).
 	**/
-	static function brotliDecompressSync(buf:EitherType<String, Buffer>, ?options:BrotliOptions):Buffer;
+	static function brotliDecompressSync(buf:ZlibInput, ?options:BrotliOptions):Buffer;
 
 	/**
 		Compress a chunk of data with `ZstdCompress`.
 
 		Stability: 1 - Experimental
 	**/
-	@:overload(function(buf:EitherType<String, Buffer>, options:ZstdOptions, callback:Error->Buffer->Void):Void {})
-	static function zstdCompress(buf:EitherType<String, Buffer>, callback:Error->Buffer->Void):Void;
+	@:overload(function(buf:ZlibInput, options:ZstdOptions, callback:Error->Buffer->Void):Void {})
+	static function zstdCompress(buf:ZlibInput, callback:Error->Buffer->Void):Void;
 
 	/**
 		Compress a chunk of data with `ZstdCompress` (synchronous version).
 
 		Stability: 1 - Experimental
 	**/
-	static function zstdCompressSync(buf:EitherType<String, Buffer>, ?options:ZstdOptions):Buffer;
+	static function zstdCompressSync(buf:ZlibInput, ?options:ZstdOptions):Buffer;
 
 	/**
 		Decompress a chunk of data with `ZstdDecompress`.
 
 		Stability: 1 - Experimental
 	**/
-	@:overload(function(buf:EitherType<String, Buffer>, options:ZstdOptions, callback:Error->Buffer->Void):Void {})
-	static function zstdDecompress(buf:EitherType<String, Buffer>, callback:Error->Buffer->Void):Void;
+	@:overload(function(buf:ZlibInput, options:ZstdOptions, callback:Error->Buffer->Void):Void {})
+	static function zstdDecompress(buf:ZlibInput, callback:Error->Buffer->Void):Void;
 
 	/**
 		Decompress a chunk of data with `ZstdDecompress` (synchronous version).
 
 		Stability: 1 - Experimental
 	**/
-	static function zstdDecompressSync(buf:EitherType<String, Buffer>, ?options:ZstdOptions):Buffer;
+	static function zstdDecompressSync(buf:ZlibInput, ?options:ZstdOptions):Buffer;
 }

--- a/src/js/node/zlib/BrotliCompress.hx
+++ b/src/js/node/zlib/BrotliCompress.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,6 +24,8 @@ package js.node.zlib;
 
 /**
 	Compress data using the Brotli algorithm.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/zlib.html#class-zlibbrotlicompress
 **/
 @:jsRequire("zlib", "BrotliCompress")
 extern class BrotliCompress extends Zlib {}

--- a/src/js/node/zlib/BrotliDecompress.hx
+++ b/src/js/node/zlib/BrotliDecompress.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,6 +24,8 @@ package js.node.zlib;
 
 /**
 	Decompress a Brotli stream.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/zlib.html#class-zlibbrotlidecompress
 **/
 @:jsRequire("zlib", "BrotliDecompress")
 extern class BrotliDecompress extends Zlib {}

--- a/src/js/node/zlib/Deflate.hx
+++ b/src/js/node/zlib/Deflate.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,6 +24,8 @@ package js.node.zlib;
 
 /**
 	Compress data using deflate.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/zlib.html#class-zlibdeflate
 **/
 @:jsRequire("zlib", "Deflate")
 extern class Deflate extends Zlib {}

--- a/src/js/node/zlib/DeflateRaw.hx
+++ b/src/js/node/zlib/DeflateRaw.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,6 +24,8 @@ package js.node.zlib;
 
 /**
 	Compress data using deflate, and do not append a zlib header.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/zlib.html#class-zlibdeflateraw
 **/
 @:jsRequire("zlib", "DeflateRaw")
 extern class DeflateRaw extends Zlib {}

--- a/src/js/node/zlib/Gunzip.hx
+++ b/src/js/node/zlib/Gunzip.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,6 +24,8 @@ package js.node.zlib;
 
 /**
 	Decompress a gzip stream.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/zlib.html#class-zlibgunzip
 **/
 @:jsRequire("zlib", "Gunzip")
 extern class Gunzip extends Zlib {}

--- a/src/js/node/zlib/Gzip.hx
+++ b/src/js/node/zlib/Gzip.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,6 +24,8 @@ package js.node.zlib;
 
 /**
 	Compress data using gzip.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/zlib.html#class-zlibgzip
 **/
 @:jsRequire("zlib", "Gzip")
 extern class Gzip extends Zlib {}

--- a/src/js/node/zlib/Inflate.hx
+++ b/src/js/node/zlib/Inflate.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,6 +24,8 @@ package js.node.zlib;
 
 /**
 	Decompress a deflate stream.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/zlib.html#class-zlibinflate
 **/
 @:jsRequire("zlib", "Inflate")
 extern class Inflate extends Zlib {}

--- a/src/js/node/zlib/InflateRaw.hx
+++ b/src/js/node/zlib/InflateRaw.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,6 +24,8 @@ package js.node.zlib;
 
 /**
 	Decompress a raw deflate stream.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/zlib.html#class-zlibinflateraw
 **/
 @:jsRequire("zlib", "InflateRaw")
 extern class InflateRaw extends Zlib {}

--- a/src/js/node/zlib/Unzip.hx
+++ b/src/js/node/zlib/Unzip.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,6 +24,8 @@ package js.node.zlib;
 
 /**
 	Decompress either a Gzip- or Deflate-compressed stream by auto-detecting the header.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/zlib.html#class-zlibunzip
 **/
 @:jsRequire("zlib", "Unzip")
 extern class Unzip extends Zlib {}

--- a/src/js/node/zlib/Zlib.hx
+++ b/src/js/node/zlib/Zlib.hx
@@ -46,9 +46,9 @@ extern class Zlib extends js.node.stream.Transform<Zlib> {
 	/**
 		Flush pending data.
 
-		`kind` defaults to `Zlib.constants.Z_FULL_FLUSH` for zlib-based streams,
-		`Zlib.constants.BROTLI_OPERATION_FLUSH` for Brotli-based streams, and
-		`Zlib.constants.ZSTD_e_flush` for Zstd-based streams.
+		`kind` defaults to `js.node.Zlib.constants.Z_FULL_FLUSH` for zlib-based streams,
+		`js.node.Zlib.constants.BROTLI_OPERATION_FLUSH` for Brotli-based streams, and
+		`js.node.Zlib.constants.ZSTD_e_flush` for Zstd-based streams.
 
 		Don't call this frivolously; premature flushes negatively impact the
 		effectiveness of the compression algorithm.

--- a/src/js/node/zlib/Zlib.hx
+++ b/src/js/node/zlib/Zlib.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,7 +24,12 @@ package js.node.zlib;
 
 /**
 	Not exported by the zlib module.
-	It is documented here because it is the base class of the compressor/decompressor classes.
+	Documented here as the base class of the compressor/decompressor classes.
+
+	Renamed from `Zlib` to `ZlibBase` in Node.js documentation (v11.7.0+);
+	this type keeps the historical Haxe name.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/zlib.html#class-zlibzlibbase
 **/
 extern class Zlib extends js.node.stream.Transform<Zlib> {
 	/**
@@ -34,18 +39,26 @@ extern class Zlib extends js.node.stream.Transform<Zlib> {
 	var bytesWritten(default, null):Float;
 
 	/**
+		Close the underlying handle.
+	**/
+	function close(?callback:Void->Void):Void;
+
+	/**
 		Flush pending data.
 
-		`kind` defaults to `Zlib.Z_FULL_FLUSH`.
+		`kind` defaults to `Zlib.constants.Z_FULL_FLUSH` for zlib-based streams,
+		`Zlib.constants.BROTLI_OPERATION_FLUSH` for Brotli-based streams, and
+		`Zlib.constants.ZSTD_e_flush` for Zstd-based streams.
 
-		Don't call this frivolously, premature flushes negatively impact the effectiveness of the compression algorithm.
+		Don't call this frivolously; premature flushes negatively impact the
+		effectiveness of the compression algorithm.
 	**/
 	@:overload(function(kind:Int, callback:Void->Void):Void {})
 	function flush(callback:Void->Void):Void;
 
 	/**
 		Dynamically update the compression level and compression strategy.
-		Only applicable to deflate algorithm.
+		Only available for zlib-based (deflate) streams — not Brotli or Zstd.
 	**/
 	function params(level:Int, strategy:Int, callback:Void->Void):Void;
 

--- a/src/js/node/zlib/ZstdCompress.hx
+++ b/src/js/node/zlib/ZstdCompress.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -26,6 +26,8 @@ package js.node.zlib;
 	Compress data using the Zstandard (zstd) algorithm.
 
 	Stability: 1 - Experimental
+
+	@see https://nodejs.org/docs/latest-v24.x/api/zlib.html#class-zlibzstdcompress
 **/
 @:jsRequire("zlib", "ZstdCompress")
 extern class ZstdCompress extends Zlib {}

--- a/src/js/node/zlib/ZstdDecompress.hx
+++ b/src/js/node/zlib/ZstdDecompress.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -26,6 +26,8 @@ package js.node.zlib;
 	Decompress data using the Zstandard (zstd) algorithm.
 
 	Stability: 1 - Experimental
+
+	@see https://nodejs.org/docs/latest-v24.x/api/zlib.html#class-zlibzstddecompress
 **/
 @:jsRequire("zlib", "ZstdDecompress")
 extern class ZstdDecompress extends Zlib {}


### PR DESCRIPTION
## Summary
- Types `Zlib.constants` as `ZlibConstants` (Z_*/Brotli/Zstd) and marks legacy top-level `Z_*` fields `@:deprecated` in favor of `Zlib.constants.*`.
- Widens convenience-method / `crc32` / dictionary inputs to string | Buffer | ArrayBuffer | ArrayBufferView; adds `ZstdOptions.pledgedSrcSize` and `zlib.Zlib.close`.
- Removes obsolete top-level constants that Node no longer exposes (`Z_TREES`, `Z_NULL`, data-type / `Z_DEFLATED` leftovers); refreshes `@see` docs and copyright to 2014–2026.

## Test plan
- [x] `haxe completion.hxml` succeeds
- [ ] Spot-check against Node.js v24 zlib docs (`constants`, `close`, `pledgedSrcSize`, TypedArray inputs)
- [ ] Confirm existing Brotli/Zstd callers still type-check with deprecated top-level `Z_*` where used


Made with [Cursor](https://cursor.com)