### PR TITLE
Audit js.node.util for Node 24 + Haxe 4

### DIFF
--- a/src/js/node/Util.hx
+++ b/src/js/node/Util.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -54,17 +54,26 @@ extern class Util {
 		The `util.debuglog()` method is used to create a function that conditionally writes debug messages to `stderr`
 		based on the existence of the `NODE_DEBUG` environment variable.
 
-		@see https://nodejs.org/api/util.html#util_util_debuglog_section
+		The optional `callback` is invoked the first time the logger is called with a more optimized logging function.
+
+		@see https://nodejs.org/api/util.html#utildebuglogsection-callback
 	**/
-	static function debuglog(section:String):Rest<Any>->Void;
+	static function debuglog(section:String, ?callback:(Rest<Any>->Void)->Void):DebugLogger;
+
+	/**
+		Alias for `Util.debuglog`.
+
+		@see https://nodejs.org/api/util.html#utildebugsection
+	**/
+	static function debug(section:String, ?callback:(Rest<Any>->Void)->Void):DebugLogger;
 
 	/**
 		The `util.deprecate()` method wraps `fn` (which may be a function or class) in such a way that it is marked
 		as deprecated.
 
-		@see https://nodejs.org/api/util.html#util_util_deprecate_fn_msg_code
+		@see https://nodejs.org/api/util.html#utildeprecatefn-msg-code-options
 	**/
-	static function deprecate<T:Function>(fun:T, msg:String, ?code:String):T;
+	static function deprecate<T:Function>(fun:T, msg:String, ?code:String, ?options:DeprecateOptions):T;
 
 	/**
 		The `util.format()` method returns a formatted string using the first argument as a `printf`-like format string
@@ -125,9 +134,11 @@ extern class Util {
 	/**
 		Returns `true` if there is deep strict equality between `val1` and `val2`.
 
-		@see https://nodejs.org/api/util.html#util_util_isdeepstrictequal_val1_val2
+		When `skipPrototype` is `true`, prototype and constructor comparison is skipped.
+
+		@see https://nodejs.org/api/util.html#utilisdeepstrictequalval1-val2-options
 	**/
-	static function isDeepStrictEqual(val1:Any, val2:Any):Bool;
+	static function isDeepStrictEqual(val1:Any, val2:Any, ?skipPrototype:Bool):Bool;
 
 	/**
 		Takes a function following the common error-first callback style, i.e. taking an `(err, value) => ...` callback
@@ -221,23 +232,23 @@ extern class Util {
 	static function getCallSite(?frameCount:Int, ?options:GetCallSitesOptions):Array<CallSiteObject>;
 
 	/**
-		Converts a POSIX signal name (e.g. `'SIGTERM'`) to the corresponding process exit code.
+		Converts a POSIX signal name (e.g. `'SIGTERM'`) to the corresponding process exit code
+		(`128 + signal number`).
+
+		@see https://nodejs.org/api/util.html#utilconvertprocesssignaltoexitcodesignal
 	**/
 	static function convertProcessSignalToExitCode(signal:String):Int;
 
 	/**
 		Enables or disables printing a stack trace when Node.js receives `SIGINT`.
+		Only available on the main thread.
+
+		@see https://nodejs.org/api/util.html#utilsettracesigtintenable
 	**/
 	static function setTraceSigInt(enable:Bool):Void;
 
 	/**
-		Deprecated predecessor of `Console.error`.
-	**/
-	@:deprecated("Use js.Node.console.error instead")
-	static function debug(string:String):Void;
-
-	/**
-		Deprecated predecessor of console.error.
+		Deprecated predecessor of `console.error` (removed; different from `Util.debug` / `debuglog`).
 	**/
 	@:deprecated("Use js.Node.console.error instead")
 	static function error(args:Rest<Any>):Void;
@@ -419,6 +430,15 @@ typedef InspectOptions = {
 	@:optional var maxArrayLength:Null<Int>;
 
 	/**
+		Specifies the maximum number of characters to include when formatting strings.
+		Set to `null` or `Infinity` to show all characters.
+		Set to `0` or negative to show no characters.
+
+		Default: `10000`.
+	**/
+	@:optional var maxStringLength:Null<Int>;
+
+	/**
 		The length at which input values are split across multiple lines.
 		Set to `Infinity` to format the input as a single line (in combination with `compact` set to `true` or any
 		number >= `1`).
@@ -457,6 +477,13 @@ typedef InspectOptions = {
 		Default: `false`.
 	**/
 	@:optional var getters:EitherType<Bool, String>;
+
+	/**
+		If set to `true`, an underscore separates every three digits in all bigints and numbers.
+
+		Default: `false`.
+	**/
+	@:optional var numericSeparator:Bool;
 }
 
 /**
@@ -468,7 +495,7 @@ typedef StyleTextOptions = {
 
 		Default: `process.stdout`.
 	**/
-	@:optional var stream:Any;
+	@:optional var stream:IWritable;
 
 	/**
 		Value indicating whether `stream` is checked to see if it can handle colors.
@@ -476,6 +503,34 @@ typedef StyleTextOptions = {
 		Default: `true`.
 	**/
 	@:optional var validateStream:Bool;
+}
+
+/**
+	Options for `Util.deprecate`.
+**/
+typedef DeprecateOptions = {
+	/**
+		When `false`, do not change the prototype of the deprecated object while emitting the warning.
+
+		Default: `true`.
+	**/
+	@:optional var modifyPrototype:Bool;
+}
+
+/**
+	Logger returned by `Util.debuglog` / `Util.debug`.
+**/
+extern class DebugLogger {
+	/**
+		Writes a debug message when this logger is enabled.
+	**/
+	@:selfCall
+	function call(args:Rest<Any>):Void;
+
+	/**
+		`true` when `NODE_DEBUG` enables this logger's section.
+	**/
+	var enabled(default, null):Bool;
 }
 
 /**
@@ -527,6 +582,10 @@ typedef GetCallSitesOptions = {
 typedef CallSiteObject = {
 	var functionName:String;
 	var scriptName:String;
+	/**
+		Unique script id (Chrome DevTools protocol `Runtime.ScriptId`).
+	**/
+	var scriptId:String;
 	var lineNumber:Int;
 	var columnNumber:Int;
 }

--- a/src/js/node/Util.hx
+++ b/src/js/node/Util.hx
@@ -37,7 +37,7 @@ import js.node.web.AbortSignal;
 /**
 	The `util` module is primarily designed to support the needs of Node.js' own internal APIs.
 
-	@see https://nodejs.org/api/util.html#util_util
+	@see https://nodejs.org/api/util.html
 **/
 @:jsRequire("util")
 extern class Util {
@@ -45,27 +45,28 @@ extern class Util {
 		Takes an `async` function (or a function that returns a `Promise`) and returns a function following the
 		error-first callback style, i.e. taking an `(err, value) => ...` callback as the last argument.
 
-		@see https://nodejs.org/api/util.html#util_util_callbackify_original
+		@see https://nodejs.org/api/util.html#utilcallbackifyoriginal
 	**/
 	// TODO(section-4): tighten callbackify return/arg types beyond Function
 	static function callbackify(original:Function):Function;
 
 	/**
-		The `util.debuglog()` method is used to create a function that conditionally writes debug messages to `stderr`
-		based on the existence of the `NODE_DEBUG` environment variable.
+		Creates a function that conditionally writes debug messages to `stderr` based on the
+		`NODE_DEBUG` environment variable.
 
-		The optional `callback` is invoked the first time the logger is called with a more optimized logging function.
+		The optional `callback` is invoked the first time the logging function is called with a more
+		optimized logger (no section-enable check on each call).
 
 		@see https://nodejs.org/api/util.html#utildebuglogsection-callback
 	**/
-	static function debuglog(section:String, ?callback:(Rest<Any>->Void)->Void):DebugLogger;
+	static function debuglog(section:String, ?callback:DebugLogger->Void):DebugLogger;
 
 	/**
-		Alias for `Util.debuglog`.
+		Alias for `util.debuglog`. Prefer this when only checking `.enabled` so the name does not imply logging.
 
 		@see https://nodejs.org/api/util.html#utildebugsection
 	**/
-	static function debug(section:String, ?callback:(Rest<Any>->Void)->Void):DebugLogger;
+	static function debug(section:String, ?callback:DebugLogger->Void):DebugLogger;
 
 	/**
 		The `util.deprecate()` method wraps `fn` (which may be a function or class) in such a way that it is marked
@@ -79,7 +80,7 @@ extern class Util {
 		The `util.format()` method returns a formatted string using the first argument as a `printf`-like format string
 		which can contain zero or more format specifiers.
 
-		@see https://nodejs.org/api/util.html#util_util_format_format_args
+		@see https://nodejs.org/api/util.html#utilformatformat-args
 	**/
 	@:overload(function(args:Rest<Any>):String {})
 	static function format(format:String, args:Rest<Any>):String;
@@ -88,7 +89,7 @@ extern class Util {
 		This function is identical to `util.format()`, except in that it takes an `inspectOptions` argument which
 		specifies options that are passed along to `util.inspect()`.
 
-		@see https://nodejs.org/api/util.html#util_util_formatwithoptions_inspectoptions_format_args
+		@see https://nodejs.org/api/util.html#utilformatwithoptionsinspectoptions-format-args
 	**/
 	@:overload(function(inspectOptions:InspectOptions, args:Rest<Any>):String {})
 	static function formatWithOptions(inspectOptions:InspectOptions, format:String, args:Rest<Any>):String;
@@ -96,7 +97,7 @@ extern class Util {
 	/**
 		Returns the string name for a numeric error code that comes from a Node.js API.
 
-		@see https://nodejs.org/api/util.html#util_util_getsystemerrorname_err
+		@see https://nodejs.org/api/util.html#utilgetsystemerrornameerr
 	**/
 	static function getSystemErrorName(err:Int):String;
 
@@ -118,15 +119,15 @@ extern class Util {
 	/**
 		Inherit the prototype methods from one `constructor` into another.
 
-		@see https://nodejs.org/api/util.html#util_util_inherits_constructor_superconstructor
+		@see https://nodejs.org/api/util.html#utilinheritsconstructor-superconstructor
 	**/
 	@:deprecated("Use class extends instead")
-	static function inherits(constructor:Class<Dynamic>, superConstructor:Class<Dynamic>):Void;
+	static function inherits(constructor:Class<Any>, superConstructor:Class<Any>):Void;
 
 	/**
 		The `util.inspect()` method returns a string representation of `object` that is intended for debugging.
 
-		@see https://nodejs.org/api/util.html#util_util_inspect_object_options
+		@see https://nodejs.org/api/util.html#utilinspectobject-options
 	**/
 	@:overload(function(object:Any, ?showHidden:Bool, ?depth:Int, ?colors:Bool):String {})
 	static function inspect(object:Any, ?options:InspectOptions):String;
@@ -134,17 +135,19 @@ extern class Util {
 	/**
 		Returns `true` if there is deep strict equality between `val1` and `val2`.
 
-		When `skipPrototype` is `true`, prototype and constructor comparison is skipped.
+		When `options.skipPrototype` (or a bare `true` third argument) is set, prototype and constructor
+		comparison is skipped.
 
 		@see https://nodejs.org/api/util.html#utilisdeepstrictequalval1-val2-options
 	**/
-	static function isDeepStrictEqual(val1:Any, val2:Any, ?skipPrototype:Bool):Bool;
+	@:overload(function(val1:Any, val2:Any, skipPrototype:Bool):Bool {})
+	static function isDeepStrictEqual(val1:Any, val2:Any, ?options:IsDeepStrictEqualOptions):Bool;
 
 	/**
 		Takes a function following the common error-first callback style, i.e. taking an `(err, value) => ...` callback
 		as the last argument, and returns a version that returns promises.
 
-		@see https://nodejs.org/api/util.html#util_util_promisify_original
+		@see https://nodejs.org/api/util.html#utilpromisifyoriginal
 	**/
 	// TODO(section-4): tighten promisify generic result typing
 	static function promisify(original:Function):Rest<Any>->Promise<Any>;
@@ -223,7 +226,7 @@ extern class Util {
 	static function getCallSites(?frameCount:Int, ?options:GetCallSitesOptions):Array<CallSiteObject>;
 
 	/**
-		Legacy alias of `getCallSites`.
+		Legacy alias of `getCallSites` (renamed in Node.js 22.12+ / 23.3+; removed as a separate export later).
 
 		@see https://nodejs.org/api/util.html#utilgetcallsitesframecount-options
 	**/
@@ -246,6 +249,14 @@ extern class Util {
 		@see https://nodejs.org/api/util.html#utilsettracesigtintenable
 	**/
 	static function setTraceSigInt(enable:Bool):Void;
+
+	/**
+		Shallow-copies enumerable properties from `source` onto `target`.
+
+		@see https://nodejs.org/api/util.html#util_extendtarget-source
+	**/
+	@:deprecated("Use Object.assign instead")
+	static function _extend(target:DynamicAccess<Any>, source:DynamicAccess<Any>):DynamicAccess<Any>;
 
 	/**
 		Deprecated predecessor of `console.error` (removed; different from `Util.debug` / `debuglog`).
@@ -466,7 +477,7 @@ typedef InspectOptions = {
 		If set to `true` the default sort is used.
 		If set to a function, it is used as a compare function.
 	**/
-	@:optional var sorted:EitherType<Bool, Any->Any->Int>;
+	@:optional var sorted:EitherType<Bool, String->String->Int>;
 
 	/**
 		If set to `true`, getters are inspected.
@@ -518,19 +529,29 @@ typedef DeprecateOptions = {
 }
 
 /**
+	Options for `Util.isDeepStrictEqual`.
+**/
+typedef IsDeepStrictEqualOptions = {
+	/**
+		If `true`, prototype and constructor comparison is skipped during deep strict equality check.
+
+		Default: `false`.
+	**/
+	@:optional var skipPrototype:Bool;
+}
+
+/**
 	Logger returned by `Util.debuglog` / `Util.debug`.
 **/
-extern class DebugLogger {
-	/**
-		Writes a debug message when this logger is enabled.
-	**/
-	@:selfCall
-	function call(args:Rest<Any>):Void;
-
+@:callable
+abstract DebugLogger(Dynamic) from Dynamic to Dynamic {
 	/**
 		`true` when `NODE_DEBUG` enables this logger's section.
 	**/
-	var enabled(default, null):Bool;
+	public var enabled(get, never):Bool;
+
+	inline function get_enabled():Bool
+		return this.enabled;
 }
 
 /**
@@ -561,7 +582,42 @@ typedef ParseArgsOptionDescriptor = {
 typedef ParseArgsResult = {
 	var values:DynamicAccess<Any>;
 	var positionals:Array<String>;
-	@:optional var tokens:Array<Any>;
+	@:optional var tokens:Array<ParseArgsToken>;
+}
+
+/**
+	A token returned when `ParseArgsConfig.tokens` is `true`.
+**/
+typedef ParseArgsToken = {
+	/**
+		One of `'option'`, `'positional'`, or `'option-terminator'`.
+	**/
+	var kind:String;
+
+	/**
+		Index of the argument in `args` that produced this token.
+	**/
+	var index:Int;
+
+	/**
+		Long name of an option token.
+	**/
+	@:optional var name:String;
+
+	/**
+		How the option appeared in `args` (e.g. `-f` or `--foo`).
+	**/
+	@:optional var rawName:String;
+
+	/**
+		Option or positional value (`undefined` for boolean options).
+	**/
+	@:optional var value:Null<EitherType<String, Bool>>;
+
+	/**
+		Whether an option value was specified inline (e.g. `--foo=bar`).
+	**/
+	@:optional var inlineValue:Null<Bool>;
 }
 
 /**
@@ -588,4 +644,8 @@ typedef CallSiteObject = {
 	var scriptId:String;
 	var lineNumber:Int;
 	var columnNumber:Int;
+	/**
+		Deprecated alias of `columnNumber` (still present on some Node versions).
+	**/
+	@:optional var column:Int;
 }

--- a/src/js/node/util/Inspect.hx
+++ b/src/js/node/util/Inspect.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -31,7 +31,7 @@ extern class Inspect {
 	/**
 		The `util.inspect()` method returns a string representation of `object` that is intended for debugging.
 
-		@see https://nodejs.org/api/util.html#util_util_inspect_object_options
+		@see https://nodejs.org/api/util.html#utilinspectobject-options
 	**/
 	@:selfCall
 	@:overload(function(object:Any, ?showHidden:Bool, ?depth:Int, ?colors:Bool):String {})
@@ -40,7 +40,7 @@ extern class Inspect {
 	/**
 		`util.inspect.styles` is a map associating a style name to a color from `util.inspect.colors` properties.
 
-		@see https://nodejs.org/api/util.html#util_customizing_util_inspect_colors
+		@see https://nodejs.org/api/util.html#customizing-utilinspect-colors
 	**/
 	static var styles:DynamicAccess<String>;
 
@@ -54,14 +54,14 @@ extern class Inspect {
 		In addition to being accessible through `util.inspect.custom`, this symbol is registered globally and can be
 		accessed in any environment as `Symbol.for('nodejs.util.inspect.custom')`.
 
-		@see https://nodejs.org/api/util.html#util_util_inspect_custom
+		@see https://nodejs.org/api/util.html#utilinspectcustom
 	**/
 	static final custom:Symbol;
 
 	/**
 		The `defaultOptions` value allows customization of the default options used by `util.inspect`.
 
-		@see https://nodejs.org/api/util.html#util_util_inspect_defaultoptions
+		@see https://nodejs.org/api/util.html#utilinspectdefaultoptions
 	**/
 	static var defaultOptions:InspectOptions;
 }

--- a/src/js/node/util/MIMEParams.hx
+++ b/src/js/node/util/MIMEParams.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -73,4 +73,14 @@ extern class MIMEParams {
 		Returns an iterator over the values of each name-value pair.
 	**/
 	function values():Iterator<String>;
+
+	/**
+		Returns the serialized parameters.
+	**/
+	function toString():String;
+
+	/**
+		Alias for `toString()`.
+	**/
+	function toJSON():String;
 }

--- a/src/js/node/util/MIMEType.hx
+++ b/src/js/node/util/MIMEType.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/util/Promisify.hx
+++ b/src/js/node/util/Promisify.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -33,16 +33,16 @@ extern class Promisify {
 		Takes a function following the common error-first callback style, i.e. taking an `(err, value) => ...` callback
 		as the last argument, and returns a version that returns promises.
 
-		@see https://nodejs.org/api/util.html#util_util_promisify_original
+		@see https://nodejs.org/api/util.html#utilpromisifyoriginal
 	**/
 	@:selfCall
 	// TODO(section-4): tighten promisify generic result typing
 	static function promisify(original:Function):Rest<Any>->Promise<Any>;
 
 	/**
-		That can be used to declare custom promisified variants of functions, see Custom promisified functions.
+		Symbol used to declare custom promisified variants of functions.
 
-		@see https://nodejs.org/api/util.html#util_util_promisify_custom
+		@see https://nodejs.org/api/util.html#utilpromisifycustom
 	**/
 	static final custom:Symbol;
 }

--- a/src/js/node/util/TextDecoder.hx
+++ b/src/js/node/util/TextDecoder.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/util/TextDecoder.hx
+++ b/src/js/node/util/TextDecoder.hx
@@ -29,42 +29,42 @@ import js.lib.ArrayBufferView;
 /**
 	An implementation of the WHATWG Encoding Standard `TextDecoder` API.
 
-	@see https://nodejs.org/api/util.html#util_class_util_textdecoder
+	@see https://nodejs.org/api/util.html#class-utiltextdecoder
 **/
 @:jsRequire("util", "TextDecoder")
 extern class TextDecoder {
 	/**
 		Creates an new `TextDecoder` instance.
 
-		@see https://nodejs.org/api/util.html#util_new_textdecoder_encoding_options
+		@see https://nodejs.org/api/util.html#new-textdecoderencoding-options
 	**/
 	function new(?encoding:String, ?options:TextDecoderOptions);
 
 	/**
 		Decodes the `input` and returns a string.
 
-		@see https://nodejs.org/api/util.html#util_textdecoder_decode_input_options
+		@see https://nodejs.org/api/util.html#textdecoderdecodeinput-options
 	**/
 	function decode(?input:EitherType<ArrayBuffer, ArrayBufferView>, ?options:TextDecodeOptions):String;
 
 	/**
 		The encoding supported by the `TextDecoder` instance.
 
-		@see https://nodejs.org/api/util.html#util_textdecoder_encoding
+		@see https://nodejs.org/api/util.html#textdecoderencoding
 	**/
 	var encoding(default, null):String;
 
 	/**
 		The value will be `true` if decoding errors result in a `TypeError` being thrown.
 
-		@see https://nodejs.org/api/util.html#util_textdecoder_fatal
+		@see https://nodejs.org/api/util.html#textdecoderfatal
 	**/
 	var fatal(default, null):Bool;
 
 	/**
 		The value will be `true` if the decoding result will include the byte order mark.
 
-		@see https://nodejs.org/api/util.html#util_textdecoder_ignorebom
+		@see https://nodejs.org/api/util.html#textdecoderignorebom
 	**/
 	var ignoreBOM(default, null):Bool;
 }
@@ -72,7 +72,7 @@ extern class TextDecoder {
 /**
 	Options object used by `new TextDecoder()`.
 
-	@see https://nodejs.org/api/util.html#util_new_textdecoder_encoding_options
+	@see https://nodejs.org/api/util.html#new-textdecoderencoding-options
 **/
 typedef TextDecoderOptions = {
 	/**

--- a/src/js/node/util/TextEncoder.hx
+++ b/src/js/node/util/TextEncoder.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/util/TextEncoder.hx
+++ b/src/js/node/util/TextEncoder.hx
@@ -30,7 +30,7 @@ import js.node.web.TextEncoder.TextEncoderEncodeIntoResult;
 
 	Aligned with the web global `js.node.web.TextEncoder` (`encode` / `encodeInto`).
 
-	@see https://nodejs.org/api/util.html#util_class_util_textencoder
+	@see https://nodejs.org/api/util.html#class-utiltextencoder
 **/
 @:jsRequire("util", "TextEncoder")
 extern class TextEncoder {
@@ -39,21 +39,21 @@ extern class TextEncoder {
 	/**
 		UTF-8 encodes the `input` string and returns a `Uint8Array` containing the encoded bytes.
 
-		@see https://nodejs.org/api/util.html#util_textencoder_encode_input
+		@see https://nodejs.org/api/util.html#textencoderencodeinput
 	**/
 	function encode(?input:String):Uint8Array;
 
 	/**
 		Encodes `source` into `destination` and returns how many code units / bytes were written.
 
-		@see https://nodejs.org/api/util.html#util_textencoder_encodeinto_src_dest
+		@see https://nodejs.org/api/util.html#textencoderencodeintosrc-dest
 	**/
 	function encodeInto(source:String, destination:Uint8Array):TextEncoderEncodeIntoResult;
 
 	/**
 		The encoding supported by the `TextEncoder` instance.
 
-		@see https://nodejs.org/api/util.html#util_textencoder_encoding
+		@see https://nodejs.org/api/util.html#textencoderencoding
 	**/
 	var encoding(default, null):String;
 }

--- a/src/js/node/util/Types.hx
+++ b/src/js/node/util/Types.hx
@@ -25,63 +25,63 @@ package js.node.util;
 /**
 	`util.types` provides a number of type checks for different kinds of built-in objects.
 
-	@see https://nodejs.org/api/util.html#util_util_types
+	@see https://nodejs.org/api/util.html#utiltypes
 **/
 @:jsRequire("util", "types")
 extern class Types {
 	/**
 		Returns `true` if the value is a built-in `ArrayBuffer` or `SharedArrayBuffer` instance.
 
-		@see https://nodejs.org/api/util.html#util_util_types_isanyarraybuffer_value
+		@see https://nodejs.org/api/util.html#utiltypesisanyarraybuffervalue
 	**/
 	static function isAnyArrayBuffer(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is an `arguments` object.
 
-		@see https://nodejs.org/api/util.html#util_util_types_isargumentsobject_value
+		@see https://nodejs.org/api/util.html#utiltypesisargumentsobjectvalue
 	**/
 	static function isArgumentsObject(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a built-in `ArrayBuffer` instance.
 
-		@see https://nodejs.org/api/util.html#util_util_types_isarraybuffer_value
+		@see https://nodejs.org/api/util.html#utiltypesisarraybuffervalue
 	**/
 	static function isArrayBuffer(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is an `ArrayBufferView` (TypedArray or DataView).
 
-		@see https://nodejs.org/api/util.html#util_util_types_isarraybufferview_value
+		@see https://nodejs.org/api/util.html#utiltypesisarraybufferviewvalue
 	**/
 	static function isArrayBufferView(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is an async function.
 
-		@see https://nodejs.org/api/util.html#util_util_types_isasyncfunction_value
+		@see https://nodejs.org/api/util.html#utiltypesisasyncfunctionvalue
 	**/
 	static function isAsyncFunction(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a `BigInt64Array` instance.
 
-		@see https://nodejs.org/api/util.html#util_util_types_isbigint64array_value
+		@see https://nodejs.org/api/util.html#utiltypesisbigint64arrayvalue
 	**/
 	static function isBigInt64Array(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a `BigUint64Array` instance.
 
-		@see https://nodejs.org/api/util.html#util_util_types_isbiguint64array_value
+		@see https://nodejs.org/api/util.html#utiltypesisbiguint64arrayvalue
 	**/
 	static function isBigUint64Array(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a boolean object, e.g. created by `new Boolean()`.
 
-		@see https://nodejs.org/api/util.html#util_util_types_isbooleanobject_value
+		@see https://nodejs.org/api/util.html#utiltypesisbooleanobjectvalue
 	**/
 	static function isBooleanObject(value:Any):Bool;
 
@@ -89,217 +89,217 @@ extern class Types {
 		Returns `true` if the value is any boxed primitive object, e.g. created by `new Boolean()`, `new String()` or
 		`Object(Symbol())`.
 
-		@see https://nodejs.org/api/util.html#util_util_types_isboxedprimitive_value
+		@see https://nodejs.org/api/util.html#utiltypesisboxedprimitivevalue
 	**/
 	static function isBoxedPrimitive(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a built-in `DataView` instance.
 
-		@see https://nodejs.org/api/util.html#util_util_types_isdataview_value
+		@see https://nodejs.org/api/util.html#utiltypesisdataviewvalue
 	**/
 	static function isDataView(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a built-in `Date` instance.
 
-		@see https://nodejs.org/api/util.html#util_util_types_isdate_value
+		@see https://nodejs.org/api/util.html#utiltypesisdatevalue
 	**/
 	static function isDate(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a native `External` value.
 
-		@see https://nodejs.org/api/util.html#util_util_types_isexternal_value
+		@see https://nodejs.org/api/util.html#utiltypesisexternalvalue
 	**/
 	static function isExternal(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a built-in `Float32Array` instance.
 
-		@see https://nodejs.org/api/util.html#util_util_types_isfloat32array_value
+		@see https://nodejs.org/api/util.html#utiltypesisfloat32arrayvalue
 	**/
 	static function isFloat32Array(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a built-in `Float64Array` instance.
 
-		@see https://nodejs.org/api/util.html#util_util_types_isfloat64array_value
+		@see https://nodejs.org/api/util.html#utiltypesisfloat64arrayvalue
 	**/
 	static function isFloat64Array(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a generator function.
 
-		@see https://nodejs.org/api/util.html#util_util_types_isgeneratorfunction_value
+		@see https://nodejs.org/api/util.html#utiltypesisgeneratorfunctionvalue
 	**/
 	static function isGeneratorFunction(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a generator object as returned from a built-in generator function.
 
-		@see https://nodejs.org/api/util.html#util_util_types_isgeneratorobject_value
+		@see https://nodejs.org/api/util.html#utiltypesisgeneratorobjectvalue
 	**/
 	static function isGeneratorObject(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a built-in `Int8Array` instance.
 
-		@see https://nodejs.org/api/util.html#util_util_types_isint8array_value
+		@see https://nodejs.org/api/util.html#utiltypesisint8arrayvalue
 	**/
 	static function isInt8Array(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a built-in `Int16Array` instance.
 
-		@see https://nodejs.org/api/util.html#util_util_types_isint16array_value
+		@see https://nodejs.org/api/util.html#utiltypesisint16arrayvalue
 	**/
 	static function isInt16Array(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a built-in `Int32Array` instance.
 
-		@see https://nodejs.org/api/util.html#util_util_types_isint32array_value
+		@see https://nodejs.org/api/util.html#utiltypesisint32arrayvalue
 	**/
 	static function isInt32Array(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a built-in `Map` instance.
 
-		@see https://nodejs.org/api/util.html#util_util_types_ismap_value
+		@see https://nodejs.org/api/util.html#utiltypesismapvalue
 	**/
 	static function isMap(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is an iterator returned for a built-in `Map` instance.
 
-		@see https://nodejs.org/api/util.html#util_util_types_ismapiterator_value
+		@see https://nodejs.org/api/util.html#utiltypesismapiteratorvalue
 	**/
 	static function isMapIterator(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is an instance of a Module Namespace Object.
 
-		@see https://nodejs.org/api/util.html#util_util_types_ismodulenamespaceobject_value
+		@see https://nodejs.org/api/util.html#utiltypesismodulenamespaceobjectvalue
 	**/
 	static function isModuleNamespaceObject(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is an instance of a built-in `Error` type.
 
-		@see https://nodejs.org/api/util.html#util_util_types_isnativeerror_value
+		@see https://nodejs.org/api/util.html#utiltypesisnativeerrorvalue
 	**/
 	static function isNativeError(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a number object, e.g. created by `new Number()`.
 
-		@see https://nodejs.org/api/util.html#util_util_types_isnumberobject_value
+		@see https://nodejs.org/api/util.html#utiltypesisnumberobjectvalue
 	**/
 	static function isNumberObject(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a built-in `Promise`.
 
-		@see https://nodejs.org/api/util.html#util_util_types_ispromise_value
+		@see https://nodejs.org/api/util.html#utiltypesispromisevalue
 	**/
 	static function isPromise(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a `Proxy` instance.
 
-		@see https://nodejs.org/api/util.html#util_util_types_isproxy_value
+		@see https://nodejs.org/api/util.html#utiltypesisproxyvalue
 	**/
 	static function isProxy(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a regular expression object.
 
-		@see https://nodejs.org/api/util.html#util_util_types_isregexp_value
+		@see https://nodejs.org/api/util.html#utiltypesisregexpvalue
 	**/
 	static function isRegExp(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a built-in `Set` instance.
 
-		@see https://nodejs.org/api/util.html#util_util_types_isset_value
+		@see https://nodejs.org/api/util.html#utiltypesissetvalue
 	**/
 	static function isSet(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is an iterator returned for a built-in `Set` instance.
 
-		@see https://nodejs.org/api/util.html#util_util_types_issetiterator_value
+		@see https://nodejs.org/api/util.html#utiltypesissetiteratorvalue
 	**/
 	static function isSetIterator(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a built-in `SharedArrayBuffer` instance.
 
-		@see https://nodejs.org/api/util.html#util_util_types_issharedarraybuffer_value
+		@see https://nodejs.org/api/util.html#utiltypesissharedarraybuffervalue
 	**/
 	static function isSharedArrayBuffer(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a string object, e.g. created by `new String()`.
 
-		@see https://nodejs.org/api/util.html#util_util_types_isstringobject_value
+		@see https://nodejs.org/api/util.html#utiltypesisstringobjectvalue
 	**/
 	static function isStringObject(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a symbol object, created by calling `Object()` on a `Symbol` primitive.
 
-		@see https://nodejs.org/api/util.html#util_util_types_issymbolobject_value
+		@see https://nodejs.org/api/util.html#utiltypesissymbolobjectvalue
 	**/
 	static function isSymbolObject(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a built-in `TypedArray` instance.
 
-		@see https://nodejs.org/api/util.html#util_util_types_istypedarray_value
+		@see https://nodejs.org/api/util.html#utiltypesistypedarrayvalue
 	**/
 	static function isTypedArray(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a built-in `Uint8Array` instance.
 
-		@see https://nodejs.org/api/util.html#util_util_types_isuint8array_value
+		@see https://nodejs.org/api/util.html#utiltypesisuint8arrayvalue
 	**/
 	static function isUint8Array(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a built-in `Uint8ClampedArray` instance.
 
-		@see https://nodejs.org/api/util.html#util_util_types_isuint8clampedarray_value
+		@see https://nodejs.org/api/util.html#utiltypesisuint8clampedarrayvalue
 	**/
 	static function isUint8ClampedArray(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a built-in `Uint16Array` instance.
 
-		@see https://nodejs.org/api/util.html#util_util_types_isuint16array_value
+		@see https://nodejs.org/api/util.html#utiltypesisuint16arrayvalue
 	**/
 	static function isUint16Array(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a built-in `Uint32Array` instance.
 
-		@see https://nodejs.org/api/util.html#util_util_types_isuint32array_value
+		@see https://nodejs.org/api/util.html#utiltypesisuint32arrayvalue
 	**/
 	static function isUint32Array(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a built-in `WeakMap` instance.
 
-		@see https://nodejs.org/api/util.html#util_util_types_isweakmap_value
+		@see https://nodejs.org/api/util.html#utiltypesisweakmapvalue
 	**/
 	static function isWeakMap(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a built-in `WeakSet` instance.
 
-		@see https://nodejs.org/api/util.html#util_util_types_isweakset_value
+		@see https://nodejs.org/api/util.html#utiltypesisweaksetvalue
 	**/
 	static function isWeakSet(value:Any):Bool;
 

--- a/src/js/node/util/Types.hx
+++ b/src/js/node/util/Types.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -306,27 +306,38 @@ extern class Types {
 	/**
 		Returns `true` if the value is a built-in `WebAssembly.Module` instance.
 
-		@see https://nodejs.org/api/util.html#util_util_types_iswebassemblycompiledmodule_value
+		Removed in Node.js (EOL). Use `value instanceof WebAssembly.Module` instead.
+
+		@see https://nodejs.org/api/deprecations.html#dep0177-utiltypesiswebassemblycompiledmodule
 	**/
+	@:deprecated("Use value instanceof WebAssembly.Module instead")
 	static function isWebAssemblyCompiledModule(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a `BigInt` object boxed wrapper (not a primitive BigInt).
+
+		@see https://nodejs.org/api/util.html#utiltypesisbigintobjectvalue
 	**/
 	static function isBigIntObject(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a `Float16Array` instance.
+
+		@see https://nodejs.org/api/util.html#utiltypesisfloat16arrayvalue
 	**/
 	static function isFloat16Array(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a `KeyObject` from the `crypto` module.
+
+		@see https://nodejs.org/api/util.html#utiltypesiskeyobjectvalue
 	**/
 	static function isKeyObject(value:Any):Bool;
 
 	/**
 		Returns `true` if the value is a Web Crypto `CryptoKey` instance.
+
+		@see https://nodejs.org/api/util.html#utiltypesiscryptokeyvalue
 	**/
 	static function isCryptoKey(value:Any):Bool;
 }


### PR DESCRIPTION
## Summary
- Audit `js.node.Util` and `js.node.util.*` against Node.js 24 util APIs and Haxe 4 styling.
- Retype `debug` as the current `debuglog` alias (with `DebugLogger.enabled` / optional callback); keep removed `error`/`print`/`puts`/`pump` as deprecated externs.
- Add `deprecate` `DeprecateOptions`, `isDeepStrictEqual(skipPrototype)`, inspect `maxStringLength`/`numericSeparator`, `CallSiteObject.scriptId`, `MIMEParams.toString`/`toJSON`.
- Mark removed `types.isWebAssemblyCompiledModule` `@:deprecated`; document Node 24 type helpers; bump copyrights to 2014–2026; normalize CRLF util sources to LF.

## Test plan
- [x] `haxe build.hxml` (ImportAll + examples) succeeds
- [ ] Spot-check against https://nodejs.org/docs/latest-v24.x/api/util.html
- [ ] Confirm `Util.debug` callers (if any outside this repo) migrate from the old console.error-era signature


Made with [Cursor](https://cursor.com)