### PR TITLE
Audit js.node events for Node 24 + Haxe 4

### DIFF
--- a/src/js/node/Events.hx
+++ b/src/js/node/Events.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -23,19 +23,21 @@
 package js.node;
 
 import haxe.Constraints.Function;
+import haxe.extern.EitherType;
 import haxe.extern.Rest;
 import js.lib.Promise;
 import js.lib.Symbol;
 import js.node.events.EventEmitter;
 import js.node.web.AbortSignal;
+import js.node.web.EventTarget;
 
 /**
 	Much of the Node.js core API is built around an idiomatic asynchronous event-driven architecture
 	in which certain kinds of objects (called "emitters") emit named events that cause `Function` objects
 	("listeners") to be called.
 
-	@see https://nodejs.org/api/events.html#events_events
- */
+	@see https://nodejs.org/api/events.html
+**/
 @:jsRequire("events")
 extern class Events {
 	/**
@@ -64,24 +66,29 @@ extern class Events {
 	/**
 		By default, a maximum of `10` listeners can be registered for any single event.
 		This alias mirrors `EventEmitter.defaultMaxListeners`.
+		If this value is not a positive number, a `RangeError` is thrown.
 
 		@see https://nodejs.org/api/events.html#eventsdefaultmaxlisteners
 	**/
 	static var defaultMaxListeners:Int;
 
 	/**
-		Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
-		event or that is rejected if the `EventEmitter` emits `'error'` while waiting.
+		Creates a `Promise` that is fulfilled when the emitter emits the given
+		event or that is rejected if an `EventEmitter` emits `'error'` while waiting.
 		The `Promise` will resolve with an array of all the arguments emitted to the
 		given event.
 
+		Works with both `EventEmitter` and web `EventTarget` instances.
+
 		@see https://nodejs.org/api/events.html#eventsonceemitter-name-options
 	**/
-	@:overload(function<T:Function>(emitter:IEventEmitter, name:Event<T>, options:EventsOnceOptions):Promise<Array<Dynamic>> {})
-	static function once<T:Function>(emitter:IEventEmitter, name:Event<T>):Promise<Array<Dynamic>>;
+	@:overload(function(emitter:EventTarget, name:String, options:EventsOnceOptions):Promise<Array<Any>> {})
+	@:overload(function(emitter:EventTarget, name:String):Promise<Array<Any>> {})
+	@:overload(function<T:Function>(emitter:IEventEmitter, name:Event<T>, options:EventsOnceOptions):Promise<Array<Any>> {})
+	static function once<T:Function>(emitter:IEventEmitter, name:Event<T>):Promise<Array<Any>>;
 
 	/**
-		Returns an `AsyncIterator` that iterates `eventName` events emitted by the `emitter`.
+		Returns an async iterator that iterates `eventName` events emitted by the `emitter`.
 
 		@see https://nodejs.org/api/events.html#eventsonemitter-eventname-options
 	**/
@@ -91,7 +98,8 @@ extern class Events {
 	/**
 		Listens once to the `abort` event on the provided `signal`.
 
-		Returns a disposable that removes the abort listener when disposed.
+		Returns a disposable that removes the abort listener when `[Symbol.dispose]()` is called.
+		Stable since Node.js 24.
 
 		@see https://nodejs.org/api/events.html#eventsaddabortlistenersignal-listener
 	**/
@@ -100,31 +108,39 @@ extern class Events {
 	/**
 		Returns a copy of the array of listeners for the event named `name`.
 
-		@see https://nodejs.org/api/events.html#eventsgeteventlistenersemitter-name
+		For `EventTarget`s this is the only way to get the event listeners for the event target.
+
+		@see https://nodejs.org/api/events.html#eventsgeteventlistenersemitterortarget-eventname
 	**/
+	@:overload(function(emitter:EventTarget, name:EitherType<String, Symbol>):Array<Function> {})
 	static function getEventListeners(emitter:IEventEmitter, name:Event<Function>):Array<Function>;
 
 	/**
-		Change the default `maxListeners` value for all `EventEmitter` instances,
-		and optionally apply that change to the given emitters.
+		Change the default `maxListeners` value for all `EventEmitter` / `EventTarget` instances,
+		and optionally apply that change to the given emitters or targets.
+		If none are specified, `n` is set as the default max for all newly created instances.
 
 		@see https://nodejs.org/api/events.html#eventssetmaxlistenersn-eventtargets
 	**/
-	static function setMaxListeners(n:Int, emitters:Rest<IEventEmitter>):Void;
+	static function setMaxListeners(n:Int, emitters:Rest<EitherType<IEventEmitter, EventTarget>>):Void;
 
 	/**
-		Returns the currently set max amount of listeners for the given emitter.
+		Returns the currently set max amount of listeners for the given emitter or target.
 
 		@see https://nodejs.org/api/events.html#eventsgetmaxlistenersemitterortarget
 	**/
-	static function getMaxListeners(emitter:IEventEmitter):Int;
+	static function getMaxListeners(emitter:EitherType<IEventEmitter, EventTarget>):Int;
 
 	/**
 		Returns the number of listeners for the given `eventName` registered on the
-		given `emitter`.
+		given emitter or target.
+
+		For `EventTarget`s this is the only way to obtain the listener count
+		(accepted since Node.js 24.14.0; deprecation revoked).
 
 		@see https://nodejs.org/api/events.html#eventslistenercountemitterortarget-eventname
 	**/
+	@:overload(function(emitter:EventTarget, eventName:EitherType<String, Symbol>):Int {})
 	static function listenerCount(emitter:IEventEmitter, eventName:Event<Function>):Int;
 }
 
@@ -154,13 +170,15 @@ typedef EventsOnOptions = {
 
 	/**
 		The high watermark. The emitter is paused every time the size of events
-		being buffered is higher than it.
+		being buffered is higher than it. Default: `Number.MAX_SAFE_INTEGER`.
+		Supported only on emitters implementing `pause()` and `resume()`.
 	**/
 	@:optional var highWaterMark:Int;
 
 	/**
 		The low watermark. The emitter is resumed every time the size of events
-		being buffered is lower than it.
+		being buffered is lower than it. Default: `1`.
+		Supported only on emitters implementing `pause()` and `resume()`.
 	**/
 	@:optional var lowWaterMark:Int;
 }
@@ -169,12 +187,13 @@ typedef EventsOnOptions = {
 	Minimal async iterator surface used by `Events.on` (for `for await...of`).
 **/
 typedef EventsAsyncIterator = {
-	function next():Promise<{done:Bool, ?value:Array<Dynamic>}>;
+	function next():Promise<{done:Bool, ?value:Array<Any>}>;
 }
 
 /**
 	Disposable returned by `Events.addAbortListener`.
+
+	Call `[Symbol.dispose]()` (Node.js maps this to `Symbol.for('nodejs.dispose')`)
+	to remove the abort listener. There is no named `dispose()` method.
 **/
-typedef EventsDisposable = {
-	function dispose():Void;
-}
+typedef EventsDisposable = {}

--- a/src/js/node/events/EventEmitter.hx
+++ b/src/js/node/events/EventEmitter.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -27,6 +27,7 @@ import haxe.extern.EitherType;
 import haxe.extern.Rest;
 import js.lib.Symbol;
 import js.node.async_hooks.AsyncResource;
+import js.node.web.EventTarget;
 
 /**
 	Enumeration of events emitted by all `EventEmitter` instances.
@@ -36,14 +37,14 @@ enum abstract EventEmitterEvent<T:Function>(Event<T>) to Event<T> {
 		The `EventEmitter` instance will emit its own `'newListener'` event before
 		a listener is added to its internal array of listeners.
 
-		@see https://nodejs.org/api/events.html#events_event_newlistener
+		@see https://nodejs.org/api/events.html#event-newlistener
 	**/
 	var NewListener:EventEmitterEvent<(eventName:EitherType<String, Symbol>, listener:Function) -> Void> = "newListener";
 
 	/**
 		The `'removeListener'` event is emitted after the `listener` is removed.
 
-		@see https://nodejs.org/api/events.html#events_event_removelistener
+		@see https://nodejs.org/api/events.html#event-removelistener
 	**/
 	var RemoveListener:EventEmitterEvent<(eventName:EitherType<String, Symbol>, listener:Function) -> Void> = "removeListener";
 }
@@ -51,7 +52,7 @@ enum abstract EventEmitterEvent<T:Function>(Event<T>) to Event<T> {
 /**
 	The `EventEmitter` class is defined and exposed by the `events` module:
 
-	@see https://nodejs.org/api/events.html#events_class_eventemitter
+	@see https://nodejs.org/api/events.html#class-eventemitter
 **/
 @:jsRequire("events", "EventEmitter")
 extern class EventEmitter<TSelf:EventEmitter<TSelf>> implements IEventEmitter {
@@ -62,10 +63,10 @@ extern class EventEmitter<TSelf:EventEmitter<TSelf>> implements IEventEmitter {
 		event. This limit can be changed for individual `EventEmitter` instances
 		using the `emitter.setMaxListeners(n)` method. To change the default
 		for all `EventEmitter` instances, the `EventEmitter.defaultMaxListeners`
-		property can be used. If this value is not a positive number, a `TypeError`
+		property can be used. If this value is not a positive number, a `RangeError`
 		will be thrown.
 
-		@see https://nodejs.org/api/events.html#events_eventemitter_defaultmaxlisteners
+		@see https://nodejs.org/api/events.html#eventsdefaultmaxlisteners
 	**/
 	static var defaultMaxListeners:Int;
 
@@ -95,37 +96,41 @@ extern class EventEmitter<TSelf:EventEmitter<TSelf>> implements IEventEmitter {
 	/**
 		Returns a copy of the array of listeners for the event named `name`.
 
-		@see https://nodejs.org/api/events.html#eventsgeteventlistenersemitter-name
+		For `EventTarget`s this is the only way to get the event listeners for the event target.
+
+		@see https://nodejs.org/api/events.html#eventsgeteventlistenersemitterortarget-eventname
 	**/
+	@:overload(function(emitter:EventTarget, name:EitherType<String, Symbol>):Array<Function> {})
 	static function getEventListeners(emitter:IEventEmitter, name:Event<Function>):Array<Function>;
 
 	/**
-		Change the default `maxListeners` value for all `EventEmitter` instances,
-		and optionally apply that change to the given emitters.
+		Change the default `maxListeners` value for all `EventEmitter` / `EventTarget` instances,
+		and optionally apply that change to the given emitters or targets.
 
 		@see https://nodejs.org/api/events.html#eventssetmaxlistenersn-eventtargets
 	**/
-	static function setMaxListeners(n:Int, emitters:Rest<IEventEmitter>):Void;
+	static function setMaxListeners(n:Int, emitters:Rest<EitherType<IEventEmitter, EventTarget>>):Void;
 
 	/**
-		Returns the currently set max amount of listeners for the given emitter.
+		Returns the currently set max amount of listeners for the given emitter or target.
 
 		@see https://nodejs.org/api/events.html#eventsgetmaxlistenersemitterortarget
 	**/
-	static function getMaxListeners(emitter:IEventEmitter):Int;
+	static function getMaxListeners(emitter:EitherType<IEventEmitter, EventTarget>):Int;
 
 	/**
 		A class method that returns the number of listeners for the given `eventName`
-		registered on the given `emitter`.
+		registered on the given emitter or target.
 
 		@see https://nodejs.org/api/events.html#eventslistenercountemitterortarget-eventname
 	**/
+	@:overload(function(emitter:EventTarget, eventName:EitherType<String, Symbol>):Int {})
 	static function listenerCount(emitter:IEventEmitter, eventName:Event<Function>):Int;
 
 	/**
 		Alias for `emitter.on(eventName, listener)`.
 
-		@see https://nodejs.org/api/events.html#events_emitter_addlistener_eventname_listener
+		@see https://nodejs.org/api/events.html#emitteraddlistenereventname-listener
 	**/
 	function addListener<T:Function>(eventName:Event<T>, listener:T):TSelf;
 
@@ -134,15 +139,15 @@ extern class EventEmitter<TSelf:EventEmitter<TSelf>> implements IEventEmitter {
 		`eventName`, in the order they were registered, passing the supplied arguments
 		to each.
 
-		@see https://nodejs.org/api/events.html#events_emitter_emit_eventname_args
+		@see https://nodejs.org/api/events.html#emitteremiteventname-args
 	**/
-	function emit<T:Function>(eventName:Event<T>, args:Rest<Dynamic>):Bool;
+	function emit<T:Function>(eventName:Event<T>, args:Rest<Any>):Bool;
 
 	/**
 		Returns an array listing the events for which the emitter has registered
 		listeners. The values in the array will be strings or `Symbol`s.
 
-		@see https://nodejs.org/api/events.html#events_emitter_eventnames
+		@see https://nodejs.org/api/events.html#emittereventnames
 	**/
 	function eventNames():Array<EitherType<String, Symbol>>;
 
@@ -151,7 +156,7 @@ extern class EventEmitter<TSelf:EventEmitter<TSelf>> implements IEventEmitter {
 		set by `emitter.setMaxListeners(n)` or defaults to
 		`EventEmitter.defaultMaxListeners`.
 
-		@see https://nodejs.org/api/events.html#events_emitter_getmaxlisteners
+		@see https://nodejs.org/api/events.html#emittergetmaxlisteners
 	**/
 	function getMaxListeners():Int;
 
@@ -160,7 +165,7 @@ extern class EventEmitter<TSelf:EventEmitter<TSelf>> implements IEventEmitter {
 		If `listener` is provided, it will return how many times the listener is
 		found in the list of the listeners of the event.
 
-		@see https://nodejs.org/api/events.html#events_emitter_listenercount_eventname
+		@see https://nodejs.org/api/events.html#emitterlistenercounteventname-listener
 	**/
 	@:overload(function<T:Function>(eventName:Event<T>, listener:T):Int {})
 	function listenerCount<T:Function>(eventName:Event<T>):Int;
@@ -168,14 +173,14 @@ extern class EventEmitter<TSelf:EventEmitter<TSelf>> implements IEventEmitter {
 	/**
 		Returns a copy of the array of listeners for the event named `eventName`.
 
-		@see https://nodejs.org/api/events.html#events_emitter_listeners_eventname
+		@see https://nodejs.org/api/events.html#emitterlistenerseventname
 	**/
 	function listeners<T:Function>(eventName:Event<T>):Array<T>;
 
 	/**
 		Alias for `emitter.removeListener()`.
 
-		@see https://nodejs.org/api/events.html#events_emitter_off_eventname_listener
+		@see https://nodejs.org/api/events.html#emitteroffeventname-listener
 	**/
 	function off<T:Function>(eventName:Event<T>, listener:T):TSelf;
 
@@ -186,7 +191,7 @@ extern class EventEmitter<TSelf:EventEmitter<TSelf>> implements IEventEmitter {
 		and `listener` will result in the `listener` being added, and called, multiple
 		times.
 
-		@see https://nodejs.org/api/events.html#events_emitter_on_eventname_listener
+		@see https://nodejs.org/api/events.html#emitteroneventname-listener
 	**/
 	function on<T:Function>(eventName:Event<T>, listener:T):TSelf;
 
@@ -194,7 +199,7 @@ extern class EventEmitter<TSelf:EventEmitter<TSelf>> implements IEventEmitter {
 		Adds a one-time `listener` function for the event named `eventName`. The
 		next time `eventName` is triggered, this listener is removed and then invoked.
 
-		@see https://nodejs.org/api/events.html#events_emitter_once_eventname_listener
+		@see https://nodejs.org/api/events.html#emitteronceeventname-listener
 	**/
 	function once<T:Function>(eventName:Event<T>, listener:T):TSelf;
 
@@ -205,7 +210,7 @@ extern class EventEmitter<TSelf:EventEmitter<TSelf>> implements IEventEmitter {
 		and `listener` will result in the `listener` being added, and called, multiple
 		times.
 
-		@see https://nodejs.org/api/events.html#events_emitter_prependlistener_eventname_listener
+		@see https://nodejs.org/api/events.html#emitterprependlistenereventname-listener
 	**/
 	function prependListener<T:Function>(eventName:Event<T>, listener:T):TSelf;
 
@@ -214,14 +219,14 @@ extern class EventEmitter<TSelf:EventEmitter<TSelf>> implements IEventEmitter {
 		beginning of the listeners array. The next time `eventName` is triggered, this
 		listener is removed, and then invoked.
 
-		@see https://nodejs.org/api/events.html#events_emitter_prependoncelistener_eventname_listener
+		@see https://nodejs.org/api/events.html#emitterprependoncelistenereventname-listener
 	**/
 	function prependOnceListener<T:Function>(eventName:Event<T>, listener:T):TSelf;
 
 	/**
 		Removes all listeners, or those of the specified `eventName`.
 
-		@see https://nodejs.org/api/events.html#events_emitter_removealllisteners_eventname
+		@see https://nodejs.org/api/events.html#emitterremovealllistenerseventname
 	**/
 	function removeAllListeners<T:Function>(?eventName:Event<T>):TSelf;
 
@@ -229,7 +234,7 @@ extern class EventEmitter<TSelf:EventEmitter<TSelf>> implements IEventEmitter {
 		Removes the specified `listener` from the listener array for the event named
 		`eventName`.
 
-		@see https://nodejs.org/api/events.html#events_emitter_removelistener_eventname_listener
+		@see https://nodejs.org/api/events.html#emitterremovelistenereventname-listener
 	**/
 	function removeListener<T:Function>(eventName:Event<T>, listener:T):TSelf;
 
@@ -241,15 +246,15 @@ extern class EventEmitter<TSelf:EventEmitter<TSelf>> implements IEventEmitter {
 		specific `EventEmitter` instance. The value can be set to `Infinity` (or `0`)
 		to indicate an unlimited number of listeners.
 
-		@see https://nodejs.org/api/events.html#events_emitter_setmaxlisteners_n
+		@see https://nodejs.org/api/events.html#emittersetmaxlistenersn
 	**/
-	function setMaxListeners(n:Int):Void;
+	function setMaxListeners(n:Int):TSelf;
 
 	/**
 		Returns a copy of the array of listeners for the event named `eventName`,
 		including any wrappers (such as those created by `.once()`).
 
-		@see https://nodejs.org/api/events.html#events_emitter_rawlisteners_eventname
+		@see https://nodejs.org/api/events.html#emitterrawlistenerseventname
 	**/
 	function rawListeners<T:Function>(eventName:Event<T>):Array<T>;
 }
@@ -259,7 +264,7 @@ extern class EventEmitter<TSelf:EventEmitter<TSelf>> implements IEventEmitter {
 **/
 typedef EventEmitterOptions = {
 	/**
-		Enables automatic capturing of promise rejection.
+		Enables automatic capturing of promise rejection. Default: `false`.
 	**/
 	@:optional var captureRejections:Bool;
 }
@@ -294,6 +299,9 @@ extern class EventEmitterAsyncResource extends EventEmitter<EventEmitterAsyncRes
 
 	/**
 		The underlying `AsyncResource`.
+
+		The returned object has an additional `eventEmitter` property that references
+		this `EventEmitterAsyncResource`.
 	**/
 	var asyncResource(default, null):AsyncResource;
 }
@@ -305,12 +313,14 @@ typedef EventEmitterAsyncResourceOptions = {
 	> EventEmitterOptions,
 
 	/**
-		The type of async event. Default: `new.target.name` if instantiated using `new`, else `'EventEmitterAsyncResource'`.
+		The type of async event.
+		Default: `new.target.name` if instantiated using `new`, else `'EventEmitterAsyncResource'`.
 	**/
 	@:optional var name:String;
 
 	/**
-		The ID of the execution context that created this async event. Default: `executionAsyncId()`.
+		The ID of the execution context that created this async event.
+		Default: `executionAsyncId()`.
 	**/
 	@:optional var triggerAsyncId:Float;
 
@@ -330,12 +340,13 @@ typedef EventEmitterAsyncResourceOptions = {
 extern interface IEventEmitter {
 	function addListener<T:Function>(eventName:Event<T>, listener:T):IEventEmitter;
 
-	function emit<T:Function>(eventName:Event<T>, args:Rest<Dynamic>):Bool;
+	function emit<T:Function>(eventName:Event<T>, args:Rest<Any>):Bool;
 
 	function eventNames():Array<EitherType<String, Symbol>>;
 
 	function getMaxListeners():Int;
 
+	@:overload(function<T:Function>(eventName:Event<T>, listener:T):Int {})
 	function listenerCount<T:Function>(eventName:Event<T>):Int;
 
 	function listeners<T:Function>(eventName:Event<T>):Array<T>;
@@ -354,7 +365,7 @@ extern interface IEventEmitter {
 
 	function removeListener<T:Function>(eventName:Event<T>, listener:T):IEventEmitter;
 
-	function setMaxListeners(n:Int):Void;
+	function setMaxListeners(n:Int):IEventEmitter;
 
 	function rawListeners<T:Function>(eventName:Event<T>):Array<T>;
 }


### PR DESCRIPTION
## Summary
- Accept `EventTarget` in `getEventListeners` / `getMaxListeners` / `setMaxListeners` / `listenerCount` / `once` (Node 24)
- Fix `addAbortListener` disposable: disposal is via `[Symbol.dispose]()`, not a named `dispose()`
- Align `emitter.setMaxListeners` return type with Node (`this` / chaining) and sync `IEventEmitter.listenerCount` overload
- Refresh `@see` anchors, comments, and copyright to 2014–2026

## Test plan
- [x] `haxe -cp src --no-output js.node.Events js.node.events.EventEmitter`
- [x] `haxe completion.hxml` (pass; unrelated Url/domain deprecation warnings only)
- [ ] Spot-check signatures against https://nodejs.org/docs/latest-v24.x/api/events.html


Made with [Cursor](https://cursor.com)