### PR TITLE
Audit vm externs for Node 24 and Haxe 4

### DIFF
--- a/src/js/node/Vm.hx
+++ b/src/js/node/Vm.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -22,16 +22,21 @@
 
 package js.node;
 
+import haxe.Constraints.Function;
 import haxe.DynamicAccess;
 import haxe.extern.EitherType;
+import js.lib.Promise;
 import js.node.vm.Script;
 
 /**
 	Options object used by `Vm.run*` methods.
+
+	Includes fields used by `runInNewContext` (`contextName`, `contextOrigin`, …);
+	those are ignored by methods that compile and run in an existing context.
 **/
 typedef VmRunOptions = {
 	> ScriptOptions,
-	> ScriptRunOptions,
+	> ScriptRunInNewContextOptions,
 }
 
 /**
@@ -39,38 +44,51 @@ typedef VmRunOptions = {
 **/
 typedef VmCreateContextOptions = {
 	/**
-		Human-readable name of the newly created context. Default: `'VM Context i'`, where `i` is an ascending
-		numerical index of the created context.
+		Human-readable name of the newly created context.
+		Default: `'VM Context i'`, where `i` is an ascending numerical index of the created context.
 	**/
 	@:optional var name:String;
 
 	/**
-		Origin corresponding to the newly created context for display purposes. The origin should be formatted like a
-		URL, but with only scheme, host, and port (if necessary). Default: `''`.
+		Origin corresponding to the newly created context for display purposes.
+		The origin should be formatted like a URL, but with only the scheme, host, and port (if necessary),
+		like the value of the `url.origin` property of a `URL` object.
+		Most notably, this string should omit the trailing slash, as that denotes a path.
+		Default: `''`.
 	**/
 	@:optional var origin:String;
 
 	/**
-		If set to `true` any wrappers corresponding to `contextObject` properties may be invoked. Default: `false`.
+		Controls whether `eval` / function constructors and WebAssembly compilation are allowed
+		inside the context. See `VmCodeGenerationOptions`.
 	**/
 	@:optional var codeGeneration:VmCodeGenerationOptions;
 
 	/**
 		If set to `afterEvaluate`, microtasks will be run immediately after evaluating code on the context
-		(before returning from e.g. `runInContext`). Default: `undefined`.
+		(before returning from e.g. `runInContext`).
 	**/
-	@:optional var microtaskMode:String;
+	@:optional var microtaskMode:VmMicrotaskMode;
+
+	/**
+		How modules should be loaded when `import()` is called in this context without a referrer script
+		or module. Part of the experimental modules API.
+
+		May also be `Vm.constants.USE_MAIN_CONTEXT_DEFAULT_LOADER`.
+		// TODO(vm): type importModuleDynamically callback
+	**/
+	@:optional var importModuleDynamically:Dynamic;
 }
 
 typedef VmCodeGenerationOptions = {
 	/**
-		If set to `false` any calls to `eval` or function constructors (`Function`, `GeneratorFunction`, etc) will throw
-		an `EvalError`. Default: `true`.
+		If set to `false`, any calls to `eval` or function constructors (`Function`, `GeneratorFunction`, etc)
+		will throw an `EvalError`. Default: `true`.
 	**/
 	@:optional var strings:Bool;
 
 	/**
-		If set to `false` any attempt to compile a WebAssembly module will throw a `WebAssembly.CompileError`.
+		If set to `false`, any attempt to compile a WebAssembly module will throw a `WebAssembly.CompileError`.
 		Default: `true`.
 	**/
 	@:optional var wasm:Bool;
@@ -81,14 +99,15 @@ typedef VmCodeGenerationOptions = {
 **/
 typedef VmCompileFunctionOptions = {
 	> ScriptOptions,
+
 	/**
-		Provides an optional data with V8's code cache data for the supplied source.
+		The contextified object in which the function should be compiled.
 	**/
 	@:optional var parsingContext:VmContext<Dynamic>;
 
 	/**
-		An array containing context extension objects. Modules and wrappers used in `code` will be available as if
-		they were referenced from these objects.
+		An array containing context extension objects. Modules and wrappers used in `code` will be
+		available as if they were referenced from these objects. Default: `[]`.
 	**/
 	@:optional var contextExtensions:Array<DynamicAccess<Dynamic>>;
 }
@@ -100,12 +119,44 @@ typedef VmMeasureMemoryOptions = {
 	/**
 		`'summary'` or `'detailed'`. Default: `'summary'`.
 	**/
-	@:optional var mode:String;
+	@:optional var mode:VmMeasureMemoryMode;
 
 	/**
-		`'self'` or `'all'`. Default: `'self'`.
+		`'default'` or `'eager'`. Default: `'default'`.
 	**/
-	@:optional var execution:String;
+	@:optional var execution:VmMeasureMemoryExecution;
+}
+
+/**
+	Result shape for `Vm.measureMemory` (V8-specific; additional fields may appear).
+**/
+typedef VmMemoryMeasurement = {
+	var total:VmMemoryInfo;
+	@:optional var current:VmMemoryInfo;
+	@:optional var other:Array<VmMemoryInfo>;
+	@:optional var WebAssembly:Dynamic;
+}
+
+/**
+	Per-context memory estimate returned by `Vm.measureMemory`.
+**/
+typedef VmMemoryInfo = {
+	var jsMemoryEstimate:Float;
+	var jsMemoryRange:Array<Float>;
+}
+
+enum abstract VmMeasureMemoryMode(String) from String to String {
+	var Summary = "summary";
+	var Detailed = "detailed";
+}
+
+enum abstract VmMeasureMemoryExecution(String) from String to String {
+	var Default = "default";
+	var Eager = "eager";
+}
+
+enum abstract VmMicrotaskMode(String) from String to String {
+	var AfterEvaluate = "afterEvaluate";
 }
 
 /**
@@ -113,54 +164,61 @@ typedef VmMeasureMemoryOptions = {
 
 	@see https://nodejs.org/docs/latest-v24.x/api/vm.html
 
-	// TODO(section-5): add vm.Module / SourceTextModule / SyntheticModule externs (large experimental surface)
+	Experimental module APIs live under `js.node.vm` (`Module`, `SourceTextModule`, `SyntheticModule`)
+	and require `--experimental-vm-modules`.
 **/
 @:jsRequire("vm")
 extern class Vm {
 	/**
-		Compiles `code`, runs it and returns the result.
+		Compiles `code`, runs it in the current `global`, and returns the result.
 		Running code does not have access to local scope.
 
-		// TODO(section-5): Dynamic is intentional for arbitrary JS eval results; refine per-call sites when possible
+		// TODO(vm): Dynamic is intentional for arbitrary JS eval results; refine per-call sites when possible
 	**/
 	static function runInThisContext(code:String, ?options:EitherType<String, VmRunOptions>):Dynamic;
 
 	/**
-		Compiles `code`, contextifies `sandbox` if passed or creates a new contextified sandbox if it's omitted,
-		and then runs the code with the sandbox as the global object and returns the result.
+		Compiles `code`, contextifies `contextObject` if passed (or creates a new contextified object if omitted),
+		runs the code with that object as the global, and returns the result.
+
+		`contextObject` may also be `Vm.constants.DONT_CONTEXTIFY`.
 	**/
-	@:overload(function(code:String, ?sandbox:{}):Dynamic {})
-	static function runInNewContext(code:String, sandbox:{}, ?options:VmRunOptions):Dynamic;
+	@:overload(function(code:String, ?contextObject:Dynamic):Dynamic {})
+	static function runInNewContext(code:String, contextObject:Dynamic, ?options:VmRunOptions):Dynamic;
 
 	/**
-		Compiles `code`, then runs it in `contextifiedSandbox` and returns the result.
+		Compiles `code`, then runs it in `contextifiedObject` and returns the result.
+		`contextifiedObject` must previously have been contextified via `createContext`.
 	**/
-	static function runInContext(code:String, contextifiedSandbox:VmContext<Dynamic>, ?options:EitherType<String, VmRunOptions>):Dynamic;
+	static function runInContext(code:String, contextifiedObject:VmContext<Dynamic>,
+		?options:EitherType<String, VmRunOptions>):Dynamic;
 
 	/**
-		If given a sandbox object, will "contextify" that sandbox so that it can be used in calls to `runInContext`
-		or `Script.runInContext`.
+		Prepares `contextObject` so it can be used in `runInContext` / `Script.runInContext`, and returns it.
+
+		If `contextObject` is omitted, an empty contextified object is created.
+		Pass `Vm.constants.DONT_CONTEXTIFY` to create a context without contextifying quirks.
 	**/
 	@:overload(function():VmContext<Dynamic> {})
-	static function createContext<T:{}>(sandbox:T, ?options:VmCreateContextOptions):VmContext<T>;
+	@:overload(function(contextObject:Dynamic, ?options:VmCreateContextOptions):VmContext<Dynamic> {})
+	static function createContext<T:{}>(contextObject:T, ?options:VmCreateContextOptions):VmContext<T>;
 
 	/**
-		Returns whether or not a sandbox object has been contextified by calling `createContext` on it.
+		Returns `true` if `object` has been contextified via `createContext`, or if it is the global
+		object of a context created with `Vm.constants.DONT_CONTEXTIFY`.
 	**/
-	static function isContext(sandbox:{}):Bool;
+	static function isContext(object:{}):Bool;
 
 	/**
-		Compiles the given `code` into a function object that may use the provided `params` as formal parameters
-		and may use the objects in `options.contextExtensions` as its local scope.
+		Compiles `code` into a function that may use `params` as formal parameters
+		and may use objects in `options.contextExtensions` as its local scope.
 	**/
-	static function compileFunction(code:String, ?params:Array<String>, ?options:VmCompileFunctionOptions):haxe.Constraints.Function;
+	static function compileFunction(code:String, ?params:Array<String>, ?options:VmCompileFunctionOptions):Function;
 
 	/**
-		Measure the known V8 heap memory attributed to this context / all contexts (experimental).
-
-		// TODO(section-5): type Promise result of measureMemory
+		Measure V8 heap memory attributed to the main context or all known contexts (experimental).
 	**/
-	static function measureMemory(?options:VmMeasureMemoryOptions):js.lib.Promise<Dynamic>;
+	static function measureMemory(?options:VmMeasureMemoryOptions):Promise<VmMemoryMeasurement>;
 
 	/**
 		Compiles and executes `code` inside the V8 debug context.
@@ -173,7 +231,7 @@ extern class Vm {
 	static function createScript(code:String, ?options:EitherType<String, ScriptOptions>):Script;
 
 	/**
-		Returns an object containing commonly used constants for VM operations.
+		Commonly used constants for VM operations.
 	**/
 	static var constants(default, null):VmConstants;
 }
@@ -183,16 +241,14 @@ extern class Vm {
 **/
 typedef VmConstants = {
 	/**
-		A constant that can be used as the `importModuleDynamically` option to `vm.Script`
-		or `vm.compileFunction` so that Node.js uses the default ESM loader from the main context
-		to load the requested module.
+		Pass as `importModuleDynamically` to `Script` / `compileFunction` so Node.js uses the default
+		ESM loader from the main context to load the requested module.
 	**/
 	var USE_MAIN_CONTEXT_DEFAULT_LOADER:Dynamic;
 
 	/**
-		When passed as `contextObject` to `vm.createContext()`, this constant creates an empty context
-		with an object wrapper that allows code running in that context to see the outer context's Object
-		prototype methods, but also has its own independent Object/Array prototypes and builtins.
+		Pass as `contextObject` to `createContext` / `runInNewContext` to create a context whose global
+		is an ordinary object (without contextifying quirks such as inability to freeze).
 	**/
 	var DONT_CONTEXTIFY:Dynamic;
 }

--- a/src/js/node/vm/Module.hx
+++ b/src/js/node/vm/Module.hx
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C)2014-2026 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.vm;
+
+import js.lib.Promise;
+import js.node.Vm.VmContext;
+
+/**
+	Options for `Module.evaluate`.
+**/
+typedef ModuleEvaluateOptions = {
+	/**
+		Specifies the number of milliseconds to evaluate before terminating execution.
+	**/
+	@:optional var timeout:Int;
+
+	/**
+		If `true`, receiving `SIGINT` (`Ctrl+C`) will terminate execution and throw an Error.
+		Default: `false`.
+	**/
+	@:optional var breakOnSigint:Bool;
+}
+
+/**
+	A request to import a module with given import attributes and phase.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/vm.html#type-modulerequest
+**/
+typedef ModuleRequest = {
+	/**
+		The specifier of the requested module.
+	**/
+	var specifier:String;
+
+	/**
+		The `"with"` value passed to the WithClause in an ImportDeclaration,
+		or an empty object if no value was provided.
+	**/
+	var attributes:Dynamic;
+
+	/**
+		The phase of the requested module (`"source"` or `"evaluation"`).
+	**/
+	var phase:ModulePhase;
+}
+
+enum abstract ModuleStatus(String) from String to String {
+	var Unlinked = "unlinked";
+	var Linking = "linking";
+	var Linked = "linked";
+	var Evaluating = "evaluating";
+	var Evaluated = "evaluated";
+	var Errored = "errored";
+}
+
+enum abstract ModulePhase(String) from String to String {
+	var Source = "source";
+	var Evaluation = "evaluation";
+}
+
+/**
+	Low-level interface for using ECMAScript modules in VM contexts.
+
+	Stability: 1 - Experimental. Requires `--experimental-vm-modules`.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/vm.html#class-vmmodule
+**/
+@:jsRequire("vm", "Module")
+extern class Module {
+	/**
+		If `status` is `'errored'`, this property contains the exception thrown during evaluation.
+		Accessing it otherwise throws.
+	**/
+	var error(default, null):Dynamic;
+
+	/**
+		The identifier of the current module, as set in the constructor.
+	**/
+	var identifier(default, null):String;
+
+	/**
+		The contextified object this module belongs to.
+	**/
+	var context(default, null):VmContext<Dynamic>;
+
+	/**
+		The namespace object of the module. Available after linking has completed.
+	**/
+	var namespace(default, null):Dynamic;
+
+	/**
+		Current status of the module.
+	**/
+	var status(default, null):ModuleStatus;
+
+	/**
+		Evaluate the module and its dependencies.
+	**/
+	function evaluate(?options:ModuleEvaluateOptions):Promise<Void>;
+
+	/**
+		Link module dependencies. Must be called before evaluation, and only once per module.
+
+		Prefer `SourceTextModule.linkRequests` + `SourceTextModule.instantiate` for the Node 24+ sync path.
+
+		// TODO(vm): linker callback typing (`specifier`, referencing module, attributes, phase)
+	**/
+	function link(linker:Dynamic):Promise<Void>;
+}

--- a/src/js/node/vm/Script.hx
+++ b/src/js/node/vm/Script.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -23,124 +23,170 @@
 package js.node.vm;
 
 import haxe.extern.EitherType;
+import js.lib.ArrayBufferView;
 import js.node.Buffer;
+import js.node.Vm.VmCodeGenerationOptions;
 import js.node.Vm.VmContext;
+import js.node.Vm.VmMicrotaskMode;
 
+/**
+	Options for compiling a `Script` (constructor / `compileFunction` / `runIn*` compile path).
+**/
 typedef ScriptOptions = {
 	/**
 		Specifies the filename used in stack traces produced by this script.
+		Default: `'evalmachine.<incremental_id>'` for `Script`, `''` for some other APIs.
 	**/
 	@:optional var filename:String;
 
 	/**
 		Specifies the line number offset that is displayed in stack traces produced by this script.
+		Default: `0`.
 	**/
 	@:optional var lineOffset:Int;
 
 	/**
 		Specifies the column number offset that is displayed in stack traces produced by this script.
+		Default: `0`.
 	**/
 	@:optional var columnOffset:Int;
 
 	/**
-		Whether or not to print any errors to stderr, with the line of code that caused them highlighted,
-		before throwing an exception.
-		Deprecated alias kept for older Node docs; prefer omitting and relying on engine defaults.
+		Optional V8 code cache data for the supplied source (`Buffer`, `TypedArray`, or `DataView`).
+		When supplied, `cachedDataRejected` on the resulting `Script` is set to `true` or `false`.
 	**/
-	@:optional var displayErrors:Bool;
+	@:optional var cachedData:EitherType<Buffer, ArrayBufferView>;
 
 	/**
-		Provides an optional data with V8's code cache data for the supplied source.
-	**/
-	@:optional var cachedData:Buffer;
-
-	/**
-		V8-specific option; when `true`, produces cached data used for faster compilation next time.
-		Deprecated in favor of `createCachedData()`.
+		When `true` and no `cachedData` is present, V8 attempts to produce code cache data for `code`.
+		Deprecated in favor of `createCachedData()`. Default: `false`.
 	**/
 	@:deprecated("Use createCachedData() instead")
 	@:optional var produceCachedData:Bool;
 
 	/**
-		Used to specify how the modules should be loaded during evaluation.
-		Passed to the experimental `importModuleDynamically` hook.
+		How modules should be loaded during evaluation when `import()` is called.
+		Part of the experimental modules API; may also be `Vm.constants.USE_MAIN_CONTEXT_DEFAULT_LOADER`.
 
-		// TODO(section-5): type importModuleDynamically callback
+		// TODO(vm): type importModuleDynamically callback
 	**/
 	@:optional var importModuleDynamically:Dynamic;
 }
 
+/**
+	Options for running a compiled script (`runInThisContext` / `runInContext`).
+**/
 typedef ScriptRunOptions = {
 	/**
-		Whether or not to print any errors to stderr, with the line of code that caused them highlighted,
-		before throwing an exception.
+		When `true`, if an `Error` occurs while compiling or running the code, the line of code
+		causing the error is attached to the stack trace. Default: `true`.
 	**/
 	@:optional var displayErrors:Bool;
 
 	/**
 		Number of milliseconds to execute code before terminating execution.
-		If execution is terminated, an Error will be thrown.
+		If execution is terminated, an `Error` is thrown. Must be a strictly positive integer.
 	**/
 	@:optional var timeout:Int;
 
 	/**
-		If `true`, the execution will be terminated when `SIGINT` (`Ctrl+C`) is received.
-		Existing handlers for the event that have been attached via `process.on('SIGINT')` will be disabled during
-		script execution, but will continue to work after that. Default: `false`.
+		If `true`, receiving `SIGINT` (`Ctrl+C`) terminates execution and throws an `Error`.
+		Existing handlers attached via `process.on('SIGINT')` are disabled during script execution
+		but continue to work afterward. Default: `false`.
 	**/
 	@:optional var breakOnSigint:Bool;
 }
 
 /**
-	A class for holding precompiled scripts, and running them in specific sandboxes.
+	Options for `runInNewContext` (script or `Vm.runInNewContext`).
+**/
+typedef ScriptRunInNewContextOptions = {
+	> ScriptRunOptions,
+
+	/**
+		Human-readable name of the newly created context.
+		Default: `'VM Context i'`, where `i` is an ascending numerical index of the created context.
+	**/
+	@:optional var contextName:String;
+
+	/**
+		Origin corresponding to the newly created context for display purposes.
+		Default: `''`.
+	**/
+	@:optional var contextOrigin:String;
+
+	/**
+		Controls `eval` / function constructors and WebAssembly compilation in the new context.
+	**/
+	@:optional var contextCodeGeneration:VmCodeGenerationOptions;
+
+	/**
+		If set to `afterEvaluate`, microtasks run immediately after the script has run.
+		They are included in the `timeout` and `breakOnSigint` scopes in that case.
+	**/
+	@:optional var microtaskMode:VmMicrotaskMode;
+}
+
+/**
+	A class for holding precompiled scripts and running them in specific contexts.
 
 	@see https://nodejs.org/docs/latest-v24.x/api/vm.html#class-vmscript
 **/
 @:jsRequire("vm", "Script")
 extern class Script {
 	/**
-		Creating a new `Script` compiles `code` but does not run it. Instead, the created `Script` object
-		represents this compiled code.
+		Creates a new `Script` by compiling `code` without running it.
+		If `options` is a string, it specifies the filename.
 	**/
 	function new(code:String, ?options:EitherType<String, ScriptOptions>);
 
 	/**
-		When producing cached data with `--produce_cached_data`, this value becomes `true` if the produced
-		cached data was rejected by V8.
+		When `cachedData` was supplied to the constructor, `true` if V8 rejected the data,
+		`false` if it was accepted; otherwise `null`/`undefined`.
 	**/
 	var cachedDataRejected(default, null):Null<Bool>;
 
 	/**
-		When the script is compiled using `cachedData` this value will be `true` if the data was accepted by V8.
+		When `produceCachedData` was used, `true`/`false` depending on whether cache data was produced.
+		Prefer `createCachedData()` instead of `produceCachedData`.
 	**/
 	var cachedDataProduced(default, null):Null<Bool>;
 
 	/**
-		When `cachedData` is supplied, the rejected or produced status is reflected here.
+		V8 code cache buffer associated with this script when produced or supplied.
 	**/
 	var cachedData(default, null):Null<Buffer>;
 
 	/**
-		Creates a code cache that can be used with `Script` constructor's `cachedData` option
-		to avoid recompilation next time.
+		When the script source contains a source map magic comment, the URL of that source map;
+		otherwise `null`/`undefined`.
+	**/
+	var sourceMapURL(default, null):Null<String>;
+
+	/**
+		Creates a code cache that can be passed as `cachedData` to a later `Script` constructor
+		to avoid recompilation.
 	**/
 	function createCachedData():Buffer;
 
 	/**
-		Similar to `Vm.runInThisContext` but a method of a precompiled `Script` object.
+		Runs this script in the current `global` context.
 
-		// TODO(section-5): Dynamic is intentional for arbitrary JS eval results
+		// TODO(vm): Dynamic is intentional for arbitrary JS eval results
 	**/
 	function runInThisContext(?options:ScriptRunOptions):Dynamic;
 
 	/**
-		Similar to `Vm.runInContext` but a method of a precompiled `Script` object.
+		Runs this script in `contextifiedObject` (from `Vm.createContext`).
 	**/
-	function runInContext(contextifiedSandbox:VmContext<Dynamic>, ?options:ScriptRunOptions):Dynamic;
+	function runInContext(contextifiedObject:VmContext<Dynamic>, ?options:ScriptRunOptions):Dynamic;
 
 	/**
-		Similar to `Vm.runInNewContext` but a method of a precompiled `Script` object.
+		Creates a new context (optionally from `contextObject`), runs this script in it, and returns the result.
+
+		`contextObject` may be an object to contextify, omitted/`undefined` for a fresh contextified object,
+		or `Vm.constants.DONT_CONTEXTIFY`.
 	**/
-	@:overload(function(sandbox:{}, ?options:ScriptRunOptions):Dynamic {})
-	function runInNewContext(?sandbox:{}):Dynamic;
+	@:overload(function(?contextObject:Dynamic):Dynamic {})
+	function runInNewContext(contextObject:Dynamic, ?options:ScriptRunInNewContextOptions):Dynamic;
 }

--- a/src/js/node/vm/SourceTextModule.hx
+++ b/src/js/node/vm/SourceTextModule.hx
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C)2014-2026 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.vm;
+
+import haxe.extern.EitherType;
+import js.lib.ArrayBufferView;
+import js.node.Buffer;
+import js.node.Vm.VmContext;
+import js.node.vm.Module.ModuleRequest;
+
+/**
+	Options for `new SourceTextModule(...)`.
+**/
+typedef SourceTextModuleOptions = {
+	/**
+		String used in stack traces. Default: `'vm:module(i)'` where `i` is a context-specific ascending index.
+	**/
+	@:optional var identifier:String;
+
+	/**
+		Optional V8 code cache data for the supplied source (`Buffer`, `TypedArray`, or `DataView`).
+		The `code` must match the module from which this cached data was created.
+	**/
+	@:optional var cachedData:EitherType<Buffer, ArrayBufferView>;
+
+	/**
+		The contextified object to compile and evaluate this module in.
+		If omitted, the module is evaluated in the current execution context.
+	**/
+	@:optional var context:VmContext<Dynamic>;
+
+	/**
+		Line number offset displayed in stack traces. Default: `0`.
+	**/
+	@:optional var lineOffset:Int;
+
+	/**
+		First-line column number offset displayed in stack traces. Default: `0`.
+	**/
+	@:optional var columnOffset:Int;
+
+	/**
+		Called during evaluation of this module to initialize `import.meta`.
+
+		// TODO(vm): type initializeImportMeta `(meta, module) -> Void`
+	**/
+	@:optional var initializeImportMeta:Dynamic;
+
+	/**
+		Used to specify how modules should be loaded during evaluation when `import()` is called.
+		Experimental modules API.
+	**/
+	@:optional var importModuleDynamically:Dynamic;
+}
+
+/**
+	Provides the Source Text Module Record as defined in the ECMAScript specification.
+
+	Stability: 1 - Experimental. Requires `--experimental-vm-modules`.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/vm.html#class-vmsourcetextmodule
+**/
+@:jsRequire("vm", "SourceTextModule")
+extern class SourceTextModule extends Module {
+	/**
+		Creates a new `SourceTextModule` instance by parsing `code`.
+	**/
+	function new(code:String, ?options:SourceTextModuleOptions);
+
+	/**
+		Creates a code cache that can be used with the `SourceTextModule` constructor's `cachedData` option.
+		May be called any number of times before the module has been evaluated.
+	**/
+	function createCachedData():Buffer;
+
+	/**
+		Specifiers of all dependencies of this module. The returned array is frozen.
+		Deprecated in Node.js 24.4.0 in favour of `moduleRequests`.
+	**/
+	@:deprecated("Use moduleRequests instead")
+	var dependencySpecifiers(default, null):Array<String>;
+
+	/**
+		Requested import dependencies of this module. The returned array is frozen.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/vm.html#sourcetextmodulemodulerequests
+	**/
+	var moduleRequests(default, null):Array<ModuleRequest>;
+
+	/**
+		Iterates over the dependency graph and returns `true` if any module in its dependencies
+		or this module itself contains top-level `await` expressions.
+
+		Requires the module to be instantiated first.
+	**/
+	function hasAsyncGraph():Bool;
+
+	/**
+		Returns whether the module itself contains any top-level `await` expressions.
+	**/
+	function hasTopLevelAwait():Bool;
+
+	/**
+		Instantiate the module with the linked requested modules.
+		Resolves imported bindings; throws synchronously if bindings cannot be resolved.
+	**/
+	function instantiate():Void;
+
+	/**
+		Link module dependencies synchronously (or after async resolution by the host).
+		Must be called before evaluation, and only once per module.
+
+		The order of `modules` must match `moduleRequests`. After linking, call `instantiate()`.
+	**/
+	function linkRequests(modules:Array<Module>):Void;
+}

--- a/src/js/node/vm/SyntheticModule.hx
+++ b/src/js/node/vm/SyntheticModule.hx
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C)2014-2026 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.vm;
+
+import js.node.Vm.VmContext;
+
+/**
+	Options for `new SyntheticModule(...)`.
+**/
+typedef SyntheticModuleOptions = {
+	/**
+		String used in stack traces. Default: `'vm:module(i)'` where `i` is a context-specific ascending index.
+	**/
+	@:optional var identifier:String;
+
+	/**
+		The contextified object to compile and evaluate this module in.
+	**/
+	@:optional var context:VmContext<Dynamic>;
+}
+
+/**
+	Provides the Synthetic Module Record as defined in the WebIDL specification.
+	Used to expose non-JavaScript sources to ECMAScript module graphs.
+
+	Stability: 1 - Experimental. Requires `--experimental-vm-modules`.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/vm.html#class-vmsyntheticmodule
+**/
+@:jsRequire("vm", "SyntheticModule")
+extern class SyntheticModule extends Module {
+	/**
+		Creates a new `SyntheticModule` instance.
+
+		`evaluateCallback` is called when the module is evaluated; use `setExport` inside it
+		to define export bindings. `this` inside the callback is the module instance.
+	**/
+	function new(exportNames:Array<String>, evaluateCallback:haxe.Constraints.Function,
+		?options:SyntheticModuleOptions);
+
+	/**
+		Sets the module export binding slot for `name` to `value`.
+	**/
+	function setExport(name:String, value:Dynamic):Void;
+}


### PR DESCRIPTION
## Summary
- Align `js.node.Vm` / `js.node.vm.Script` with Node.js 24: `DONT_CONTEXTIFY`, `importModuleDynamically` on contexts, `ScriptRunInNewContextOptions`, `ArrayBufferView` cached data, and corrected `measureMemory` `execution` docs (`default`/`eager`).
- Add experimental `--experimental-vm-modules` externs: `Module`, `SourceTextModule`, `SyntheticModule`, plus Node 24 `moduleRequests` / `linkRequests` / `instantiate` / `hasAsyncGraph`.
- Refresh copyright headers to 2014–2026 and point docs at the v24 API.

## Test plan
- [x] `haxe build.hxml` (ImportAll + BuildExamples)
- [x] `haxe -js dummy.js -cp src --macro 'ImportAll.run("src")' --macro '_internal.SuppressDeprecated.run()' --no-output`
- [ ] Spot-check `createContext(Vm.constants.DONT_CONTEXTIFY)` and `SourceTextModule.linkRequests` against Node 24 docs


Made with [Cursor](https://cursor.com)