### PR TITLE
Audit js.node.crypto for Node 24 + Haxe 4

### DIFF
--- a/src/js/node/Crypto.hx
+++ b/src/js/node/Crypto.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -30,11 +30,10 @@ import js.lib.ArrayBufferView;
 import js.lib.Error;
 import js.node.Buffer;
 import js.node.crypto.*;
-import js.node.crypto.DiffieHellman.IDiffieHellman;
 import js.node.tls.SecureContext;
 
 /**
-	Enumerations of crypto algorighms to be used.
+	Enumerations of crypto algorithms to be used.
 **/
 enum abstract CryptoAlgorithm(String) from String to String {
 	var SHA1 = "sha1";
@@ -58,30 +57,27 @@ enum abstract DiffieHellmanGroupName(String) from String to String {
 }
 
 /**
-	The crypto module offers a way of encapsulating secure credentials
-	to be used as part of a secure HTTPS net or http connection.
+	The `node:crypto` module provides cryptographic functionality that includes
+	a set of wrappers for OpenSSL's hash, HMAC, cipher, decipher, sign, and verify functions.
 
-	It also offers a set of wrappers for OpenSSL's hash, hmac, cipher, decipher, sign and verify methods.
+	@see https://nodejs.org/docs/latest-v24.x/api/crypto.html
 **/
 @:jsRequire("crypto")
 extern class Crypto {
 	/**
-		Load and set engine for some/all OpenSSL functions (selected by `flags`).
+		Load and set an OpenSSL engine for some/all OpenSSL functions (selected by `flags`).
 
-		`engine` could be either an id or a path to the to the engine's shared library.
+		`engine` could be either an id or a path to the engine's shared library.
 
 		`flags` is optional and has `Constants.ENGINE_METHOD_ALL` value by default.
-		It could take one of or mix of flags prefixed with `ENGINE_METHOD_` defined in `Constants` module.
+		It could take one of or a mix of flags prefixed with `ENGINE_METHOD_` defined in `Constants`.
 	**/
 	static function setEngine(engine:String, ?flags:Int):Void;
 
 	/**
-		The default encoding to use for functions that can take either strings or buffers.
-		The default value is 'buffer', which makes it default to using `Buffer` objects.
-		This is here to make the crypto module more easily compatible with legacy programs
-		that expected 'binary' to be the default encoding.
+		Legacy default encoding for crypto helpers that accept strings or buffers.
 
-		Note that new programs will probably expect buffers, so only use this as a temporary measure.
+		Kept for compatibility with older typings; modern Node.js always prefers buffers.
 	**/
 	@:deprecated("Use explicitly set encoding on crypto streams instead")
 	static var DEFAULT_ENCODING:String;
@@ -98,12 +94,12 @@ extern class Crypto {
 	/**
 		OpenSSL crypto constants (padding modes, DH check codes, engine methods, etc.).
 	**/
-	static var constants(default, never):DynamicAccess<Int>;
+	static final constants:DynamicAccess<Int>;
 
 	/**
 		A convenient alias for `Crypto.webcrypto.subtle`.
 	**/
-	static var subtle(default, never):SubtleCrypto;
+	static final subtle:SubtleCrypto;
 
 	/**
 		Node.js Web Crypto API implementation (`crypto.webcrypto`).
@@ -114,7 +110,7 @@ extern class Crypto {
 
 		// TODO(section-4): audit Node-only Web Crypto additions vs `js.html.Crypto`
 	**/
-	static var webcrypto(default, never):js.html.Crypto;
+	static final webcrypto:js.html.Crypto;
 
 	/**
 		Returns `1` if and only if a FIPS compliant crypto provider is currently in use, `0` otherwise.
@@ -160,93 +156,89 @@ extern class Crypto {
 	static function createCredentials(?details:SecureContextOptions):SecureContext;
 
 	/**
-		Creates and returns a hash object, a cryptographic hash with the given algorithm which can be used to generate hash digests.
-		`algorithm` is dependent on the available algorithms supported by the version of OpenSSL on the platform.
-		Examples are 'sha1', 'md5', 'sha256', 'sha512', etc.
-		On recent releases, openssl list-message-digest-algorithms will display the available digest algorithms.
+		Creates and returns a `Hash` object that can be used to generate hash digests
+		using the given `algorithm`. `options` is an optional stream configuration;
+		for XOF hash functions such as `'shake256'`, `outputLength` may be used.
 	**/
-	static function createHash(algorithm:CryptoAlgorithm):Hash;
+	static function createHash(algorithm:CryptoAlgorithm, ?options:HashCreateOptions):Hash;
 
 	/**
-		Creates and returns a hmac object, a cryptographic hmac with the given algorithm and key.
-		`algorithm` is dependent on the available algorithms supported by OpenSSL - see `createHash` above.
-		`key` is the hmac key to be used.
+		Creates and returns an `Hmac` object that uses the given `algorithm` and `key`.
+		`key` may be a `KeyObject` of type `secret`.
 	**/
-	static function createHmac(algorithm:CryptoAlgorithm, key:EitherType<String, Buffer>):Hmac;
+	static function createHmac(algorithm:CryptoAlgorithm, key:EitherType<String, EitherType<Buffer, KeyObject>>,
+		?options:js.node.stream.Transform.TransformNewOptions):Hmac;
 
 	/**
-		Creates and returns a cipher object, with the given algorithm and password.
+		Creates and returns a `Cipher` object with the given `algorithm` and `password`.
 
-		`algorithm` is dependent on OpenSSL, examples are 'aes192', etc.
-		On recent releases, openssl list-cipher-algorithms will display the available cipher algorithms.
-
-		`password` is used to derive key and IV, which must be a 'binary' encoded string or a buffer.
-
-		It is a stream that is both readable and writable. The written data is used to compute the hash.
-		Once the writable side of the stream is ended, use the `read` method to get the computed hash digest.
-		The legacy `update` and `digest` methods are also supported.
+		Removed from Node.js; use `createCipheriv` instead.
 	**/
+	@:deprecated("Removed from Node.js; use createCipheriv instead")
 	static function createCipher(algorithm:String, password:EitherType<String, Buffer>):Cipher;
 
 	/**
-		Creates and returns a cipher object, with the given algorithm, key and iv.
+		Creates and returns a `Cipheriv` object with the given `algorithm`, `key` and initialization vector (`iv`).
 
-		`algorithm` is the same as the argument to `createCipher`.
-
-		`key` is the raw key used by the algorithm.
-
-		`iv` is an initialization vector.
-
-		`key` and `iv` must be 'binary' encoded strings or buffers.
+		`key` may be a `KeyObject` of type `secret`. `iv` may be `null` for ciphers that do not need an IV.
+		`options` controls stream behavior; `authTagLength` is required for CCM/OCB modes.
 	**/
-	@:overload(function(algorithm:String, key:EitherType<EitherType<String, Buffer>, KeyObject>, iv:Null<EitherType<String, Buffer>>):Cipher {})
-	static function createCipheriv(algorithm:String, key:EitherType<String, Buffer>, iv:EitherType<String, Buffer>):Cipher;
+	@:overload(function(algorithm:String, key:EitherType<EitherType<String, Buffer>, KeyObject>, iv:Null<EitherType<String, Buffer>>,
+		?options:CipherivOptions):Cipheriv {})
+	@:overload(function(algorithm:String, key:EitherType<EitherType<String, Buffer>, KeyObject>, iv:Null<EitherType<String, Buffer>>):Cipheriv {})
+	static function createCipheriv(algorithm:String, key:EitherType<String, Buffer>, iv:EitherType<String, Buffer>,
+		?options:CipherivOptions):Cipheriv;
 
 	/**
-		Creates and returns a decipher object, with the given algorithm and key.
-		This is the mirror of the `createCipher` above.
+		Creates and returns a `Decipher` object with the given `algorithm` and `password`.
+
+		Removed from Node.js; use `createDecipheriv` instead.
 	**/
+	@:deprecated("Removed from Node.js; use createDecipheriv instead")
 	static function createDecipher(algorithm:String, password:EitherType<String, Buffer>):Decipher;
 
 	/**
-		Creates and returns a decipher object, with the given algorithm, key and iv.
-		This is the mirror of the `createCipheriv` above.
+		Creates and returns a `Decipheriv` object with the given `algorithm`, `key` and initialization vector (`iv`).
+
+		`key` may be a `KeyObject` of type `secret`. `iv` may be `null` for ciphers that do not need an IV.
+		`options` controls stream behavior; `authTagLength` is required for CCM/OCB modes.
 	**/
-	@:overload(function(algorithm:String, key:EitherType<EitherType<String, Buffer>, KeyObject>, iv:Null<EitherType<String, Buffer>>):Decipher {})
-	static function createDecipheriv(algorithm:String, key:EitherType<String, Buffer>, iv:EitherType<String, Buffer>):Decipher;
+	@:overload(function(algorithm:String, key:EitherType<EitherType<String, Buffer>, KeyObject>, iv:Null<EitherType<String, Buffer>>,
+		?options:CipherivOptions):Decipheriv {})
+	@:overload(function(algorithm:String, key:EitherType<EitherType<String, Buffer>, KeyObject>, iv:Null<EitherType<String, Buffer>>):Decipheriv {})
+	static function createDecipheriv(algorithm:String, key:EitherType<String, Buffer>, iv:EitherType<String, Buffer>,
+		?options:CipherivOptions):Decipheriv;
 
 	/**
-		Creates and returns a signing object, with the given algorithm.
-		On recent OpenSSL releases, openssl list-public-key-algorithms will display the available signing algorithms.
-		Example: 'RSA-SHA256'.
+		Creates and returns a `Sign` object that uses the given `algorithm`.
+		Example: `'RSA-SHA256'`.
 	**/
-	static function createSign(algorithm:String):Sign;
+	static function createSign(algorithm:String, ?options:js.node.stream.Writable.WritableNewOptions):Sign;
 
 	/**
-		Creates and returns a verification object, with the given algorithm.
-		This is the mirror of the signing object above.
+		Creates and returns a `Verify` object that uses the given `algorithm`.
 	**/
-	static function createVerify(algorithm:String):Verify;
+	static function createVerify(algorithm:String, ?options:js.node.stream.Writable.WritableNewOptions):Verify;
 
 	/**
-		Creates a Diffie-Hellman key exchange object using the supplied `prime` or generated prime of given bit `prime_length`.
-		The generator used is 2. `encoding` can be 'binary', 'hex', or 'base64'.
+		Creates a `DiffieHellman` key exchange object.
 
-		Creates a Diffie-Hellman key exchange object and generates a prime of the given bit length. The generator used is 2.
+		Overloads accept a prime length (generator defaults to `2`), a prime `Buffer`,
+		or a prime string with encoding (and optional generator).
 	**/
-	@:overload(function(prime_length:Int):DiffieHellman {})
-	@:overload(function(prime:Buffer):DiffieHellman {})
+	@:overload(function(prime_length:Int, ?generator:Int):DiffieHellman {})
+	@:overload(function(prime:Buffer, ?generator:EitherType<Int, Buffer>):DiffieHellman {})
+	@:overload(function(prime:String, primeEncoding:String, ?generator:EitherType<Int, EitherType<String, Buffer>>,
+		?generatorEncoding:String):DiffieHellman {})
 	static function createDiffieHellman(prime:String, encoding:String):DiffieHellman;
 
 	/**
-		Creates a predefined Diffie-Hellman key exchange object.
-		The supported groups are: 'modp1', 'modp2', 'modp5' (defined in RFC 2412) and 'modp14', 'modp15', 'modp16', 'modp17', 'modp18' (defined in RFC 3526).
-		The returned object mimics the interface of objects created by `createDiffieHellman` above,
-		but will not allow to change the keys (with setPublicKey() for example).
-		The advantage of using this routine is that the parties don't have to generate nor exchange group modulus beforehand,
-		saving both processor and communication time.
+		Creates a predefined Diffie-Hellman key exchange object for a well-known group.
+		Keys cannot be changed after creation (`setPublicKey` / `setPrivateKey` are unavailable).
+
+		Groups `'modp1'`, `'modp2'`, and `'modp5'` are still supported but deprecated.
 	**/
-	static function getDiffieHellman(group_name:DiffieHellmanGroupName):IDiffieHellman;
+	static function getDiffieHellman(group_name:DiffieHellmanGroupName):DiffieHellmanGroup;
 
 	/**
 		An alias for `getDiffieHellman`.
@@ -278,18 +270,18 @@ extern class Crypto {
 	static function createSecretKey(key:EitherType<String, EitherType<Buffer, ArrayBufferView>>):KeyObject;
 
 	/**
-		Asynchronous PBKDF2 applies pseudorandom function HMAC-SHA1 to derive a key of given length
-		from the given password, salt and iterations.
+		Provides an asynchronous Password-Based Key Derivation Function 2 (PBKDF2) implementation.
+		Applies a cryptographic HMAC digest chosen by `digest` to derive a key of the requested byte length
+		from `password`, `salt` and `iterations`.
 	**/
-	@:overload(function(password:EitherType<String, Buffer>, salt:EitherType<String, Buffer>, iterations:Int, keylen:Int, digest:String,
-		callback:Error->Buffer->Void):Void {})
-	static function pbkdf2(password:EitherType<String, Buffer>, salt:EitherType<String, Buffer>, iterations:Int, keylen:Int,
-		callback:Error->Buffer->Void):Void;
+	static function pbkdf2(password:EitherType<String, Buffer>, salt:EitherType<String, Buffer>, iterations:Int, keylen:Int, digest:String,
+		callback:(err:Null<Error>, derivedKey:Buffer)->Void):Void;
 
 	/**
-		Synchronous PBKDF2 function. Returns derivedKey or throws error.
+		Provides a synchronous Password-Based Key Derivation Function 2 (PBKDF2) implementation.
 	**/
-	static function pbkdf2Sync(password:EitherType<String, Buffer>, salt:EitherType<String, Buffer>, iterations:Int, keylen:Int, ?digest:String):Buffer;
+	static function pbkdf2Sync(password:EitherType<String, Buffer>, salt:EitherType<String, Buffer>, iterations:Int, keylen:Int,
+		digest:String):Buffer;
 
 	/**
 		Provides an asynchronous scrypt implementation.
@@ -297,8 +289,8 @@ extern class Crypto {
 		computationally and memory-wise in order to make brute-force attacks unrewarding.
 	**/
 	@:overload(function(password:EitherType<String, Buffer>, salt:EitherType<String, Buffer>, keylen:Int, options:ScryptOptions,
-		callback:Error->Buffer->Void):Void {})
-	static function scrypt(password:EitherType<String, Buffer>, salt:EitherType<String, Buffer>, keylen:Int, callback:Error->Buffer->Void):Void;
+		callback:(err:Null<Error>, buffer:Buffer)->Void):Void {})
+	static function scrypt(password:EitherType<String, Buffer>, salt:EitherType<String, Buffer>, keylen:Int, callback:(err:Null<Error>, buffer:Buffer)->Void):Void;
 
 	/**
 		Provides a synchronous scrypt implementation.
@@ -312,7 +304,7 @@ extern class Crypto {
 		The successfully generated derived key is passed to the callback as an `ArrayBuffer`.
 	**/
 	static function hkdf(digest:String, ikm:EitherType<String, Buffer>, salt:EitherType<String, Buffer>, info:EitherType<String, Buffer>, keylen:Int,
-		callback:Error->ArrayBuffer->Void):Void;
+		callback:(err:Null<Error>, derivedKey:ArrayBuffer)->Void):Void;
 
 	/**
 		Provides a synchronous HKDF key derivation function as defined in RFC 5869.
@@ -332,7 +324,7 @@ extern class Crypto {
 		to generate cryptographically strong data. In other words, `randomBytes` without callback will not
 		block even if all entropy sources are drained.
 	**/
-	@:overload(function(size:Int, callback:Error->Buffer->Void):Void {})
+	@:overload(function(size:Int, callback:(err:Null<Error>, buffer:Buffer)->Void):Void {})
 	static function randomBytes(size:Int):Buffer;
 
 	/**
@@ -342,9 +334,9 @@ extern class Crypto {
 		The supplied callback is invoked with two arguments: `err` and `buf`.
 		The `buf` argument is a reference to the `buffer` filled with random data.
 	**/
-	@:overload(function<T>(buffer:T, offset:Int, callback:Error->T->Void):Void {})
-	@:overload(function<T>(buffer:T, offset:Int, size:Int, callback:Error->T->Void):Void {})
-	static function randomFill<T>(buffer:T, callback:Error->T->Void):Void;
+	@:overload(function<T>(buffer:T, offset:Int, callback:(err:Null<Error>, buf:T)->Void):Void {})
+	@:overload(function<T>(buffer:T, offset:Int, size:Int, callback:(err:Null<Error>, buf:T)->Void):Void {})
+	static function randomFill<T>(buffer:T, callback:(err:Null<Error>, buf:T)->Void):Void;
 
 	/**
 		Synchronous version of `randomFill`. Returns the filled buffer.
@@ -361,9 +353,9 @@ extern class Crypto {
 
 		If the callback function is not provided, the random integer is generated synchronously.
 	**/
-	@:overload(function(max:Int, callback:Error->Int->Void):Void {})
+	@:overload(function(max:Int, callback:(err:Null<Error>, n:Int)->Void):Void {})
 	@:overload(function(min:Int, max:Int):Int {})
-	@:overload(function(min:Int, max:Int, callback:Error->Int->Void):Void {})
+	@:overload(function(min:Int, max:Int, callback:(err:Null<Error>, n:Int)->Void):Void {})
 	static function randomInt(max:Int):Int;
 
 	/**
@@ -390,8 +382,8 @@ extern class Crypto {
 	/**
 		Checks the primality of the `candidate`.
 	**/
-	@:overload(function(candidate:CryptoArrayBufferLike, options:CheckPrimeOptions, callback:Error->Bool->Void):Void {})
-	static function checkPrime(candidate:CryptoArrayBufferLike, callback:Error->Bool->Void):Void;
+	@:overload(function(candidate:CryptoArrayBufferLike, options:CheckPrimeOptions, callback:(err:Null<Error>, result:Bool)->Void):Void {})
+	static function checkPrime(candidate:CryptoArrayBufferLike, callback:(err:Null<Error>, result:Bool)->Void):Void;
 
 	/**
 		Checks the primality of the `candidate` (synchronous version).
@@ -448,7 +440,7 @@ extern class Crypto {
 		Asynchronously generates a new random secret key of the given `length`.
 		`type` is currently `'hmac'` or `'aes'`.
 	**/
-	static function generateKey(type:String, options:GenerateKeyOptions, callback:Error->KeyObject->Void):Void;
+	static function generateKey(type:String, options:GenerateKeyOptions, callback:(err:Null<Error>, key:KeyObject)->Void):Void;
 
 	/**
 		Synchronously generates a new random secret key of the given `length`.
@@ -461,9 +453,9 @@ extern class Crypto {
 
 		// TODO(section-4): finer-grained overloads per key type / encoding (RSA, EC, Ed25519, …)
 	**/
-	@:overload(function(type:String, options:Any, callback:Error->EitherType<String, KeyObject>->EitherType<String, KeyObject>->Void):Void {})
-	@:overload(function(type:String, callback:Error->KeyObject->KeyObject->Void):Void {})
-	static function generateKeyPair(type:String, options:Any, callback:Error->KeyObject->KeyObject->Void):Void;
+	@:overload(function(type:String, options:Any, callback:(err:Null<Error>, publicKey:EitherType<String, KeyObject>, privateKey:EitherType<String, KeyObject>)->Void):Void {})
+	@:overload(function(type:String, callback:(err:Null<Error>, publicKey:KeyObject, privateKey:KeyObject)->Void):Void {})
+	static function generateKeyPair(type:String, options:Any, callback:(err:Null<Error>, publicKey:KeyObject, privateKey:KeyObject)->Void):Void;
 
 	/**
 		Synchronously generates a new asymmetric key pair of the given `type`.
@@ -476,8 +468,8 @@ extern class Crypto {
 	/**
 		Generates a pseudorandom prime of `size` bits.
 	**/
-	@:overload(function(size:Int, options:GeneratePrimeOptions, callback:Error->EitherType<ArrayBuffer, Any>->Void):Void {})
-	static function generatePrime(size:Int, callback:Error->ArrayBuffer->Void):Void;
+	@:overload(function(size:Int, options:GeneratePrimeOptions, callback:(err:Null<Error>, prime:EitherType<ArrayBuffer, Any>)->Void):Void {})
+	static function generatePrime(size:Int, callback:(err:Null<Error>, derivedKey:ArrayBuffer)->Void):Void;
 
 	/**
 		Generates a pseudorandom prime of `size` bits (synchronous).
@@ -494,7 +486,7 @@ extern class Crypto {
 		Calculates and returns the signature for `data` using the given private key and algorithm.
 	**/
 	@:overload(function(algorithm:Null<String>, data:EitherType<Buffer, ArrayBufferView>, key:EitherType<String, EitherType<Buffer, KeyObject>>,
-		callback:Error->Buffer->Void):Void {})
+		callback:(err:Null<Error>, buffer:Buffer)->Void):Void {})
 	static function sign(algorithm:Null<String>, data:EitherType<Buffer, ArrayBufferView>,
 		key:EitherType<String, EitherType<Buffer, EitherType<KeyObject, CryptoKeyInput>>>):Buffer;
 
@@ -503,7 +495,7 @@ extern class Crypto {
 	**/
 	@:overload(function(algorithm:Null<String>, data:EitherType<Buffer, ArrayBufferView>,
 		key:EitherType<String, EitherType<Buffer, EitherType<KeyObject, CryptoKeyInput>>>, signature:EitherType<Buffer, ArrayBufferView>,
-		callback:Error->Bool->Void):Void {})
+		callback:(err:Null<Error>, result:Bool)->Void):Void {})
 	static function verify(algorithm:Null<String>, data:EitherType<Buffer, ArrayBufferView>,
 		key:EitherType<String, EitherType<Buffer, EitherType<KeyObject, CryptoKeyInput>>>,
 		signature:EitherType<Buffer, ArrayBufferView>):Bool;
@@ -511,7 +503,7 @@ extern class Crypto {
 	/**
 		Computes the Diffie-Hellman shared secret based on a `privateKey` and a `publicKey`.
 	**/
-	@:overload(function(options:DiffieHellmanOptions, callback:Error->Buffer->Void):Void {})
+	@:overload(function(options:DiffieHellmanOptions, callback:(err:Null<Error>, buffer:Buffer)->Void):Void {})
 	static function diffieHellman(options:DiffieHellmanOptions):Buffer;
 
 	/**
@@ -528,21 +520,21 @@ extern class Crypto {
 		Key encapsulation (KEM) using a public key.
 	**/
 	@:overload(function(key:EitherType<String, EitherType<Buffer, EitherType<KeyObject, CryptoKeyInput>>>,
-		callback:Error->EncapsulateResult->Void):Void {})
+		callback:(err:Null<Error>, result:EncapsulateResult)->Void):Void {})
 	static function encapsulate(key:EitherType<String, EitherType<Buffer, EitherType<KeyObject, CryptoKeyInput>>>):EncapsulateResult;
 
 	/**
 		Key decapsulation using a private key.
 	**/
 	@:overload(function(key:EitherType<String, EitherType<Buffer, EitherType<KeyObject, CryptoKeyInput>>>,
-		ciphertext:EitherType<ArrayBuffer, ArrayBufferView>, callback:Error->Buffer->Void):Void {})
+		ciphertext:EitherType<ArrayBuffer, ArrayBufferView>, callback:(err:Null<Error>, buffer:Buffer)->Void):Void {})
 	static function decapsulate(key:EitherType<String, EitherType<Buffer, EitherType<KeyObject, CryptoKeyInput>>>,
 		ciphertext:EitherType<ArrayBuffer, ArrayBufferView>):Buffer;
 
 	/**
 		Provides an asynchronous Argon2 implementation.
 	**/
-	static function argon2(algorithm:Argon2Algorithm, parameters:Argon2Parameters, callback:Error->Buffer->Void):Void;
+	static function argon2(algorithm:Argon2Algorithm, parameters:Argon2Parameters, callback:(err:Null<Error>, buffer:Buffer)->Void):Void;
 
 	/**
 		Provides a synchronous Argon2 implementation.
@@ -557,12 +549,12 @@ typedef CryptoKeyOptions = {
 	/**
 		PEM encoded public key
 	**/
-	var key:String;
+	final key:String;
 
 	/**
 		Passphrase for the private key
 	**/
-	@:optional var passphrase:String;
+	@:optional final passphrase:String;
 
 	/**
 		Padding value, one of the following:
@@ -570,7 +562,7 @@ typedef CryptoKeyOptions = {
 		* `Constants.RSA_PKCS1_PADDING`
 		* `Constants.RSA_PKCS1_OAEP_PADDING`
 	**/
-	@:optional var padding:Int;
+	@:optional final padding:Int;
 }
 
 /**
@@ -586,40 +578,40 @@ typedef ScryptOptions = {
 		CPU/memory cost parameter. Must be a power of two greater than one. Default: `16384`.
 		Only one of `cost` or `N` may be specified.
 	**/
-	@:optional var cost:Int;
+	@:optional final cost:Int;
 
 	/**
 		Block size parameter. Default: `8`.
 		Only one of `blockSize` or `r` may be specified.
 	**/
-	@:optional var blockSize:Int;
+	@:optional final blockSize:Int;
 
 	/**
 		Parallelization parameter. Default: `1`.
 		Only one of `parallelization` or `p` may be specified.
 	**/
-	@:optional var parallelization:Int;
+	@:optional final parallelization:Int;
 
 	/**
 		Alias for `cost`. Only one of `cost` or `N` may be specified.
 	**/
-	@:optional var N:Int;
+	@:optional final N:Int;
 
 	/**
 		Alias for `blockSize`. Only one of `blockSize` or `r` may be specified.
 	**/
-	@:optional var r:Int;
+	@:optional final r:Int;
 
 	/**
 		Alias for `parallelization`. Only one of `parallelization` or `p` may be specified.
 	**/
-	@:optional var p:Int;
+	@:optional final p:Int;
 
 	/**
 		Memory upper bound. It is an error when (approximately) `128 * N * r > maxmem`.
 		Default: `32 * 1024 * 1024`.
 	**/
-	@:optional var maxmem:Int;
+	@:optional final maxmem:Int;
 }
 
 /**
@@ -631,7 +623,7 @@ typedef RandomUUIDOptions = {
 		to generate up to 128 random UUIDs. To generate a UUID without using the cache,
 		set `disableEntropyCache` to `true`. Default: `false`.
 	**/
-	@:optional var disableEntropyCache:Bool;
+	@:optional final disableEntropyCache:Bool;
 }
 
 /**
@@ -643,7 +635,7 @@ typedef CheckPrimeOptions = {
 		When the value is `0`, a number of checks is used that yields a false positive rate
 		of at most 2^-64 for random input. Default: `0`.
 	**/
-	@:optional var checks:Int;
+	@:optional final checks:Int;
 }
 
 /**
@@ -653,12 +645,12 @@ typedef CipherInfoOptions = {
 	/**
 		A test key length.
 	**/
-	@:optional var keyLength:Int;
+	@:optional final keyLength:Int;
 
 	/**
 		A test IV length.
 	**/
-	@:optional var ivLength:Int;
+	@:optional final ivLength:Int;
 }
 
 /**
@@ -668,113 +660,132 @@ typedef CipherInfo = {
 	/**
 		The name of the cipher.
 	**/
-	var name:String;
+	final name:String;
 
 	/**
 		The nid of the cipher.
 	**/
-	var nid:Int;
+	final nid:Int;
 
 	/**
 		The block size of the cipher in bytes.
 		This property is omitted when `mode` is `'stream'`.
 	**/
-	@:optional var blockSize:Int;
+	@:optional final blockSize:Int;
 
 	/**
 		The expected or default initialization vector length in bytes.
 		This property is omitted if the cipher does not use an initialization vector.
 	**/
-	@:optional var ivLength:Int;
+	@:optional final ivLength:Int;
 
 	/**
 		The expected or default key length in bytes.
 	**/
-	@:optional var keyLength:Int;
+	@:optional final keyLength:Int;
 
 	/**
 		The cipher mode. One of `'cbc'`, `'ccm'`, `'cfb'`, `'ctr'`, `'ecb'`, `'gcm'`,
 		`'ocb'`, `'ofb'`, `'stream'`, `'wrap'`, `'xts'`.
 	**/
-	@:optional var mode:String;
+	@:optional final mode:String;
 }
 
 /**
 	Input object accepted by several crypto key helpers.
 **/
 typedef CryptoKeyInput = {
-	var key:EitherType<String, EitherType<Buffer, ArrayBufferView>>;
-	@:optional var format:String;
-	@:optional var type:String;
-	@:optional var passphrase:EitherType<String, Buffer>;
-	@:optional var encoding:String;
+	final key:EitherType<String, EitherType<Buffer, ArrayBufferView>>;
+	@:optional final format:String;
+	@:optional final type:String;
+	@:optional final passphrase:EitherType<String, Buffer>;
+	@:optional final encoding:String;
 }
 
 /**
 	Options for `Crypto.generateKey` / `generateKeySync`.
 **/
 typedef GenerateKeyOptions = {
-	var length:Int;
+	final length:Int;
 }
 
 /**
 	Result when `generateKeyPairSync` returns KeyObject instances.
 **/
 typedef KeyPairKeyObjectResult = {
-	var publicKey:KeyObject;
-	var privateKey:KeyObject;
+	final publicKey:KeyObject;
+	final privateKey:KeyObject;
 }
 
 /**
 	Result when `generateKeyPairSync` returns encoded keys.
 **/
 typedef KeyPairEncodedResult = {
-	var publicKey:EitherType<String, Buffer>;
-	var privateKey:EitherType<String, Buffer>;
+	final publicKey:EitherType<String, Buffer>;
+	final privateKey:EitherType<String, Buffer>;
 }
 
 /**
 	Options for `Crypto.generatePrime` / `generatePrimeSync`.
 **/
 typedef GeneratePrimeOptions = {
-	@:optional var safe:Bool;
-	@:optional var bigint:Bool;
-	@:optional var add:EitherType<ArrayBuffer, ArrayBufferView>;
-	@:optional var rem:EitherType<ArrayBuffer, ArrayBufferView>;
+	@:optional final safe:Bool;
+	@:optional final bigint:Bool;
+	@:optional final add:EitherType<ArrayBuffer, ArrayBufferView>;
+	@:optional final rem:EitherType<ArrayBuffer, ArrayBufferView>;
 }
 
 /**
 	Options for one-shot `Crypto.hash`.
 **/
 typedef HashOptions = {
-	@:optional var outputEncoding:String;
-	@:optional var outputLength:Int;
+	@:optional final outputEncoding:String;
+	@:optional final outputLength:Int;
+}
+
+/**
+	Options for `Crypto.createHash` (stream options plus optional XOF `outputLength`).
+**/
+typedef HashCreateOptions = {
+	> js.node.stream.Transform.TransformNewOptions,
+	@:optional final outputLength:Int;
+}
+
+/**
+	Options for `Crypto.createCipheriv` / `createDecipheriv` (stream options plus AEAD tag length).
+**/
+typedef CipherivOptions = {
+	> js.node.stream.Transform.TransformNewOptions,
+	/**
+		Length of the authentication tag in bytes. Required for CCM/OCB modes.
+	**/
+	@:optional final authTagLength:Int;
 }
 
 /**
 	Options for `Crypto.diffieHellman`.
 **/
 typedef DiffieHellmanOptions = {
-	var privateKey:KeyObject;
-	var publicKey:KeyObject;
+	final privateKey:KeyObject;
+	final publicKey:KeyObject;
 }
 
 /**
 	Result of `Crypto.secureHeapUsed`.
 **/
 typedef SecureHeapUsage = {
-	var total:Float;
-	var min:Float;
-	var used:Float;
-	var utilization:Float;
+	final total:Float;
+	final min:Float;
+	final used:Float;
+	final utilization:Float;
 }
 
 /**
 	Result of `Crypto.encapsulate`.
 **/
 typedef EncapsulateResult = {
-	var sharedKey:Buffer;
-	var ciphertext:Buffer;
+	final sharedKey:Buffer;
+	final ciphertext:Buffer;
 }
 
 /**
@@ -790,12 +801,12 @@ enum abstract Argon2Algorithm(String) from String to String {
 	Parameters for `Crypto.argon2` / `argon2Sync`.
 **/
 typedef Argon2Parameters = {
-	var message:EitherType<String, EitherType<ArrayBuffer, ArrayBufferView>>;
-	var nonce:EitherType<String, EitherType<ArrayBuffer, ArrayBufferView>>;
-	var parallelism:Int;
-	var tagLength:Int;
-	var memory:Int;
-	var passes:Int;
-	@:optional var secret:EitherType<String, EitherType<ArrayBuffer, ArrayBufferView>>;
-	@:optional var associatedData:EitherType<String, EitherType<ArrayBuffer, ArrayBufferView>>;
+	final message:EitherType<String, EitherType<ArrayBuffer, ArrayBufferView>>;
+	final nonce:EitherType<String, EitherType<ArrayBuffer, ArrayBufferView>>;
+	final parallelism:Int;
+	final tagLength:Int;
+	final memory:Int;
+	final passes:Int;
+	@:optional final secret:EitherType<String, EitherType<ArrayBuffer, ArrayBufferView>>;
+	@:optional final associatedData:EitherType<String, EitherType<ArrayBuffer, ArrayBufferView>>;
 }

--- a/src/js/node/Crypto.hx
+++ b/src/js/node/Crypto.hx
@@ -469,7 +469,7 @@ extern class Crypto {
 		Generates a pseudorandom prime of `size` bits.
 	**/
 	@:overload(function(size:Int, options:GeneratePrimeOptions, callback:(err:Null<Error>, prime:EitherType<ArrayBuffer, Any>)->Void):Void {})
-	static function generatePrime(size:Int, callback:(err:Null<Error>, derivedKey:ArrayBuffer)->Void):Void;
+	static function generatePrime(size:Int, callback:(err:Null<Error>, prime:ArrayBuffer)->Void):Void;
 
 	/**
 		Generates a pseudorandom prime of `size` bits (synchronous).

--- a/src/js/node/crypto/Certificate.hx
+++ b/src/js/node/crypto/Certificate.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -22,34 +22,42 @@
 
 package js.node.crypto;
 
+import haxe.extern.EitherType;
+import js.lib.ArrayBuffer;
+import js.lib.ArrayBufferView;
 import js.node.Buffer;
 
 /**
 	SPKAC is a Certificate Signing Request mechanism originally implemented by Netscape
-	and now specified formally as part of HTML5's keygen element.
+	and formerly specified as part of HTML5's `keygen` element.
+
+	Prefer the static methods. The instance API is a deprecated legacy interface.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/crypto.html#class-certificate
 **/
 @:jsRequire("crypto", "Certificate")
 extern class Certificate {
+	/**
+		Legacy constructor. Prefer static `Certificate` methods.
+	**/
+	@:deprecated("Use Certificate static methods instead")
 	function new();
 
 	/**
-		Returns the challenge component in the form of a Node.js `Buffer`.
-
-		The `spkac` data structure includes a public key and a challenge.
+		Returns the challenge component of the `spkac` data structure.
 	**/
-	@:overload(function(spkac:String):Buffer {})
-	function exportChallenge(spkac:Buffer):Buffer;
+	@:overload(function(spkac:EitherType<String, EitherType<ArrayBuffer, ArrayBufferView>>, ?encoding:String):Buffer {})
+	static function exportChallenge(spkac:Buffer):Buffer;
 
 	/**
-		Returns the public key component in the form of a Node.js `Buffer`.
-
-		The `spkac` data structure includes a public key and a challenge.
+		Returns the public key component of the `spkac` data structure.
 	**/
-	@:overload(function(spkac:String):Buffer {})
-	function exportPublicKey(spkac:Buffer):Buffer;
+	@:overload(function(spkac:EitherType<String, EitherType<ArrayBuffer, ArrayBufferView>>, ?encoding:String):Buffer {})
+	static function exportPublicKey(spkac:Buffer):Buffer;
 
 	/**
-		Returns true if the given `spkac` data structure is valid, false otherwise.
+		Returns `true` if the given `spkac` data structure is valid.
 	**/
-	function verifySpkac(spkac:Buffer):Bool;
+	@:overload(function(spkac:EitherType<String, EitherType<ArrayBuffer, ArrayBufferView>>, ?encoding:String):Bool {})
+	static function verifySpkac(spkac:Buffer):Bool;
 }

--- a/src/js/node/crypto/Cipher.hx
+++ b/src/js/node/crypto/Cipher.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -27,21 +27,23 @@ import js.node.Buffer;
 /**
 	Class for encrypting data.
 
-	Returned by `Crypto.createCipher` and `Crypto.createCipheriv`.
+	Returned by `Crypto.createCipheriv` (and the removed legacy `Crypto.createCipher`).
 
 	Cipher objects are streams that are both readable and writable.
 	The written plain text data is used to produce the encrypted data on the readable side.
 
 	The legacy `update` and `final` methods are also supported.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/crypto.html#class-cipheriv
 **/
 extern class Cipher extends js.node.stream.Transform<Cipher> {
 	/**
 		Updates the cipher with `data`, the encoding of which is given in `input_encoding`
-		and can be 'utf8', 'ascii' or 'binary'. If no encoding is provided, then a buffer is expected.
+		and can be `'utf8'`, `'ascii'` or `'binary'`. If no encoding is provided, then a buffer is expected.
 		If data is a Buffer then `input_encoding` is ignored.
 
 		The `output_encoding` specifies the output format of the enciphered data,
-		and can be 'binary', 'base64' or 'hex'. If no encoding is provided, then a buffer is returned.
+		and can be `'binary'`, `'base64'` or `'hex'`. If no encoding is provided, then a buffer is returned.
 
 		Returns the enciphered contents, and can be called many times with new data as it is streamed.
 	**/
@@ -50,7 +52,7 @@ extern class Cipher extends js.node.stream.Transform<Cipher> {
 	function update(data:String, input_encoding:String, output_encoding:String):String;
 
 	/**
-		Returns any remaining enciphered contents, with `output_encoding` being one of: 'binary', 'base64' or 'hex'.
+		Returns any remaining enciphered contents, with `output_encoding` being one of: `'binary'`, `'base64'` or `'hex'`.
 		If no encoding is provided, then a buffer is returned.
 
 		Note: cipher object can not be used after `final` method has been called.
@@ -66,19 +68,30 @@ extern class Cipher extends js.node.stream.Transform<Cipher> {
 		Useful for non-standard padding, e.g. using 0x0 instead of PKCS padding.
 		You must call this before `final`.
 	**/
-	@:overload(function():Void {})
-	function setAutoPadding(auto_padding:Bool):Void;
+	@:overload(function():Cipher {})
+	function setAutoPadding(auto_padding:Bool):Cipher;
 
 	/**
-		For authenticated encryption modes (currently supported: GCM), this method returns a `Buffer`
-		that represents the authentication tag that has been computed from the given data.
-		Should be called after encryption has been completed using the `final` method!
+		For authenticated encryption modes (GCM, CCM, OCB, chacha20-poly1305),
+		returns a `Buffer` that represents the authentication tag computed from the given data.
+		Should be called after encryption has been completed using the `final` method.
 	**/
 	function getAuthTag():Buffer;
 
 	/**
-		For authenticated encryption modes (currently supported: GCM), this method sets the value
-		used for the additional authenticated data (AAD) input parameter.
+		For authenticated encryption modes (GCM, CCM, OCB, chacha20-poly1305),
+		sets the value used for the additional authenticated data (AAD) input parameter.
+
+		Must be called before `update`. When using CCM, `options.plaintextLength` is required.
 	**/
-	function setAAD(buffer:Buffer):Void;
+	@:overload(function(buffer:Buffer, ?options:CipherAADOptions):Cipher {})
+	function setAAD(buffer:Buffer):Cipher;
+}
+
+/**
+	Options for `Cipher.setAAD` / `Decipher.setAAD` (CCM mode).
+**/
+typedef CipherAADOptions = {
+	/** When using CCM, the length of the actual plaintext/ciphertext in bytes. **/
+	@:optional final plaintextLength:Int;
 }

--- a/src/js/node/crypto/Cipheriv.hx
+++ b/src/js/node/crypto/Cipheriv.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,6 +25,8 @@ package js.node.crypto;
 /**
 	Constructor export for cipher instances created via `Crypto.createCipheriv`.
 	Prefer `Crypto.createCipheriv` over constructing this class directly.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/crypto.html#class-cipheriv
 **/
 @:jsRequire("crypto", "Cipheriv")
 extern class Cipheriv extends Cipher {}

--- a/src/js/node/crypto/Decipher.hx
+++ b/src/js/node/crypto/Decipher.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -23,23 +23,26 @@
 package js.node.crypto;
 
 import js.node.Buffer;
+import js.node.crypto.Cipher.CipherAADOptions;
 
 /**
 	Class for decrypting data.
 
-	Returned by `Crypto.createDecipher` and `Crypto.createDecipheriv`.
+	Returned by `Crypto.createDecipheriv` (and the removed legacy `Crypto.createDecipher`).
 
 	Decipher objects are streams that are both readable and writable.
-	The written enciphered data is used to produce the plain-text data on the the readable side.
+	The written enciphered data is used to produce the plain-text data on the readable side.
 
 	The legacy `update` and `final` methods are also supported.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/crypto.html#class-decipheriv
 **/
 extern class Decipher extends js.node.stream.Transform<Decipher> {
 	/**
-		Updates the decipher with `data`, which is encoded in 'binary', 'base64' or 'hex'.
+		Updates the decipher with `data`, which is encoded in `'binary'`, `'base64'` or `'hex'`.
 		If no encoding is provided, then a buffer is expected.
 
-		The `output_decoding` specifies in what format to return the deciphered plaintext: 'binary', 'ascii' or 'utf8'.
+		The `output_encoding` specifies in what format to return the deciphered plaintext: `'binary'`, `'ascii'` or `'utf8'`.
 		If no encoding is provided, then a buffer is returned.
 	**/
 	@:overload(function(data:Buffer):Buffer {})
@@ -48,7 +51,7 @@ extern class Decipher extends js.node.stream.Transform<Decipher> {
 
 	/**
 		Returns any remaining plaintext which is deciphered,
-		with `output_encoding` being one of: 'binary', 'ascii' or 'utf8'.
+		with `output_encoding` being one of: `'binary'`, `'ascii'` or `'utf8'`.
 		If no encoding is provided, then a buffer is returned.
 
 		Note: decipher object can not be used after `final` method has been called.
@@ -60,24 +63,26 @@ extern class Decipher extends js.node.stream.Transform<Decipher> {
 		You can disable auto padding if the data has been encrypted without standard block padding
 		to prevent `final` from checking and removing it.
 
-		Can only work if the input data's length is a multiple of the ciphers block size.
+		Can only work if the input data's length is a multiple of the cipher's block size.
 
 		You must call this before streaming data to `update`.
 	**/
-	@:overload(function():Void {})
-	function setAutoPadding(auto_padding:Bool):Void;
+	@:overload(function():Decipher {})
+	function setAutoPadding(auto_padding:Bool):Decipher;
 
 	/**
-		For authenticated encryption modes (currently supported: GCM), this method must be used
-		to pass in the received authentication tag. If no tag is provided or if the ciphertext
-		has been tampered with, `final` will throw, thus indicating that the ciphertext should be
-		discarded due to failed authentication.
+		For authenticated encryption modes (GCM, CCM, OCB, chacha20-poly1305),
+		this method must be used to pass in the received authentication tag.
+		If no tag is provided or if the ciphertext has been tampered with, `final` will throw.
 	**/
-	function setAuthTag(buffer:Buffer):Void;
+	function setAuthTag(buffer:Buffer):Decipher;
 
 	/**
-		For authenticated encryption modes (currently supported: GCM), this method sets the value
-		used for the additional authenticated data (AAD) input parameter.
+		For authenticated encryption modes (GCM, CCM, OCB, chacha20-poly1305),
+		sets the value used for the additional authenticated data (AAD) input parameter.
+
+		Must be called before `update`. When using CCM, `options.plaintextLength` is required.
 	**/
-	function setAAD(buffer:Buffer):Void;
+	@:overload(function(buffer:Buffer, ?options:CipherAADOptions):Decipher {})
+	function setAAD(buffer:Buffer):Decipher;
 }

--- a/src/js/node/crypto/Decipheriv.hx
+++ b/src/js/node/crypto/Decipheriv.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,6 +25,8 @@ package js.node.crypto;
 /**
 	Constructor export for decipher instances created via `Crypto.createDecipheriv`.
 	Prefer `Crypto.createDecipheriv` over constructing this class directly.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/crypto.html#class-decipheriv
 **/
 @:jsRequire("crypto", "Decipheriv")
 extern class Decipheriv extends Decipher {}

--- a/src/js/node/crypto/DiffieHellman.hx
+++ b/src/js/node/crypto/DiffieHellman.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,39 +25,22 @@ package js.node.crypto;
 import js.node.Buffer;
 
 /**
-	Common interface for `DiffieHellman` and a mimic object returned by `Crypto.getDiffieHellman`.
-	See `DiffieHellman` documentation.
-**/
-@:remove
-extern interface IDiffieHellman {
-	@:overload(function():Buffer {})
-	function generateKeys(encoding:String):String;
-
-	@:overload(function(other_public_key:Buffer):Buffer {})
-	@:overload(function(other_public_key:String, input_encoding:String):Buffer {})
-	function computeSecret(other_public_key:String, input_encoding:String, output_encoding:String):String;
-
-	@:overload(function():Buffer {})
-	function getPrime(encoding:String):String;
-
-	@:overload(function():Buffer {})
-	function getGenerator(encoding:String):String;
-
-	@:overload(function():Buffer {})
-	function getPublicKey(encoding:String):String;
-
-	@:overload(function():Buffer {})
-	function getPrivateKey(encoding:String):String;
-}
-
-/**
 	The class for creating Diffie-Hellman key exchanges.
 	Returned by `Crypto.createDiffieHellman`.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/crypto.html#class-diffiehellman
 **/
-extern class DiffieHellman implements IDiffieHellman {
+@:jsRequire("crypto", "DiffieHellman")
+extern class DiffieHellman {
+	/**
+		A bit field containing any warnings and/or errors resulting from a check
+		performed during initialization of the `DiffieHellman` object.
+	**/
+	final verifyError:Int;
+
 	/**
 		Generates private and public Diffie-Hellman key values, and returns the public key in the specified `encoding`.
-		This key should be transferred to the other party. `encoding` can be 'binary', 'hex', or 'base64'.
+		This key should be transferred to the other party. `encoding` can be `'binary'`, `'hex'`, or `'base64'`.
 	**/
 	@:overload(function():Buffer {})
 	function generateKeys(encoding:String):String;
@@ -69,7 +52,7 @@ extern class DiffieHellman implements IDiffieHellman {
 		Supplied key is interpreted using specified `input_encoding`,
 		and secret is encoded using specified `output_encoding`.
 
-		Encodings can be 'binary', 'hex', or 'base64'.
+		Encodings can be `'binary'`, `'hex'`, or `'base64'`.
 
 		If the input encoding is not provided, then a buffer is expected.
 	**/
@@ -78,42 +61,42 @@ extern class DiffieHellman implements IDiffieHellman {
 	function computeSecret(other_public_key:String, input_encoding:String, output_encoding:String):String;
 
 	/**
-		Returns the Diffie-Hellman prime in the specified encoding, which can be 'binary', 'hex', or 'base64'.
+		Returns the Diffie-Hellman prime in the specified encoding, which can be `'binary'`, `'hex'`, or `'base64'`.
 		If no encoding is provided, then a buffer is returned.
 	**/
 	@:overload(function():Buffer {})
 	function getPrime(encoding:String):String;
 
 	/**
-		Returns the Diffie-Hellman generator in the specified encoding, which can be 'binary', 'hex', or 'base64'.
+		Returns the Diffie-Hellman generator in the specified encoding, which can be `'binary'`, `'hex'`, or `'base64'`.
 		If no encoding is provided, then a buffer is returned.
 	**/
 	@:overload(function():Buffer {})
 	function getGenerator(encoding:String):String;
 
 	/**
-		Returns the Diffie-Hellman public key in the specified encoding, which can be 'binary', 'hex', or 'base64'.
+		Returns the Diffie-Hellman public key in the specified encoding, which can be `'binary'`, `'hex'`, or `'base64'`.
 		If no encoding is provided, then a buffer is returned.
 	**/
 	@:overload(function():Buffer {})
 	function getPublicKey(encoding:String):String;
 
 	/**
-		Returns the Diffie-Hellman private key in the specified encoding, which can be 'binary', 'hex', or 'base64'.
+		Returns the Diffie-Hellman private key in the specified encoding, which can be `'binary'`, `'hex'`, or `'base64'`.
 		If no encoding is provided, then a buffer is returned.
 	**/
 	@:overload(function():Buffer {})
 	function getPrivateKey(encoding:String):String;
 
 	/**
-		Sets the Diffie-Hellman public key. Key encoding can be 'binary', 'hex' or 'base64'.
+		Sets the Diffie-Hellman public key. Key encoding can be `'binary'`, `'hex'` or `'base64'`.
 		If no `encoding` is provided, then a `Buffer` is expected.
 	**/
 	@:overload(function(public_key:Buffer):Void {})
 	function setPublicKey(public_key:String, encoding:String):Void;
 
 	/**
-		Sets the Diffie-Hellman private key. Key encoding can be 'binary', 'hex' or 'base64'.
+		Sets the Diffie-Hellman private key. Key encoding can be `'binary'`, `'hex'` or `'base64'`.
 		If no `encoding` is provided, then a `Buffer` is expected.
 	**/
 	@:overload(function(private_key:Buffer):Void {})

--- a/src/js/node/crypto/DiffieHellmanGroup.hx
+++ b/src/js/node/crypto/DiffieHellmanGroup.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -29,9 +29,17 @@ import js.node.Buffer;
 	`Crypto.getDiffieHellman` / `Crypto.createDiffieHellmanGroup`.
 
 	Unlike `DiffieHellman`, keys cannot be set with `setPublicKey` / `setPrivateKey`.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/crypto.html#class-diffiehellmangroup
 **/
 @:jsRequire("crypto", "DiffieHellmanGroup")
 extern class DiffieHellmanGroup {
+	/**
+		A bit field containing any warnings and/or errors resulting from a check
+		performed during initialization.
+	**/
+	final verifyError:Int;
+
 	@:overload(function():Buffer {})
 	function generateKeys(encoding:String):String;
 

--- a/src/js/node/crypto/ECDH.hx
+++ b/src/js/node/crypto/ECDH.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -35,16 +35,27 @@ enum abstract ECDHFormat(String) from String to String {
 	The class for creating EC Diffie-Hellman key exchanges.
 
 	Returned by `Crypto.createECDH`.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/crypto.html#class-ecdh
 **/
 extern class ECDH {
+	/**
+		Converts the EC Diffie-Hellman public key specified by `key` and `curve` to the format specified by `format`.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/crypto.html#static-method-ecdhconvertkeykey-curve-inputencoding-outputencoding-format
+	**/
+	@:overload(function(key:EitherType<String, Buffer>, curve:String, ?inputEncoding:String, ?outputEncoding:String,
+		?format:ECDHFormat):EitherType<String, Buffer> {})
+	static function convertKey(key:Buffer, curve:String):Buffer;
+
 	/**
 		Generates private and public EC Diffie-Hellman key values, and returns the public key
 		in the specified `format` and `encoding`. This key should be transferred to the other party.
 
-		Format specifies point encoding and can be 'compressed', 'uncompressed', or 'hybrid'.
-		If no format is provided - the point will be returned in 'uncompressed' format.
+		Format specifies point encoding and can be `'compressed'`, `'uncompressed'`, or `'hybrid'`.
+		If no format is provided - the point will be returned in `'uncompressed'` format.
 
-		Encoding can be 'binary', 'hex', or 'base64'. If no encoding is provided, then a buffer is returned.
+		Encoding can be `'binary'`, `'hex'`, or `'base64'`. If no encoding is provided, then a buffer is returned.
 	**/
 	function generateKeys(?encoding:String, ?format:ECDHFormat):EitherType<String, Buffer>;
 
@@ -53,7 +64,7 @@ extern class ECDH {
 		and returns the computed shared secret. Supplied key is interpreted using specified `input_encoding`,
 		and secret is encoded using specified `output_encoding`.
 
-		Encodings can be 'binary', 'hex', or 'base64'.
+		Encodings can be `'binary'`, `'hex'`, or `'base64'`.
 
 		If the input encoding is not provided, then a buffer is expected.
 		If no output encoding is given, then a buffer is returned.
@@ -65,15 +76,15 @@ extern class ECDH {
 	/**
 		Returns the EC Diffie-Hellman public key in the specified `encoding` and `format`.
 
-		Format specifies point encoding and can be 'compressed', 'uncompressed', or 'hybrid'.
-		If no format is provided - the point will be returned in 'uncompressed' format.
+		Format specifies point encoding and can be `'compressed'`, `'uncompressed'`, or `'hybrid'`.
+		If no format is provided - the point will be returned in `'uncompressed'` format.
 
-		Encoding can be 'binary', 'hex', or 'base64'. If no encoding is provided, then a buffer is returned.
+		Encoding can be `'binary'`, `'hex'`, or `'base64'`. If no encoding is provided, then a buffer is returned.
 	**/
 	function getPublicKey(?encoding:String, ?format:ECDHFormat):EitherType<String, Buffer>;
 
 	/**
-		Returns the EC Diffie-Hellman private key in the specified encoding, which can be 'binary', 'hex', or 'base64'.
+		Returns the EC Diffie-Hellman private key in the specified encoding, which can be `'binary'`, `'hex'`, or `'base64'`.
 		If no `encoding` is provided, then a buffer is returned.
 	**/
 	@:overload(function():Buffer {})
@@ -82,16 +93,20 @@ extern class ECDH {
 	/**
 		Sets the EC Diffie-Hellman public key.
 
-		Key encoding can be 'binary', 'hex' or 'base64'.
+		Deprecated since Node.js v5.2.0 — usually unnecessary because the exchange only uses the private key
+		and the other party's public key.
+
+		Key encoding can be `'binary'`, `'hex'` or `'base64'`.
 		If no encoding is provided, then a buffer is expected.
 	**/
+	@:deprecated("ECDH.setPublicKey is deprecated; setting the private key is sufficient")
 	@:overload(function(public_key:Buffer):Void {})
 	function setPublicKey(public_key:String, encoding:String):Void;
 
 	/**
 		Sets the EC Diffie-Hellman private key.
 
-		Key encoding can be 'binary', 'hex' or 'base64'.
+		Key encoding can be `'binary'`, `'hex'` or `'base64'`.
 		If no encoding is provided, then a buffer is expected.
 	**/
 	@:overload(function(private_key:Buffer):Void {})

--- a/src/js/node/crypto/Hash.hx
+++ b/src/js/node/crypto/Hash.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -34,14 +34,23 @@ import js.node.Buffer;
 	The legacy `update` and `digest` methods are also supported.
 
 	Returned by `Crypto.createHash`.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/crypto.html#class-hash
 **/
 extern class Hash extends js.node.stream.Transform<Hash> {
 	/**
-		Updates the hash content with the given `data`,
+		Creates a new `Hash` object that contains a deep copy of the internal state of this `Hash` object.
+		Throws if called after `digest`.
 
-		the `encoding` of which is given in `input_encoding` and can be 'utf8', 'ascii' or 'binary'.
-		If no `encoding` is provided and the input is a string an encoding of 'binary' is enforced.
-		If `data` is a `Buffer` then `input_encoding` is ignored.
+		For XOF hash functions such as `'shake256'`, `options.outputLength` may specify the desired output length in bytes.
+	**/
+	function copy(?options:HashCopyOptions):Hash;
+
+	/**
+		Updates the hash content with the given `data`.
+
+		If `data` is a string and `input_encoding` is omitted, `'utf8'` is used.
+		If `data` is a `Buffer`, `TypedArray`, or `DataView`, `input_encoding` is ignored.
 
 		This can be called many times with new data as it is streamed.
 	**/
@@ -50,11 +59,19 @@ extern class Hash extends js.node.stream.Transform<Hash> {
 
 	/**
 		Calculates the digest of all of the passed data to be hashed.
-		The `encoding` can be 'hex', 'binary' or 'base64'.
+		The `encoding` can be `'hex'`, `'base64'`, `'base64url'`, or `'binary'`.
 		If no `encoding` is provided, then a buffer is returned.
 
 		Note: hash object can not be used after `digest` method has been called.
 	**/
 	@:overload(function():Buffer {})
 	function digest(encoding:String):String;
+}
+
+/**
+	Options for `Hash.copy`.
+**/
+typedef HashCopyOptions = {
+	> js.node.stream.Transform.TransformNewOptions,
+	@:optional var outputLength:Int;
 }

--- a/src/js/node/crypto/Hmac.hx
+++ b/src/js/node/crypto/Hmac.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -33,6 +33,8 @@ import js.node.Buffer;
 	The legacy `update` and `digest` methods are also supported.
 
 	Returned by `Crypto.createHmac`.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/crypto.html#class-hmac
 **/
 extern class Hmac extends js.node.stream.Transform<Hmac> {
 	/**
@@ -45,7 +47,7 @@ extern class Hmac extends js.node.stream.Transform<Hmac> {
 
 	/**
 		Calculates the digest of all of the passed data to the hmac.
-		The `encoding` can be 'hex', 'binary' or 'base64'.
+		The `encoding` can be `'hex'`, `'binary'` or `'base64'`.
 		If no `encoding` is provided, then a buffer is returned.
 
 		Note: hmac object can not be used after `digest` method has been called.

--- a/src/js/node/crypto/KeyObject.hx
+++ b/src/js/node/crypto/KeyObject.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -30,7 +30,7 @@ import js.node.Buffer;
 	Node.js representation of a key for use by crypto APIs.
 	Instances are created via `Crypto.create*Key` / `generateKey*` helpers.
 
-	@see https://nodejs.org/api/crypto.html#class-keyobject
+	@see https://nodejs.org/docs/latest-v24.x/api/crypto.html#class-keyobject
 **/
 @:jsRequire("crypto", "KeyObject")
 extern class KeyObject {
@@ -43,25 +43,23 @@ extern class KeyObject {
 		Depending on the type of this `KeyObject`, this property is either
 		`'secret'`, `'public'`, or `'private'`.
 	**/
-	var type(default, never):KeyObjectType;
+	final type:KeyObjectType;
 
 	/**
 		For asymmetric keys, the type of the key (e.g. `'rsa'`, `'ec'`, `'ed25519'`).
 		`undefined` for secret keys.
 	**/
-	@:optional var asymmetricKeyType(default, never):String;
+	@:optional final asymmetricKeyType:String;
 
 	/**
 		Details about an asymmetric key. `undefined` for secret keys.
-
-		// TODO(section-4): finer-grained AsymmetricKeyDetails fields
 	**/
-	@:optional var asymmetricKeyDetails(default, never):Any;
+	@:optional final asymmetricKeyDetails:AsymmetricKeyDetails;
 
 	/**
 		For secret keys, the size of the key in bytes. `undefined` for asymmetric keys.
 	**/
-	@:optional var symmetricKeySize(default, never):Int;
+	@:optional final symmetricKeySize:Int;
 
 	/**
 		Returns `true` if the keys have exactly the same type, value, and parameters.
@@ -73,6 +71,11 @@ extern class KeyObject {
 		Result type depends on `format` (`'pem'` → String, `'der'` → Buffer, `'jwk'` → object).
 	**/
 	function export(?options:KeyExportOptions):EitherType<String, EitherType<Buffer, Any>>;
+
+	/**
+		Converts this `KeyObject` instance to a Web Crypto `CryptoKey`.
+	**/
+	function toCryptoKey(algorithm:Any, extractable:Bool, keyUsages:Array<String>):CryptoKey;
 }
 
 /**
@@ -85,11 +88,31 @@ enum abstract KeyObjectType(String) from String to String {
 }
 
 /**
+	Details about an asymmetric key from `KeyObject.asymmetricKeyDetails`.
+**/
+typedef AsymmetricKeyDetails = {
+	/** Key size in bits (RSA, DSA). **/
+	@:optional final modulusLength:Int;
+	/** Public exponent (RSA). Number or BigInt depending on key material. **/
+	@:optional final publicExponent:Any;
+	/** Name of the message digest (RSA-PSS). **/
+	@:optional final hashAlgorithm:String;
+	/** Name of the message digest used by MGF1 (RSA-PSS). **/
+	@:optional final mgf1HashAlgorithm:String;
+	/** Minimal salt length in bytes (RSA-PSS). **/
+	@:optional final saltLength:Int;
+	/** Size of `q` in bits (DSA). **/
+	@:optional final divisorLength:Int;
+	/** Name of the curve (EC). **/
+	@:optional final namedCurve:String;
+}
+
+/**
 	Options for `KeyObject.export`.
 **/
 typedef KeyExportOptions = {
-	@:optional var type:String;
-	@:optional var format:String;
-	@:optional var cipher:String;
-	@:optional var passphrase:EitherType<String, Buffer>;
+	@:optional final type:String;
+	@:optional final format:String;
+	@:optional final cipher:String;
+	@:optional final passphrase:EitherType<String, Buffer>;
 }

--- a/src/js/node/crypto/Sign.hx
+++ b/src/js/node/crypto/Sign.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -24,6 +24,7 @@ package js.node.crypto;
 
 import haxe.extern.EitherType;
 import js.node.Buffer;
+import js.node.Crypto.CryptoKeyInput;
 import js.node.stream.Writable;
 
 /**
@@ -32,26 +33,29 @@ import js.node.stream.Writable;
 	Returned by `Crypto.createSign`.
 
 	Sign objects are writable streams. The written data is used to generate the signature.
-	Once all of the data has been written, the sign method will return the signature.
+	Once all of the data has been written, the `sign` method will return the signature.
 
 	The legacy `update` method is also supported.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/crypto.html#class-sign
 **/
 extern class Sign extends Writable<Sign> {
 	/**
 		Updates the sign object with data.
 		This can be called many times with new data as it is streamed.
 	**/
-	@:overload(function(data:Buffer):Void {})
-	function update(data:String, ?encoding:String):Void;
+	@:overload(function(data:Buffer):Sign {})
+	function update(data:String, ?encoding:String):Sign;
 
 	/**
 		Calculates the signature on all the updated data passed through the sign.
-		`private_key` is a string containing the PEM encoded private key for signing.
-		Returns the signature in `output_format` which can be 'binary', 'hex' or 'base64'.
+
+		`private_key` can be a PEM string, a `KeyObject`, or a key object descriptor.
+		Returns the signature in `output_format` which can be `'binary'`, `'hex'` or `'base64'`.
 		If no encoding is provided, then a buffer is returned.
 
 		Note: sign object can not be used after `sign` method has been called.
 	**/
-	@:overload(function(private_key:EitherType<String, {key:String, passphrase:String}>):Buffer {})
-	function sign(private_key:EitherType<String, {key:String, passphrase:String}>, output_format:String):String;
+	@:overload(function(private_key:EitherType<String, EitherType<Buffer, EitherType<KeyObject, CryptoKeyInput>>>):Buffer {})
+	function sign(private_key:EitherType<String, EitherType<Buffer, EitherType<KeyObject, CryptoKeyInput>>>, output_format:String):String;
 }

--- a/src/js/node/crypto/Verify.hx
+++ b/src/js/node/crypto/Verify.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -22,7 +22,9 @@
 
 package js.node.crypto;
 
+import haxe.extern.EitherType;
 import js.node.Buffer;
+import js.node.Crypto.CryptoKeyInput;
 import js.node.stream.Writable;
 
 /**
@@ -30,31 +32,34 @@ import js.node.stream.Writable;
 	Returned by `Crypto.createVerify`.
 
 	Verify objects are writable streams. The written data is used to validate against the supplied signature.
-	Once all of the data has been written, the verify method will return true if the supplied signature is valid.
+	Once all of the data has been written, the `verify` method will return true if the supplied signature is valid.
 
 	The legacy `update` method is also supported.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/crypto.html#class-verify
 **/
-extern class Verify extends Writable<Sign> {
+extern class Verify extends Writable<Verify> {
 	/**
 		Updates the verifier object with data. This can be called many times with new data as it is streamed.
 	**/
-	@:overload(function(data:Buffer):Void {})
-	function update(data:String, ?encoding:String):Void;
+	@:overload(function(data:Buffer):Verify {})
+	function update(data:String, ?encoding:String):Verify;
 
 	/**
 		Verifies the signed data by using the object and signature.
 
-		`object` is a string containing a PEM encoded object, which can be one of RSA public key,
-		DSA public key, or X.509 certificate.
+		`object` can be a PEM string, a `KeyObject`, or a key object descriptor
+		(RSA/DSA public key or X.509 certificate).
 
 		`signature` is the previously calculated signature for the data,
-		in the `signature_format` which can be 'binary', 'hex' or 'base64'.
+		in the `signature_format` which can be `'binary'`, `'hex'` or `'base64'`.
 		If no encoding is specified, then a buffer is expected.
 
 		Returns true or false depending on the validity of the signature for the data and public key.
 
 		Note: verifier object can not be used after `verify` method has been called.
 	**/
-	@:overload(function(object:String, signature:Buffer):Bool {})
-	function verify(object:String, signature:String, signature_format:String):Bool;
+	@:overload(function(object:EitherType<String, EitherType<Buffer, EitherType<KeyObject, CryptoKeyInput>>>, signature:Buffer):Bool {})
+	function verify(object:EitherType<String, EitherType<Buffer, EitherType<KeyObject, CryptoKeyInput>>>, signature:String,
+		signature_format:String):Bool;
 }

--- a/src/js/node/crypto/X509Certificate.hx
+++ b/src/js/node/crypto/X509Certificate.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -28,7 +28,7 @@ import js.node.Buffer;
 /**
 	Encapsulates an X509 certificate and provides read-only access to its information.
 
-	@see https://nodejs.org/api/crypto.html#class-x509certificate
+	@see https://nodejs.org/docs/latest-v24.x/api/crypto.html#class-x509certificate
 **/
 @:jsRequire("crypto", "X509Certificate")
 extern class X509Certificate {
@@ -40,87 +40,97 @@ extern class X509Certificate {
 	/**
 		The SHA-1 fingerprint of this certificate.
 	**/
-	var fingerprint(default, never):String;
+	final fingerprint:String;
 
 	/**
 		The SHA-256 fingerprint of this certificate.
 	**/
-	var fingerprint256(default, never):String;
+	final fingerprint256:String;
 
 	/**
 		The SHA-512 fingerprint of this certificate.
 	**/
-	var fingerprint512(default, never):String;
+	final fingerprint512:String;
 
 	/**
 		The issuer identification included in this certificate.
 	**/
-	var issuer(default, never):String;
+	final issuer:String;
+
+	/**
+		The issuer certificate corresponding to this certificate, if available.
+	**/
+	@:optional final issuerCertificate:X509Certificate;
 
 	/**
 		The subject identification included in this certificate.
 	**/
-	var subject(default, never):String;
+	final subject:String;
 
 	/**
 		The subject alternative names included in this certificate.
 	**/
-	@:optional var subjectAltName(default, never):String;
+	@:optional final subjectAltName:String;
 
 	/**
 		Information access information for this certificate.
 	**/
-	@:optional var infoAccess(default, never):String;
+	@:optional final infoAccess:String;
 
 	/**
 		The date/time from which this certificate is valid (ISO string).
 	**/
-	var validFrom(default, never):String;
+	final validFrom:String;
 
 	/**
 		The date/time until which this certificate is valid (ISO string).
 	**/
-	var validTo(default, never):String;
+	final validTo:String;
 
 	/**
 		The date from which this certificate is valid.
 	**/
-	var validFromDate(default, never):js.lib.Date;
+	final validFromDate:js.lib.Date;
 
 	/**
 		The date until which this certificate is valid.
 	**/
-	var validToDate(default, never):js.lib.Date;
+	final validToDate:js.lib.Date;
 
 	/**
 		The serial number of this certificate.
 	**/
-	var serialNumber(default, never):String;
+	final serialNumber:String;
 
 	/**
 		The algorithm used to sign this certificate.
 	**/
-	var signatureAlgorithm(default, never):String;
+	final signatureAlgorithm:String;
+
+	/**
+		The OID of the algorithm used to sign this certificate.
+	**/
+	final signatureAlgorithmOid:String;
 
 	/**
 		The raw DER bytes of this certificate.
 	**/
-	var raw(default, never):Buffer;
+	final raw:Buffer;
 
 	/**
 		The public key of this certificate.
 	**/
-	var publicKey(default, never):KeyObject;
+	final publicKey:KeyObject;
 
 	/**
 		`true` if this is a Certificate Authority (CA) certificate.
 	**/
-	var ca(default, never):Bool;
+	final ca:Bool;
 
 	/**
 		Key usages for this certificate, if any.
 	**/
-	var keyUsage(default, never):Array<String>;
+	final keyUsage:Array<String>;
 
 	/**
 		Checks whether the certificate matches the given host name.
@@ -148,6 +158,11 @@ extern class X509Certificate {
 	function checkPrivateKey(privateKey:KeyObject):Bool;
 
 	/**
+		Verifies that this certificate was signed by the given public key.
+	**/
+	function verify(publicKey:KeyObject):Bool;
+
+	/**
 		PEM encoding of this certificate.
 	**/
 	function toString():String;
@@ -156,15 +171,20 @@ extern class X509Certificate {
 		Legacy encoding used by older Node.js versions / JSON serialization helper.
 	**/
 	function toJSON():String;
+
+	/**
+		Returns an information object representing this certificate for compatibility with legacy APIs.
+	**/
+	function toLegacyObject():Any;
 }
 
 /**
 	Options for `X509Certificate` host/email checks.
 **/
 typedef X509CheckOptions = {
-	@:optional var subject:String;
-	@:optional var wildcards:Bool;
-	@:optional var partialWildcards:Bool;
-	@:optional var multiLabelWildcards:Bool;
-	@:optional var singleLabelSubdomains:Bool;
+	@:optional final subject:String;
+	@:optional final wildcards:Bool;
+	@:optional final partialWildcards:Bool;
+	@:optional final multiLabelWildcards:Bool;
+	@:optional final singleLabelSubdomains:Bool;
 }


### PR DESCRIPTION
## Summary
- Align `js.node.Crypto` and `js.node.crypto.*` with Node.js 24 crypto surface (KeyObject.toCryptoKey, Hash.copy, Certificate statics, X509/ECDH/DH gaps, createCipheriv options / Cipheriv returns).
- Haxe 4 modernization: `final` fields, named-arg callback types, deprecate removed `createCipher`/`createDecipher`, fix `Verify` stream self-type.
- Refresh copyright headers to 2014–2026 and Node 24 `@see` links.

## Test plan
- [x] `haxe build.hxml` succeeds in the audit worktree
- [ ] Spot-check `Crypto.createCipheriv` / `KeyObject` / `X509Certificate` usage against Node 24 docs


Made with [Cursor](https://cursor.com)