### PR TITLE
Audit worker_threads externs for Node 24 and Haxe 4

### DIFF
--- a/src/js/node/WorkerThreads.hx
+++ b/src/js/node/WorkerThreads.hx
@@ -28,10 +28,8 @@ import js.lib.Symbol;
 import js.node.Vm.VmContext;
 import js.node.web.LockManager;
 import js.node.worker_threads.BroadcastChannel;
-import js.node.worker_threads.MessageChannel;
 import js.node.worker_threads.MessagePort;
 import js.node.worker_threads.Transferable;
-import js.node.worker_threads.Worker;
 
 /**
 	The `node:worker_threads` module enables the use of threads that execute JavaScript in parallel.

--- a/src/js/node/WorkerThreads.hx
+++ b/src/js/node/WorkerThreads.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2025 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -22,15 +22,21 @@
 
 package js.node;
 
+import haxe.extern.EitherType;
 import js.lib.Promise;
 import js.lib.Symbol;
 import js.node.Vm.VmContext;
+import js.node.web.LockManager;
+import js.node.worker_threads.BroadcastChannel;
+import js.node.worker_threads.MessageChannel;
 import js.node.worker_threads.MessagePort;
 import js.node.worker_threads.Transferable;
 import js.node.worker_threads.Worker;
 
 /**
 	The `node:worker_threads` module enables the use of threads that execute JavaScript in parallel.
+
+	Stability: 2 - Stable.
 
 	Core surface for Node.js 24+. Posted message values remain loosely typed
 	because structured clone accepts many object graphs; transfer lists use `Transferable`.
@@ -39,44 +45,127 @@ import js.node.worker_threads.Worker;
 **/
 @:jsRequire("worker_threads")
 extern class WorkerThreads {
+	/**
+		If this thread was not created as a `Worker`, `null`.
+		Otherwise, a `MessagePort` allowing communication with the parent.
+	**/
 	static final parentPort:Null<MessagePort>;
 
 	/**
+		Arbitrary clone of data passed to this thread's `Worker` constructor.
 		// TODO(section-5): workerData is application-defined; typed as Dynamic
 	**/
 	static final workerData:Dynamic;
 
+	/**
+		`true` if this code is not running inside of a `Worker` thread.
+	**/
 	static final isMainThread:Bool;
+
+	/**
+		`true` if this code is running inside an internal `Worker` thread
+		(for example the loader thread).
+	**/
 	static final isInternalThread:Bool;
+
+	/**
+		Integer identifier for the current thread.
+	**/
 	static final threadId:Int;
+
+	/**
+		String identifier for the current thread, or `null` if the thread is not running.
+	**/
 	static final threadName:Null<String>;
+
+	/**
+		Special value for `Worker` `env` so parent and worker share `process.env`.
+	**/
 	static final SHARE_ENV:Symbol;
+
+	/**
+		JS engine resource constraints inside this Worker thread.
+		Empty object when read from the main thread.
+	**/
 	static final resourceLimits:WorkerResourceLimits;
 
 	/**
+		Web Locks API manager for coordinating access across threads in this process.
+		Stability: 1 - Experimental.
+	**/
+	static final locks:LockManager;
+
+	/**
+		Returns a clone of data set by `setEnvironmentData` in the spawning thread.
 		// TODO(section-5): environment data value typing is application-defined
 	**/
 	static function getEnvironmentData(key:Dynamic):Dynamic;
 
+	/**
+		Sets environment data cloned into all new `Worker` instances from this context.
+		Passing `value` as `undefined` deletes any previously set value for `key`.
+	**/
 	static function setEnvironmentData(key:Dynamic, ?value:Dynamic):Void;
+
+	/**
+		Marks an object as not transferable. Occurrence in a transfer list throws.
+	**/
 	static function markAsUntransferable(object:Dynamic):Void;
+
+	/**
+		Returns `true` if the object has been marked as untransferable.
+	**/
 	static function isMarkedAsUntransferable(object:Dynamic):Bool;
+
+	/**
+		Marks an object as not cloneable for structured clone / `postMessage`.
+	**/
 	static function markAsUncloneable(object:Dynamic):Void;
 
 	/**
-		Posts a value to another thread. `transferList` uses `js.node.worker_threads.Transferable`.
+		Sends a value to another worker identified by `threadId`.
+		`transferList` uses `js.node.worker_threads.Transferable`.
+
+		Stability: 1.1 - Active development.
 	**/
 	static function postMessageToThread(threadId:Int, value:Dynamic, ?transferList:Array<Transferable>, ?timeout:Int):Promise<Void>;
 
-	static function receiveMessageOnPort(port:MessagePort):Null<{message:Dynamic}>;
+	/**
+		Receive a single queued message from `port` without emitting `'message'`.
+		Returns `undefined` when the queue is empty.
+	**/
+	static function receiveMessageOnPort(port:EitherType<MessagePort, BroadcastChannel>):Null<{message:Dynamic}>;
+
+	/**
+		Transfers `port` into `contextifiedSandbox`, returning a port that inherits
+		from the target context's `Object`.
+	**/
 	static function moveMessagePortToContext(port:MessagePort, contextifiedSandbox:VmContext<Dynamic>):MessagePort;
 }
 
+/**
+	Resource limits for the JS engine in a `Worker`.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/worker_threads.html#workerresourcelimits
+**/
 typedef WorkerResourceLimits = {
+	/**
+		Maximum size of the main heap in MB.
+	**/
 	@:optional var maxOldGenerationSizeMb:Float;
+
+	/**
+		Maximum size of a heap space for recently created objects.
+	**/
 	@:optional var maxYoungGenerationSizeMb:Float;
+
+	/**
+		Size of a pre-allocated memory range used for generated code.
+	**/
 	@:optional var codeRangeSizeMb:Float;
+
+	/**
+		Default maximum stack size for the thread. Default: `4`.
+	**/
 	@:optional var stackSizeMb:Float;
 }
-
-// TODO(section-5): BroadcastChannel / locks / Worker performance profiling APIs

--- a/src/js/node/worker_threads/BroadcastChannel.hx
+++ b/src/js/node/worker_threads/BroadcastChannel.hx
@@ -22,23 +22,47 @@
 
 package js.node.worker_threads;
 
-import haxe.extern.EitherType;
-import js.lib.ArrayBuffer;
-import js.node.fs.FileHandle;
-import js.node.web.AbortSignal;
-import js.node.web.ReadableStream;
-import js.node.web.TransformStream;
-import js.node.web.WritableStream;
+import js.node.web.EventTarget;
+import js.node.web.MessageEvent;
 
 /**
-	Objects accepted in a `worker_threads` `transferList` / structured-clone transfer list.
+	Asynchronous one-to-many messaging with all other `BroadcastChannel` instances
+	bound to the same channel name.
 
-	Matches the Node.js transferable set that already has externs in this repo
-	(`ArrayBuffer`, `MessagePort`, `AbortSignal`, `FileHandle`, and web streams).
-	Does not invent types such as `SharedArrayBuffer` that are not yet externed.
+	Also available as the web global `js.node.web.BroadcastChannel`.
 
-	@see https://nodejs.org/docs/latest-v24.x/api/worker_threads.html#portpostmessagevalue-transferlist
+	@see https://nodejs.org/docs/latest-v24.x/api/worker_threads.html#class-broadcastchannel
 **/
-typedef Transferable = EitherType<ArrayBuffer,
-	EitherType<MessagePort,
-		EitherType<AbortSignal, EitherType<FileHandle, EitherType<ReadableStream, EitherType<WritableStream, TransformStream>>>>>>;
+@:jsRequire("worker_threads", "BroadcastChannel")
+extern class BroadcastChannel extends EventTarget {
+	/**
+		The channel name.
+	**/
+	var name(default, null):String;
+
+	var onmessage:Null<MessageEvent->Void>;
+	var onmessageerror:Null<MessageEvent->Void>;
+
+	function new(name:String):Void;
+
+	/**
+		Closes the channel connection.
+	**/
+	function close():Void;
+
+	/**
+		Posts a message that will be delivered to all other `BroadcastChannel`
+		objects listening on the same name.
+	**/
+	function postMessage(message:Any):Void;
+
+	/**
+		Opposite of `unref()`. Returns `this`.
+	**/
+	function ref():BroadcastChannel;
+
+	/**
+		Allows the thread to exit if this is the only active handle. Returns `this`.
+	**/
+	function unref():BroadcastChannel;
+}

--- a/src/js/node/worker_threads/MessageChannel.hx
+++ b/src/js/node/worker_threads/MessageChannel.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2025 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -23,13 +23,21 @@
 package js.node.worker_threads;
 
 /**
-	Instances of `MessageChannel` represent an asynchronous two-way communications channel.
+	An asynchronous two-way communications channel pairing two linked `MessagePort`s.
 
 	@see https://nodejs.org/docs/latest-v24.x/api/worker_threads.html#class-messagechannel
 **/
 @:jsRequire("worker_threads", "MessageChannel")
 extern class MessageChannel {
 	function new():Void;
+
+	/**
+		Port whose opposite is `port2`.
+	**/
 	var port1(default, null):MessagePort;
+
+	/**
+		Port whose opposite is `port1`.
+	**/
 	var port2(default, null):MessagePort;
 }

--- a/src/js/node/worker_threads/MessagePort.hx
+++ b/src/js/node/worker_threads/MessagePort.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2025 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,43 +24,71 @@ package js.node.worker_threads;
 
 import js.lib.Error;
 import js.node.events.EventEmitter;
+import js.node.web.MessageEvent;
 
 /**
 	Events emitted by `MessagePort`.
 **/
 enum abstract MessagePortEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
-	var Close:MessagePortEvent<Void->Void> = "close";
-	// TODO(section-5): message value is structured-clone Dynamic
-	var Message:MessagePortEvent<Dynamic->Void> = "message";
-	var MessageError:MessagePortEvent<Error->Void> = "messageerror";
+	/**
+		Emitted once either side of the channel has been disconnected.
+	**/
+	var Close:MessagePortEvent<() -> Void> = "close";
+
+	/**
+		Emitted for any incoming message containing the cloned `postMessage` value.
+		// TODO(section-5): message value is structured-clone Dynamic
+	**/
+	var Message:MessagePortEvent<(value:Dynamic) -> Void> = "message";
+
+	/**
+		Emitted when deserializing a message failed.
+	**/
+	var MessageError:MessagePortEvent<(error:Error) -> Void> = "messageerror";
 }
 
 /**
-	Instances of `MessagePort` represent one end of an asynchronous two-way communication channel.
+	One end of an asynchronous two-way communication channel.
+
+	Matches browser `MessagePort`s. Node.js documents inheritance from `EventTarget`;
+	this extern keeps `EventEmitter` for the existing `.on` / enum-event ergonomics.
 
 	@see https://nodejs.org/docs/latest-v24.x/api/worker_threads.html#class-messageport
 **/
 @:jsRequire("worker_threads", "MessagePort")
 extern class MessagePort extends EventEmitter<MessagePort> {
 	/**
+		EventTarget-style handler; setting it automatically calls `start()`.
+	**/
+	var onmessage:Null<MessageEvent->Void>;
+
+	/**
+		EventTarget-style handler for deserialization failures.
+	**/
+	var onmessageerror:Null<MessageEvent->Void>;
+
+	/**
 		Sends a JavaScript value to the receiving end of the channel.
-		`transferList` may include ArrayBuffer, MessagePort, AbortSignal, FileHandle, or web streams.
+		`transferList` may include `ArrayBuffer`, `MessagePort`, `AbortSignal`,
+		`FileHandle`, or web streams (see `Transferable`).
 		// TODO(section-5): value typing for structured clone remains application-defined Dynamic
 	**/
 	function postMessage(value:Dynamic, ?transferList:Array<Transferable>):Void;
 
 	/**
-		Disables further sending of messages from either port. Once done, no further messages can be received.
+		Disables further sending of messages from either port.
+		Once done, no further messages can be received.
 	**/
 	function close():Void;
 
 	/**
-		Starts receiving messages. Automatically called if a listener for `'message'` is attached.
+		Starts receiving messages. Automatically called if a listener for `'message'`
+		is attached. Exists mainly for parity with the Web `MessagePort` API.
 	**/
 	function start():Void;
 
 	/**
-		Opposite of `unref()`. Increases active handle count.
+		Opposite of `unref()`. Increases the active handle count.
 	**/
 	function ref():Void;
 
@@ -70,7 +98,7 @@ extern class MessagePort extends EventEmitter<MessagePort> {
 	function unref():Void;
 
 	/**
-		If true, the MessagePort will keep the event loop of the thread alive.
+		Returns `true` if the MessagePort will keep the event loop of the thread alive.
 	**/
 	function hasRef():Bool;
 }

--- a/src/js/node/worker_threads/Worker.hx
+++ b/src/js/node/worker_threads/Worker.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2025 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,6 +25,10 @@ package js.node.worker_threads;
 import haxe.extern.EitherType;
 import js.lib.Error;
 import js.lib.Promise;
+import js.node.PerfHooks.EventLoopUtilization;
+import js.node.Process.CpuUsage;
+import js.node.V8.V8HeapSnapshotOptions;
+import js.node.V8.V8HeapStatistics;
 import js.node.WorkerThreads.WorkerResourceLimits;
 import js.node.events.EventEmitter;
 import js.node.stream.Readable.IReadable;
@@ -35,16 +39,43 @@ import js.node.url.URL;
 	Events emitted by `Worker`.
 **/
 enum abstract WorkerEvent<T:haxe.Constraints.Function>(Event<T>) to Event<T> {
-	var Error:WorkerEvent<Error->Void> = "error";
-	var Exit:WorkerEvent<Int->Void> = "exit";
-	// TODO(section-5): message value is structured-clone Dynamic
-	var Message:WorkerEvent<Dynamic->Void> = "message";
-	var MessageError:WorkerEvent<Error->Void> = "messageerror";
-	var Online:WorkerEvent<Void->Void> = "online";
+	/**
+		Emitted if the worker thread throws an uncaught exception.
+		The worker is terminated in that case.
+	**/
+	var Error:WorkerEvent<(err:Error) -> Void> = "error";
+
+	/**
+		Emitted once the worker has stopped.
+		Final event emitted by any `Worker` instance.
+	**/
+	var Exit:WorkerEvent<(exitCode:Int) -> Void> = "exit";
+
+	/**
+		Emitted when the worker invokes `parentPort.postMessage()`.
+		// TODO(section-5): message value is structured-clone Dynamic
+	**/
+	var Message:WorkerEvent<(value:Dynamic) -> Void> = "message";
+
+	/**
+		Emitted when deserializing a message failed.
+	**/
+	var MessageError:WorkerEvent<(error:Error) -> Void> = "messageerror";
+
+	/**
+		Emitted when the worker thread has started executing JavaScript code.
+	**/
+	var Online:WorkerEvent<() -> Void> = "online";
 }
 
 /**
 	The `Worker` class represents an independent JavaScript execution thread.
+
+	Most Node.js APIs are available inside of it. Creating `Worker` instances
+	inside other `Worker`s is supported.
+
+	// TODO(section-5): `Symbol.asyncDispose` (`await using`) terminates the worker;
+	// add when Disposable models are standardized in hxnodejs.
 
 	@see https://nodejs.org/docs/latest-v24.x/api/worker_threads.html#class-worker
 **/
@@ -56,37 +87,62 @@ extern class Worker extends EventEmitter<Worker> {
 	function new(filename:EitherType<String, URL>, ?options:WorkerOptions);
 
 	/**
-		Send a message to the worker that will be received via `require('worker_threads').parentPort.on('message')`.
+		Send a message to the worker that will be received via
+		`require('worker_threads').parentPort.on('message')`.
 		// TODO(section-5): value typing for structured clone remains application-defined Dynamic
 	**/
 	function postMessage(value:Dynamic, ?transferList:Array<Transferable>):Void;
 
 	/**
-		Opposite of `unref()`. Calls will take effect if the Worker previously was `unref`ed.
+		Opposite of `unref()`. Calling `ref()` on a previously `unref`ed worker
+		does not let the program exit if it is the only active handle left.
 	**/
 	function ref():Void;
 
 	/**
-		Calling `unref` on a worker allows the thread to exit if this is the only active handle in the event system.
+		Allows the thread to exit if this is the only active handle in the event system.
 	**/
 	function unref():Void;
 
 	/**
 		Stop all JavaScript execution in the worker thread as soon as possible.
-		Returns a Promise for the exit code.
+		Returns a Promise for the exit code fulfilled when `'exit'` is emitted.
 	**/
 	function terminate():Promise<Int>;
 
 	/**
-		Returns a readable stream for a V8 snapshot of the current state of the Worker.
+		Returns thread CPU usage identical to `process.threadCpuUsage()`,
+		or rejects with `ERR_WORKER_NOT_RUNNING` if the worker has stopped.
 	**/
-	function getHeapSnapshot():Promise<IReadable>;
+	function cpuUsage(?prev:CpuUsage):Promise<CpuUsage>;
 
 	/**
-		Returns statistics about the worker's V8 heap.
-		// TODO(section-5): align with V8HeapStatistics once shared typing is practical
+		Returns a readable stream for a V8 snapshot of the current state of the Worker.
 	**/
-	function getHeapStatistics():Promise<Dynamic>;
+	function getHeapSnapshot(?options:V8HeapSnapshotOptions):Promise<IReadable>;
+
+	/**
+		Returns statistics identical to `V8.getHeapStatistics()`,
+		or rejects with `ERR_WORKER_NOT_RUNNING` if the worker has stopped.
+	**/
+	function getHeapStatistics():Promise<V8HeapStatistics>;
+
+	/**
+		Starts a CPU profile. Supports `await using` to discard on scope exit.
+		// TODO(section-5): refine profile-handle typing / Symbol.asyncDispose
+	**/
+	function startCpuProfile():Promise<WorkerCpuProfileHandle>;
+
+	/**
+		Starts a heap profile. Supports `await using` to discard on scope exit.
+		// TODO(section-5): refine profile-handle typing / Symbol.asyncDispose
+	**/
+	function startHeapProfile():Promise<WorkerHeapProfileHandle>;
+
+	/**
+		An object that can be used to query performance information from a worker.
+	**/
+	var performance(default, null):WorkerPerformance;
 
 	/**
 		An integer identifier for the referenced thread. Identical to `threadId` inside the worker.
@@ -94,34 +150,40 @@ extern class Worker extends EventEmitter<Worker> {
 	var threadId(default, null):Int;
 
 	/**
-		Optional name assigned when creating the worker.
+		Optional name assigned when creating the worker, or `null` if not running.
 	**/
 	var threadName(default, null):Null<String>;
 
 	/**
-		If `stdin: true` was passed to the constructor, this is a writable stream connected to worker's `process.stdin`.
+		If `stdin: true` was passed to the constructor, a writable stream connected to the worker's `process.stdin`.
 	**/
 	var stdin(default, null):Null<IWritable>;
 
 	/**
-		A readable stream connected to worker's `process.stdout`.
+		A readable stream connected to the worker's `process.stdout`.
 	**/
 	var stdout(default, null):IReadable;
 
 	/**
-		A readable stream connected to worker's `process.stderr`.
+		A readable stream connected to the worker's `process.stderr`.
 	**/
 	var stderr(default, null):IReadable;
 
 	/**
-		An object containing information about the resource limits of the Worker.
+		JS engine resource constraints for this Worker.
+		Empty object if the worker has stopped.
 	**/
 	var resourceLimits(default, null):Null<WorkerResourceLimits>;
 }
 
+/**
+	Options for `new Worker(filename, options)`.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/worker_threads.html#new-workerfilename-options
+**/
 typedef WorkerOptions = {
 	/**
-		Additional data to send in parallel.
+		Additional data cloned into the worker as `workerData`.
 		// TODO(section-5): workerData typing is application-defined
 	**/
 	@:optional var workerData:Dynamic;
@@ -131,26 +193,67 @@ typedef WorkerOptions = {
 	**/
 	@:optional var transferList:Array<Transferable>;
 
+	/**
+		Arguments stringified and appended to `process.argv` in the worker.
+	**/
+	@:optional var argv:Array<Dynamic>;
+
+	/**
+		If `true` and `filename` is a string, interpret it as a script to evaluate
+		once the worker is online.
+	**/
+	@:optional var eval:Bool;
+
 	@:optional var stdin:Bool;
 	@:optional var stdout:Bool;
 	@:optional var stderr:Bool;
 
 	/**
-		Executable used to create the worker.
+		Node CLI options passed to the worker (available as `process.execArgv`).
+		V8 / process-affecting flags are not supported. Default: inherit from parent.
 	**/
 	@:optional var execArgv:Array<String>;
 
 	/**
-		An optional environment object keyed like `process.env`.
-		Use `WorkerThreads.SHARE_ENV` to share the env.
+		Initial `process.env` inside the Worker.
+		Use `WorkerThreads.SHARE_ENV` to share the parent's environment.
 	**/
 	@:optional var env:EitherType<haxe.DynamicAccess<String>, js.lib.Symbol>;
 
 	@:optional var resourceLimits:WorkerResourceLimits;
+
+	/**
+		Optional name for the thread / worker title (debugging). Default: `'WorkerThread'`.
+	**/
 	@:optional var name:String;
 
 	/**
-		If `true`, track unmanaged resources managed by the worker.
+		If `true`, track unmanaged FDs opened via `fs.open` / `fs.close`. Default: `true`.
 	**/
 	@:optional var trackUnmanagedFds:Bool;
+}
+
+/**
+	Worker-specific performance helpers.
+**/
+typedef WorkerPerformance = {
+	/**
+		Same as `PerfHooks.eventLoopUtilization`, but for this worker instance.
+		Values are `0` before `'online'` or after `'exit'`.
+	**/
+	function eventLoopUtilization(?utilization1:EventLoopUtilization, ?utilization2:EventLoopUtilization):EventLoopUtilization;
+}
+
+/**
+	Handle returned by `Worker.startCpuProfile`.
+**/
+typedef WorkerCpuProfileHandle = {
+	function stop():Promise<String>;
+}
+
+/**
+	Handle returned by `Worker.startHeapProfile`.
+**/
+typedef WorkerHeapProfileHandle = {
+	function stop():Promise<String>;
 }


### PR DESCRIPTION
## Summary
- Align `js.node.WorkerThreads` / `js.node.worker_threads.*` with Node.js 24: `BroadcastChannel`, `locks`, `Worker` cpu/heap profiling + `performance`, `argv`/`eval` options, and typed `getHeapStatistics` / snapshot options.
- Refresh docs to `latest-v24.x`, use Haxe 4 named-arg event listeners, and bump copyright to 2014–2026.
- Leave intentional `Dynamic` structured-clone seams and `Symbol.asyncDispose` TODOs where typing is still application-defined / unfinished in hxnodejs.

## Test plan
- [x] `haxe build.hxml` (Haxe 5.0.0-preview.1)
- [ ] Spot-check new APIs against https://nodejs.org/docs/latest-v24.x/api/worker_threads.html
- [ ] Optional: small sample using `Worker` + `BroadcastChannel` / `locks`


Made with [Cursor](https://cursor.com)