### PR TITLE
Audit https externs for Node 24 + Haxe 4

### DIFF
--- a/src/js/node/Https.hx
+++ b/src/js/node/Https.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -31,11 +31,16 @@ import js.node.url.URL;
 /**
 	HTTPS is the HTTP protocol over TLS/SSL.
 	In Node.js this is implemented as a separate module.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/https.html
 **/
 @:jsRequire("https")
 extern class Https {
 	/**
 		Returns a new HTTPS web server object.
+
+		`options` accepts fields from `tls.createServer()`, `tls.createSecureContext()`, and `http.createServer()`.
+		The `requestListener` is a function which is automatically added to the `'request'` event.
 	**/
 	@:overload(function(options:HttpsCreateServerOptions, ?requestListener:(request:IncomingMessage, response:ServerResponse) -> Void):Server {})
 	static function createServer(?requestListener:(request:IncomingMessage, response:ServerResponse) -> Void):Server;
@@ -46,42 +51,60 @@ extern class Https {
 		`options` can be an object, a string, or a `URL` object.
 		If `options` is a string, it is automatically parsed with `new URL()`.
 		If it is a `URL` object, it will be automatically converted to an ordinary `options` object.
+
+		Accepts the same options as `request()`, with the method set to GET by default.
 	**/
-	@:overload(function(url:URL, ?callback:IncomingMessage->Void):ClientRequest {})
-	@:overload(function(url:URL, options:HttpsRequestOptions, ?callback:IncomingMessage->Void):ClientRequest {})
-	@:overload(function(url:String, ?callback:IncomingMessage->Void):ClientRequest {})
-	@:overload(function(url:String, options:HttpsRequestOptions, ?callback:IncomingMessage->Void):ClientRequest {})
-	static function get(options:HttpsRequestOptions, ?callback:IncomingMessage->Void):ClientRequest;
+	@:overload(function(url:URL, ?options:HttpsRequestOptions, ?callback:(response:IncomingMessage) -> Void):ClientRequest {})
+	@:overload(function(url:String, ?options:HttpsRequestOptions, ?callback:(response:IncomingMessage) -> Void):ClientRequest {})
+	static function get(options:HttpsRequestOptions, ?callback:(response:IncomingMessage) -> Void):ClientRequest;
 
 	/**
 		Global instance of `https.Agent` for all HTTPS client requests.
+
+		Diverges from a default `https.Agent` configuration by having `keepAlive` enabled
+		and a `timeout` of 5 seconds (since Node.js v19).
 	**/
 	static var globalAgent:Agent;
 
 	/**
 		Makes a request to a secure web server.
 
-		The following additional `options` from `tls.connect()` are also accepted:
-		`ca`, `cert`, `ciphers`, `clientCertEngine`, `crl`, `dhparam`, `ecdhCurve`, `honorCipherOrder`, `key`, `passphrase`, `pfx`,
-		`rejectUnauthorized`, `secureOptions`, `secureProtocol`, `servername`, `sessionIdContext`.
+		Accepts all options from `http.request()`, with different defaults:
+		`protocol` default `'https:'`, `port` default `443`, `agent` default `https.globalAgent`.
+
+		The following additional options from `tls.connect()` are also accepted:
+		`ca`, `cert`, `ciphers`, `clientCertEngine` (deprecated), `crl`, `dhparam`, `ecdhCurve`,
+		`honorCipherOrder`, `key`, `passphrase`, `pfx`, `rejectUnauthorized`, `secureOptions`,
+		`secureProtocol`, `servername`, `sessionIdContext`, `highWaterMark`.
 
 		`options` can be an object, a string, or a `URL` object.
 		If `options` is a string, it is automatically parsed with `new URL()`.
 		If it is a `URL` object, it will be automatically converted to an ordinary `options` object.
+
+		Returns an instance of `http.ClientRequest`.
 	**/
-	@:overload(function(url:URL, ?callback:IncomingMessage->Void):ClientRequest {})
-	@:overload(function(url:URL, options:HttpsRequestOptions, ?callback:IncomingMessage->Void):ClientRequest {})
-	@:overload(function(url:String, ?callback:IncomingMessage->Void):ClientRequest {})
-	@:overload(function(url:String, options:HttpsRequestOptions, ?callback:IncomingMessage->Void):ClientRequest {})
-	static function request(options:HttpsRequestOptions, ?callback:IncomingMessage->Void):ClientRequest;
+	@:overload(function(url:URL, ?options:HttpsRequestOptions, ?callback:(response:IncomingMessage) -> Void):ClientRequest {})
+	@:overload(function(url:String, ?options:HttpsRequestOptions, ?callback:(response:IncomingMessage) -> Void):ClientRequest {})
+	static function request(options:HttpsRequestOptions, ?callback:(response:IncomingMessage) -> Void):ClientRequest;
 }
 
+/**
+	Options for `Https.createServer`.
+
+	Accepts options from `tls.createServer()`, `tls.createSecureContext()`, and `http.createServer()`.
+**/
 typedef HttpsCreateServerOptions = {
 	> js.node.Tls.TlsCreateServerOptions,
 	> js.node.tls.SecureContext.SecureContextOptions,
 	> js.node.Http.HttpCreateServerOptions,
 }
 
+/**
+	Options for `Https.request` / `Https.get`.
+
+	Combines `http.request()` options with `tls.connect()` options.
+	Defaults differ from HTTP: `protocol` is `'https:'`, `port` is `443`, and `agent` is `Https.globalAgent`.
+**/
 typedef HttpsRequestOptions = {
 	> js.node.Http.HttpRequestOptions,
 	> js.node.Tls.TlsConnectOptions,

--- a/src/js/node/https/Agent.hx
+++ b/src/js/node/https/Agent.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -22,30 +22,85 @@
 
 package js.node.https;
 
+import haxe.DynamicAccess;
+import js.node.Buffer;
+import js.node.events.EventEmitter.Event;
+import js.node.tls.TLSSocket;
+
+/**
+	Events emitted by `https.Agent` in addition to inherited `http.Agent` / `EventEmitter` events.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/https.html#event-keylog
+**/
+enum abstract AgentEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
+	/**
+		Emitted when key material is generated or received by a connection managed by this agent
+		(typically before handshake has completed, but not necessarily).
+
+		Listener arguments:
+			line - ASCII text in NSS `SSLKEYLOGFILE` format
+			tlsSocket - the `tls.TLSSocket` instance on which it was generated
+	**/
+	var Keylog:AgentEvent<(line:Buffer, tlsSocket:TLSSocket) -> Void> = "keylog";
+}
+
 /**
 	An Agent object for HTTPS similar to `http.Agent`.
-	See [https.request](https://nodejs.org/api/http.html#http_http_request_options_callback) for more information.
+
+	Like `http.Agent`, `createConnection(options[, callback])` can be overridden to customize
+	how TLS connections are established.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/https.html#class-httpsagent
 **/
 @:jsRequire("https", "Agent")
 extern class Agent extends js.node.http.Agent {
 	function new(?options:HttpsAgentOptions);
 }
 
+/**
+	Options for `https.Agent`.
+
+	Accepts the same fields as `http.Agent`, plus TLS session / SNI options and
+	Node.js v24.5+ proxy / default port fields listed below.
+**/
 typedef HttpsAgentOptions = {
 	> js.node.http.Agent.HttpAgentOptions,
 
 	/**
-		maximum number of TLS cached sessions. Use `0` to disable TLS session caching.
+		Maximum number of TLS cached sessions. Use `0` to disable TLS session caching.
 
 		Default: `100`.
 	**/
 	@:optional var maxCachedSessions:Int;
 
 	/**
-		the value of [Server Name Indication extension](https://en.wikipedia.org/wiki/Server_Name_Indication) to be sent to the server.
+		The value of [Server Name Indication extension](https://en.wikipedia.org/wiki/Server_Name_Indication) to be sent to the server.
 		Use empty string `''` to disable sending the extension.
 
 		Default: hostname of the target server, unless the target server is specified using an IP address, in which case the default is `''` (no extension).
+
+		Since Node.js v12.5.0, `servername` is not automatically set when the target host was specified using an IP address.
 	**/
 	@:optional var servername:String;
+
+	/**
+		Environment variables for proxy configuration. See Node.js built-in proxy support.
+
+		Default: `undefined`. Added in Node.js v24.5.0.
+	**/
+	@:optional var proxyEnv:DynamicAccess<String>;
+
+	/**
+		Default port to use when the port is not specified in requests.
+
+		Default: `443`. Added in Node.js v24.5.0.
+	**/
+	@:optional var defaultPort:Int;
+
+	/**
+		The protocol to use for the agent.
+
+		Default: `'https:'`. Added in Node.js v24.5.0.
+	**/
+	@:optional var protocol:String;
 }

--- a/src/js/node/https/Server.hx
+++ b/src/js/node/https/Server.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -22,9 +22,92 @@
 
 package js.node.https;
 
+import js.node.net.Socket;
+
 /**
-	This class is a subclass of `tls.Server` and emits events same as `http.Server`.
-	See [http.Server](https://nodejs.org/api/http.html#http_class_http_server) for more information.
+	This class is a subclass of `tls.Server` and emits the same events as `http.Server`.
+
+	See `http.Server` for HTTP request/response events and behavior.
+	`listen()` is identical to `net.Server.listen()`.
+
+	`[Symbol.asyncDispose]()` (calls `close()` and returns a promise) is not typed here;
+	use `close` / promise wrappers as needed.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/https.html#class-httpsserver
 **/
 @:jsRequire("https", "Server")
-extern class Server extends js.node.tls.Server {}
+extern class Server extends js.node.tls.Server {
+	/**
+		Limit the amount of time the parser will wait to receive the complete HTTP headers.
+
+		See `http.Server.headersTimeout`.
+
+		Default: `60000`.
+	**/
+	var headersTimeout:Int;
+
+	/**
+		Sets the timeout value in milliseconds for receiving the entire request from the client.
+
+		See `http.Server.requestTimeout`.
+
+		Default: `300000`.
+	**/
+	var requestTimeout:Int;
+
+	/**
+		Limits maximum incoming headers count. If set to 0, no limit will be applied.
+
+		See `http.Server.maxHeadersCount`.
+
+		Default: `2000`.
+	**/
+	var maxHeadersCount:Null<Int>;
+
+	/**
+		Sets the timeout value for sockets, and emits a `'timeout'` event on the Server object,
+		passing the socket as an argument, if a timeout occurs.
+
+		See `http.Server.setTimeout()`.
+
+		Default `msecs`: `120000` (2 minutes).
+	**/
+	@:overload(function(?callback:(socket:Socket) -> Void):Server {})
+	function setTimeout(msecs:Int, ?callback:(socket:Socket) -> Void):Server;
+
+	/**
+		The number of milliseconds of inactivity before a socket is presumed to have timed out.
+
+		A value of `0` disables the timeout behavior on incoming connections.
+
+		See `http.Server.timeout`.
+
+		Default: `0` (no timeout).
+	**/
+	var timeout:Int;
+
+	/**
+		The number of milliseconds of inactivity a server needs to wait for additional incoming data,
+		after it has finished writing the last response, before a socket will be destroyed.
+
+		See `http.Server.keepAliveTimeout`.
+
+		Default: `5000` (5 seconds).
+	**/
+	var keepAliveTimeout:Int;
+
+	/**
+		Closes all connections connected to this server.
+
+		See `http.Server.closeAllConnections()`.
+	**/
+	function closeAllConnections():Void;
+
+	/**
+		Closes all connections connected to this server which are not sending a request
+		or waiting for a response.
+
+		See `http.Server.closeIdleConnections()`.
+	**/
+	function closeIdleConnections():Void;
+}


### PR DESCRIPTION
## Summary
- Align `js.node.Https` / `js.node.https` with Node.js 24: server timeout/close APIs, `Agent` `keylog` event, and v24.5 `proxyEnv` / `defaultPort` / `protocol` on `HttpsAgentOptions`.
- Modernize `get` / `request` overloads (optional options + arrow callbacks) and refresh module docs (HTTPS defaults, deprecated `clientCertEngine`, `highWaterMark`).
- Update copyright headers to 2014–2026.

## Test plan
- [x] `haxe build.hxml` on this branch
- [ ] Spot-check `Https.createServer` / `get` / `request` and `https.Server` / `https.Agent` usage against Node 24 docs