### PR TITLE
Audit http externs for Node 24 + Haxe 4

### DIFF
--- a/src/js/node/Http.hx
+++ b/src/js/node/Http.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -81,7 +81,13 @@ extern class Http {
 	**/
 	static var globalAgent:Agent;
 
-	static var maxHeaderSize:Int;
+	/**
+		Read-only maximum allowed size of HTTP headers in bytes.
+		Defaults to 16 KiB. Configurable via `--max-http-header-size`.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/http.html#httpmaxheadersize
+	**/
+	static var maxHeaderSize(default, null):Int;
 
 	/**
 		Node.js maintains several connections per server to make HTTP requests.
@@ -125,6 +131,16 @@ extern class Http {
 		Undici `WebSocket` constructor exposed via `node:http`.
 	**/
 	static var WebSocket:Class<js.node.web.WebSocket>;
+
+	/**
+		Undici `CloseEvent` constructor exposed via `node:http`.
+	**/
+	static var CloseEvent:Class<js.node.web.CloseEvent>;
+
+	/**
+		Undici `MessageEvent` constructor exposed via `node:http`.
+	**/
+	static var MessageEvent:Class<js.node.web.MessageEvent>;
 
 	/**
 		Parent class of `http.ClientRequest` and `http.ServerResponse`.
@@ -217,16 +233,53 @@ typedef HttpCreateServerOptions = {
 	@:optional var noDelay:Bool;
 
 	/**
-		Sets the maximum number of unique header names allowed per request. Default: `2000`.
+		Optionally overrides the value of `--max-http-header-size` for requests
+		received by this server. Default: `16384` (16 KiB).
+	**/
+	@:optional var maxHeaderSize:Int;
+
+	/**
+		If set to `true`, use an HTTP parser with leniency flags enabled.
+		Default: `false`.
+	**/
+	@:optional var insecureHTTPParser:Bool;
+
+	/**
+		If set to `true`, join duplicate header field values with `, ` instead of discarding.
+		Default: `false`.
 	**/
 	@:optional var joinDuplicateHeaders:Bool;
 
 	/**
+		If set to `true`, respond with `400 Bad Request` when an HTTP/1.1 request lacks a `Host` header.
+		Default: `true`.
+	**/
+	@:optional var requireHostHeader:Bool;
+
+	/**
+		Callback that receives an incoming request and returns whether an upgrade should be accepted.
+		Default: accept upgrades when a `'upgrade'` listener is registered.
+	**/
+	@:optional var shouldUpgradeCallback:(request:IncomingMessage) -> Bool;
+
+	/**
 		`uniqueHeaders` is an optional configuration specific to HTTP servers.
 
-		@see https://nodejs.org/api/http.html#httpcreateserveroptions-requestlistener
+		@see https://nodejs.org/docs/latest-v24.x/api/http.html#httpcreateserveroptions-requestlistener
 	**/
 	@:optional var uniqueHeaders:Array<EitherType<String, Array<String>>>;
+
+	/**
+		If set to `true`, writing a body for methods/statuses that do not allow one throws.
+		Default: `false`.
+	**/
+	@:optional var rejectNonStandardBodyWrites:Bool;
+
+	/**
+		If set to `true`, requests without a body are initialized as already-ended readable streams.
+		Default: `false`.
+	**/
+	@:optional var optimizeEmptyRequests:Bool;
 }
 
 /**
@@ -252,10 +305,10 @@ typedef HttpRequestOptions = {
 	/**
 		A function that produces a socket/stream to use for the request when the `agent` option is not used.
 		This can be used to avoid creating a custom `Agent` class just to override the default `createConnection` function.
-		See [agent.createConnection()](https://nodejs.org/api/http.html#http_agent_createconnection_options_callback) for more details.
+		See [agent.createConnection()](https://nodejs.org/docs/latest-v24.x/api/http.html#agentcreateconnectionoptions-callback) for more details.
 		Any `Duplex` stream is a valid return value.
 	**/
-	@:optional var createConnection:(options:SocketConnectOptionsTcp, ?callabck:(err:Error, stream:IDuplex) -> Void) -> IDuplex;
+	@:optional var createConnection:(options:SocketConnectOptionsTcp, ?callback:(err:Error, stream:IDuplex) -> Void) -> IDuplex;
 
 	/**
 		Default port for the protocol.
@@ -271,9 +324,9 @@ typedef HttpRequestOptions = {
 	@:optional var family:js.node.Dns.DnsAddressFamily;
 
 	/**
-		An object containing request headers.
+		An object or raw-headers array containing request headers.
 	**/
-	@:optional var headers:DynamicAccess<EitherType<String, Array<String>>>;
+	@:optional var headers:EitherType<DynamicAccess<EitherType<String, Array<String>>>, Array<String>>;
 
 	/**
 		A domain name or IP address of the server to issue the request to.
@@ -324,7 +377,15 @@ typedef HttpRequestOptions = {
 	@:optional var protocol:String;
 
 	/**
+		Specifies whether or not to automatically add default headers such as
+		`Connection`, `Content-Length`, `Transfer-Encoding`, and `Host`.
+		Defaults to `true`.
+	**/
+	@:optional var setDefaultHeaders:Bool;
+
+	/**
 		Specifies whether or not to automatically add the Host header.
+		If provided, this overrides `setDefaultHeaders`.
 		Defaults to `true`.
 	**/
 	@:optional var setHost:Bool;
@@ -349,6 +410,12 @@ typedef HttpRequestOptions = {
 		Optional dns.lookup() hints.
 	**/
 	@:optional var hints:Int;
+
+	/**
+		Custom lookup function. Default: `Dns.lookup`.
+	**/
+	@:optional var lookup:(hostname:String, options:Null<js.node.Dns.DnsLookupOptions>,
+		callback:js.node.Dns.DnsLookupCallbackSingle) -> Void;
 
 	/**
 		An AbortSignal that may be used to abort an ongoing request.

--- a/src/js/node/http/Agent.hx
+++ b/src/js/node/http/Agent.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -80,7 +80,7 @@ extern class Agent {
 		This method can be overridden by a particular `Agent` subclass.
 		If this method returns a falsy value, the socket will be destroyed instead of persisting it for use with the next request.
 	**/
-	function keepSocketAlive(socket:Socket):Void;
+	function keepSocketAlive(socket:Socket):Any;
 
 	/**
 		Called when `socket` is attached to `request` after being persisted because of the keep-alive options.
@@ -101,7 +101,7 @@ extern class Agent {
 	/**
 		An object which contains arrays of sockets currently awaiting use by the agent when keepAlive is enabled.
 		Do not modify.
-	 */
+	**/
 	var freeSockets(default, null):DynamicAccess<Array<Socket>>;
 
 	/**
@@ -140,6 +140,25 @@ extern class Agent {
 		Do not modify.
 	**/
 	var sockets(default, null):DynamicAccess<Array<Socket>>;
+
+	/**
+		Default port to use when the port is not specified in requests.
+
+		Default: `80`.
+	**/
+	var defaultPort:Int;
+
+	/**
+		The protocol to use for the agent.
+
+		Default: `'http:'`.
+	**/
+	var protocol:String;
+
+	/**
+		The set of options used when creating the agent. Read-only.
+	**/
+	var options(default, null):HttpAgentOptions;
 }
 
 /**
@@ -194,4 +213,31 @@ typedef HttpAgentOptions = {
 		Scheduling strategy when picking an idle socket. One of `'fifo'` or `'lifo'`. Default: `'lifo'`.
 	**/
 	@:optional var scheduling:String;
+
+	/**
+		Environment variables for built-in proxy configuration.
+
+		See Built-in Proxy Support for details. Default: `undefined`.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/http.html#built-in-proxy-support
+	**/
+	@:optional var proxyEnv:DynamicAccess<String>;
+
+	/**
+		Default port to use when the port is not specified in requests. Default: `80`.
+	**/
+	@:optional var defaultPort:Int;
+
+	/**
+		The protocol to use for the agent. Default: `'http:'`.
+	**/
+	@:optional var protocol:String;
+
+	/**
+		Milliseconds to subtract from the server-provided `keep-alive: timeout=...` hint
+		when determining socket expiration time. Default: `1000`.
+
+		Added in: v24.7.0.
+	**/
+	@:optional var agentKeepAliveTimeoutBuffer:Int;
 }

--- a/src/js/node/http/ClientRequest.hx
+++ b/src/js/node/http/ClientRequest.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -35,7 +35,10 @@ enum abstract ClientRequestEvent<T:haxe.Constraints.Function>(Event<T>) to Event
 	/**
 		Emitted when the request has been aborted by the client.
 		This event is only emitted on the first call to `abort()`.
+
+		Deprecated since Node.js v17.0.0. Listen for `'close'` instead.
 	**/
+	@:deprecated("Listen for ClientRequestEvent.Close / 'close' instead")
 	var Abort:ClientRequestEvent<Void->Void> = "abort";
 
 	/**
@@ -80,9 +83,9 @@ enum abstract ClientRequestEvent<T:haxe.Constraints.Function>(Event<T>) to Event
 
 	/**
 		Emitted when the underlying socket times out from inactivity.
-		This only notifies that the socket has been idle. The request must be aborted manually.
+		This only notifies that the socket has been idle. The request must be destroyed manually.
 
-		See also: [request.setTimeout()](https://nodejs.org/api/http.html#http_request_settimeout_timeout_callback).
+		See also: [request.setTimeout()](https://nodejs.org/docs/latest-v24.x/api/http.html#requestsettimeouttimeout-callback).
 	**/
 	var Timeout:ClientRequestEvent<Socket->Void> = "timeout";
 
@@ -92,10 +95,10 @@ enum abstract ClientRequestEvent<T:haxe.Constraints.Function>(Event<T>) to Event
 		clients receiving an upgrade header will have their connections closed.
 	**/
 	var Upgrade:ClientRequestEvent<(response:IncomingMessage, socket:Socket, head:Buffer) -> Void> = "upgrade";
-	}
+}
 
 /**
-	This object is created internally and returned from http.request().
+	This object is created internally and returned from `http.request()`.
 	It represents an in-progress request whose header has already been queued.
 	The header is still mutable using the `setHeader(name, value)`, `getHeader(name)`, `removeHeader(name)` API.
 	The actual header will be sent along with the first data chunk or when calling `request.end()`.
@@ -116,27 +119,41 @@ enum abstract ClientRequestEvent<T:haxe.Constraints.Function>(Event<T>) to Event
 	but instead emits the `'aborted'` event.
 
 	Node.js does not check whether Content-Length and the length of the body which has been transmitted are equal or not.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/http.html#class-httpclientrequest
 **/
 @:jsRequire("http", "ClientRequest")
 extern class ClientRequest extends Writable<ClientRequest> {
 	/**
 		Marks the request as aborting. Calling this will cause remaining data in the response to be dropped and the socket to be destroyed.
+
+		Deprecated since Node.js v14.1.0 / v13.14.0. Use `destroy()` instead.
 	**/
+	@:deprecated("Use destroy() instead")
 	function abort():Void;
 
 	/**
-		The request.aborted property will be true if the request has been aborted.
+		The `request.aborted` property will be `true` if the request has been aborted.
+
+		Deprecated since Node.js v17.0.0. Check `destroyed` instead.
 	**/
+	@:deprecated("Use destroyed instead")
 	var aborted(default, null):Bool;
 
 	/**
 		See `request.socket`.
+
+		Deprecated since Node.js v16.0.0.
 	**/
+	@:deprecated("Use socket instead")
 	var connection(default, null):Socket;
 
 	/**
-		The `response.finished` property will be true if `response.end()` has been called.
+		The `request.finished` property will be true if `request.end()` has been called.
+
+		Deprecated since Node.js v13.4.0 / v12.16.0. Use `writableEnded` instead.
 	**/
+	@:deprecated("Use writableEnded instead")
 	var finished(default, null):Bool;
 
 	/**
@@ -260,10 +277,15 @@ extern class ClientRequest extends Writable<ClientRequest> {
 	function setTimeout(timeout:Int, ?callback:Socket->Void):ClientRequest;
 
 	/**
+		Clears the timeout set by `request.setTimeout()`.
+	**/
+	function clearTimeout():Void;
+
+	/**
 		Reference to the underlying socket. Usually users will not want to access this property.
 		In particular, the socket will not emit `'readable'` events because of how the protocol parser attaches to the socket.
 		The `socket` may also be accessed via `request.connection`.
-	 */
+	**/
 	var socket(default, null):Socket;
 
 	// This field is defined in super class.

--- a/src/js/node/http/IncomingMessage.hx
+++ b/src/js/node/http/IncomingMessage.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -26,21 +26,25 @@ import haxe.DynamicAccess;
 import js.node.events.EventEmitter.Event;
 import js.node.net.Socket;
 import js.node.stream.Readable;
+import js.node.web.AbortSignal;
 import js.lib.Error;
 
 /**
 	Enumeration of events emitted by the `IncomingMessage` objects in addition to its parent class events.
 **/
-enum abstract IncomingMessageeEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
+enum abstract IncomingMessageEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 	/**
 		Emitted when the request has been aborted.
+
+		@deprecated Listen for the `'close'` event instead.
 	**/
-	var Aborted:IncomingMessageeEvent<Void->Void> = "aborted";
+	@:deprecated("Listen for close instead")
+	var Aborted:IncomingMessageEvent<Void->Void> = "aborted";
 
 	/**
-		Indicates that the underlying connection was closed.
+		Indicates that the underlying connection was closed / the request has been completed.
 	**/
-	var Close:IncomingMessageeEvent<Void->Void> = "close";
+	var Close:IncomingMessageEvent<Void->Void> = "close";
 }
 
 /**
@@ -48,12 +52,15 @@ enum abstract IncomingMessageeEvent<T:haxe.Constraints.Function>(Event<T>) to Ev
 	It may be used to access response status, headers and data.
 
 	It implements the `Readable Stream` interface, as well as the following additional events, methods, and properties.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/http.html#class-httpincomingmessage
 **/
 @:jsRequire("http", "IncomingMessage")
 extern class IncomingMessage extends Readable<IncomingMessage> {
 	/**
 		The `aborted` property will be `true` if the request has been aborted.
 	**/
+	@:deprecated("Use destroyed instead")
 	var aborted(default, null):Bool;
 
 	/**
@@ -75,7 +82,7 @@ extern class IncomingMessage extends Readable<IncomingMessage> {
 		Duplicates in raw headers are handled in the following ways, depending on the header name:
 
 		- Duplicates of `age`, `authorization`, `content-length`, `content-type`, `etag`, `expires`, `from`, `host`, `if-modified-since`, `if-unmodified-since`,
-		  `last-modified`, `location`, `max-forwards`, `proxy-authorization`, `referer`, `retry-after`, or `user-agent` are discarded.
+		  `last-modified`, `location`, `max-forwards`, `proxy-authorization`, `referer`, `retry-after`, `server`, or `user-agent` are discarded.
 		- `set-cookie` is always an array. Duplicates are added to the array.
 		- For duplicate `cookie` headers, the values are joined together with '; '.
 		- For all other headers, the values are joined together with ', '.
@@ -129,9 +136,19 @@ extern class IncomingMessage extends Readable<IncomingMessage> {
 	var rawTrailers(default, null):Array<String>;
 
 	/**
-		Calls `connection.setTimeout(msecs, callback)`.
+		Calls `message.socket.setTimeout(msecs, callback)`.
 	**/
-	function setTimeout(msecs:Int, ?callback:Void->Void):Void;
+	function setTimeout(msecs:Int, ?callback:Void->Void):IncomingMessage;
+
+	/**
+		An `AbortSignal` aborted when the underlying socket closes or the request is destroyed.
+		Created lazily on first access.
+
+		Added in: v24.16.0.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/http.html#messagesignal
+	**/
+	var signal(default, null):AbortSignal;
 
 	/**
 		The `Socket` object associated with the connection.
@@ -143,6 +160,7 @@ extern class IncomingMessage extends Readable<IncomingMessage> {
 	/**
 		Alias for `socket`.
 	**/
+	@:deprecated("Use socket instead")
 	var connection(default, null):Socket;
 
 	/**

--- a/src/js/node/http/Method.hx
+++ b/src/js/node/http/Method.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -23,8 +23,9 @@
 package js.node.http;
 
 /**
-	Enumeration of possible HTTP methods as described in
-	http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html
+	HTTP methods supported by the Node.js HTTP parser (`http.METHODS`).
+
+	@see https://nodejs.org/docs/latest-v24.x/api/http.html#httpmethods
 **/
 enum abstract Method(String) from String to String {
 	var Acl = "ACL";
@@ -35,15 +36,15 @@ enum abstract Method(String) from String to String {
 	var Delete = "DELETE";
 	var Get = "GET";
 	var Head = "HEAD";
-	var Link = "LINK'";
-	var Lock = "LOCK'";
-	var MSearch = "M-SEARCH'";
-	var Merge = "MERGE'";
-	var Mkactivity = "MKACTIVITY'";
-	var Mkcalendar = "MKCALENDAR'";
-	var Mkcol = "MKCOL'";
-	var Move = "MOVE'";
-	var Notify = "NOTIFY'";
+	var Link = "LINK";
+	var Lock = "LOCK";
+	var MSearch = "M-SEARCH";
+	var Merge = "MERGE";
+	var Mkactivity = "MKACTIVITY";
+	var Mkcalendar = "MKCALENDAR";
+	var Mkcol = "MKCOL";
+	var Move = "MOVE";
+	var Notify = "NOTIFY";
 	var Options = "OPTIONS";
 	var Patch = "PATCH";
 	var Post = "POST";
@@ -51,9 +52,11 @@ enum abstract Method(String) from String to String {
 	var Proppatch = "PROPPATCH";
 	var Purge = "PURGE";
 	var Put = "PUT";
+	var Query = "QUERY";
 	var Rebind = "REBIND";
 	var Report = "REPORT";
 	var Search = "SEARCH";
+	var Source = "SOURCE";
 	var Subscribe = "SUBSCRIBE";
 	var Trace = "TRACE";
 	var Unbind = "UNBIND";

--- a/src/js/node/http/OutgoingMessage.hx
+++ b/src/js/node/http/OutgoingMessage.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -36,6 +36,14 @@ import js.node.web.Headers;
 **/
 @:jsRequire("http", "OutgoingMessage")
 extern class OutgoingMessage extends Writable<OutgoingMessage> {
+	/**
+		Adds HTTP trailers (headers at the end of the message) to the message.
+
+		Trailers will only be emitted if the message is chunked encoded.
+	**/
+	@:overload(function(headers:Array<Array<String>>):Void {})
+	function addTrailers(headers:DynamicAccess<String>):Void;
+
 	/**
 		Append a single header value for the header object.
 
@@ -114,6 +122,9 @@ extern class OutgoingMessage extends Writable<OutgoingMessage> {
 
 	/**
 		Alias of `socket`.
+
+		Deprecated since Node.js v16.0.0.
 	**/
+	@:deprecated("Use socket instead")
 	var connection(default, null):Socket;
 }

--- a/src/js/node/http/Server.hx
+++ b/src/js/node/http/Server.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -74,13 +74,13 @@ enum abstract ServerEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 		After this event is emitted, the request's socket will not have a `'data'` event listener,
 		meaning it will need to be bound in order to handle data sent to the server on that socket.
 	**/
-	var Connect:ServerEvent<(request:IncomingMessage, socekt:Socket, head:Buffer) -> Void> = "connect";
+	var Connect:ServerEvent<(request:IncomingMessage, socket:Socket, head:Buffer) -> Void> = "connect";
 
 	/**
 		This event is emitted when a new TCP stream is established.
 		`socket` is typically an object of type net.Socket. Usually users will not want to access this event.
 		In particular, the socket will not emit `'readable'` events because of how the protocol parser attaches to the socket.
-		The `socket` can also be accessed at `request.connection`.
+		The `socket` can also be accessed at `request.socket`.
 
 		This event can also be explicitly emitted by users to inject connections into the HTTP server. In that case,
 		any `Duplex` stream can be passed.
@@ -108,13 +108,15 @@ enum abstract ServerEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
 	/**
 		Emitted when a request could not be completed due to exceeding `server.maxRequestsPerSocket`.
 
-		@see https://nodejs.org/api/http.html#event-droprequest
+		@see https://nodejs.org/docs/latest-v24.x/api/http.html#event-droprequest
 	**/
 	var DropRequest:ServerEvent<(request:IncomingMessage, socket:Socket) -> Void> = "dropRequest";
 }
 
 /**
-	This class inherits `from net.Server`.
+	An HTTP server that inherits from `net.Server`.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/http.html#class-httpserver
 **/
 @:jsRequire("http", "Server")
 extern class Server extends js.node.net.Server {
@@ -129,7 +131,7 @@ extern class Server extends js.node.net.Server {
 		If the check fails, a `'timeout'` event is emitted on the server object, and (by default) the socket is destroyed.
 		See [server.timeout](https://nodejs.org/api/http.html#http_server_timeout) for more information on how timeout behavior can be customized.
 
-		Default: `40000`
+		Default: The minimum between `server.requestTimeout` or `60000`.
 	**/
 	var headersTimeout:Int;
 
@@ -158,13 +160,12 @@ extern class Server extends js.node.net.Server {
 
 		If there is a `'timeout'` event listener on the Server object, then it will be called with the timed-out socket as an argument.
 
-		By default, the Server's timeout value is 2 minutes, and sockets are destroyed automatically if they time out.
-		However, if a callback is assigned to the Server's `'timeout'` event, timeouts must be handled explicitly.
+		By default, the Server's timeout value is 0 (no timeout).
 
-		To change the default timeout use the `--http-server-default-timeout` flag.
+		@see https://nodejs.org/docs/latest-v24.x/api/http.html#serversettimeoutmsecs-callback
 	**/
-	@:overload(function(?callback:js.node.net.Socket->Void):Void {})
-	function setTimeout(msecs:Int, ?callback:js.node.net.Socket->Void):Void;
+	@:overload(function(?callback:js.node.net.Socket->Void):Server {})
+	function setTimeout(msecs:Int, ?callback:js.node.net.Socket->Void):Server;
 
 	/**
 		The number of milliseconds of inactivity before a socket is presumed to have timed out.
@@ -174,9 +175,7 @@ extern class Server extends js.node.net.Server {
 		The socket timeout logic is set up on connection, so changing this value only affects new connections to the server,
 		not any existing connections.
 
-		To change the default timeout use the `--http-server-default-timeout` flag.
-
-		Default: `120000` (2 minutes)
+		Default: `0` (no timeout).
 	**/
 	var timeout:Int;
 

--- a/src/js/node/http/ServerResponse.hx
+++ b/src/js/node/http/ServerResponse.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -65,12 +65,18 @@ extern class ServerResponse extends Writable<ServerResponse> {
 
 	/**
 		See `socket`.
+
+		Deprecated since Node.js v16.0.0.
 	**/
+	@:deprecated("Use socket instead")
 	var connection(default, null):Socket;
 
 	/**
 		The `finished` property will be true if `end()` has been called.
+
+		Deprecated since Node.js v13.4.0 / v12.16.0. Use `writableEnded` instead.
 	**/
+	@:deprecated("Use writableEnded instead")
 	var finished(default, null):Bool;
 
 	/**
@@ -232,19 +238,15 @@ extern class ServerResponse extends Writable<ServerResponse> {
 
 		When headers have been set with `setHeader()`, they will be merged with any headers passed to `writeHead()`, with the headers passed to `writeHead()` given precedence.
 
-		If this method is called and `setHeader()` has not been called, it will directly write the supplied header values onto the network channel without caching internally,
-		and the `getHeader()` on the header will not yield the expected result.
-		If progressive population of headers is desired with potential future retrieval and modification, use `setHeader()` instead.
-
 		`Content-Length` is given in bytes not characters.
-		The above example works because the string `'hello world'` contains only single byte characters.
-		If the body contains higher coded characters then `Buffer.byteLength()` should be used to determine the number of bytes in a given encoding.
-		And Node.js does not check whether `Content-Length` and the length of the body which has been transmitted are equal or not.
 
 		Attempting to set a header field name or value that contains invalid characters will result in a `TypeError` being thrown.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/http.html#responsewriteheadstatuscode-statusmessage-headers
 	**/
-	@:overload(function(statusCode:Int, ?headers:DynamicAccess<String>):Void {})
-	function writeHead(statusCode:Int, reasonPhrase:String, ?headers:DynamicAccess<String>):Void;
+	@:overload(function(statusCode:Int, ?headers:DynamicAccess<String>):ServerResponse {})
+	@:overload(function(statusCode:Int, ?headers:Array<String>):ServerResponse {})
+	function writeHead(statusCode:Int, reasonPhrase:String, ?headers:DynamicAccess<String>):ServerResponse;
 
 	/**
 		Sends a HTTP/1.1 102 Processing message to the client, indicating that the request body should be sent.


### PR DESCRIPTION
## Summary
- Aligns `js.node.Http` and `js.node.http.*` with Node.js v24 Active LTS (`createServer` / `request` options, Agent `proxyEnv` / `defaultPort` / `protocol` / `agentKeepAliveTimeoutBuffer`, `IncomingMessage.signal`, `CloseEvent` / `MessageEvent`, `OutgoingMessage.addTrailers`).
- Fixes Method abstract value typos (stray quotes), adds missing `QUERY` / `SOURCE`, renames `IncomingMessageeEvent` → `IncomingMessageEvent`, and corrects `socekt` / `callabck` parameter names.
- Marks deprecated surfaces (`abort` / `aborted` / `finished` / `connection`) with replacement guidance; refreshes copyright to 2014–2026 and docs links to latest-v24.x.

## Test plan
- [x] `haxe build.hxml` (ImportAll) succeeds
- [ ] Spot-check HTTP examples still typecheck
- [ ] Review `IncomingMessageEvent` rename for any downstream callers of the old typo name


Made with [Cursor](https://cursor.com)