### PR TITLE
Audit js.node.test for Node 24 + Haxe 4

### DIFF
--- a/src/js/node/Test.hx
+++ b/src/js/node/Test.hx
@@ -110,6 +110,8 @@ extern class Test {
 	/**
 		Shorthand for expecting a test to fail: `test(name, { expectFailure: true }[, fn])`.
 
+		Same function as `test.expectFailure` / `it.expectFailure`.
+
 		Added in: v24.14.0
 
 		@see https://nodejs.org/docs/latest-v24.x/api/test.html#expecting-tests-to-fail

--- a/src/js/node/Test.hx
+++ b/src/js/node/Test.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -41,9 +41,16 @@ import js.lib.RegExp;
 
 	This module is only available under the `node:` scheme.
 
-	These externs target **Node.js 24+ Active LTS**. Dual-LTS APIs such as
-	`expectFailure`, `run({ randomize })`, and `TestContext.workerId` are typed
-	without version gates; older LTS releases may not provide them at runtime.
+	These externs target **Node.js 24+ Active LTS**. Newer APIs such as
+	`expectFailure` (v24.14+), `run({ randomize })`, `TestContext.workerId`
+	(v24.15+), `SuiteContext.passed` / `attempt` / `diagnostic` (v24.16+), and
+	`TestContext.attempt` (v25+) are typed without version gates; older LTS
+	releases may not provide them at runtime.
+
+	`tags` / `context.tags` / `run({ testTagFilters })` are Node.js 26+ and are
+	intentionally omitted.
+
+	Built-in reporters live in `js.node.test.Reporters` (`node:test/reporters`).
 
 	@see https://nodejs.org/docs/latest-v24.x/api/test.html
 **/
@@ -56,16 +63,18 @@ extern class Test {
 		Returns a `Promise` that fulfills once the test completes (or immediately if
 		called within a suite).
 
+		Supports `.skip`, `.todo`, `.only`, and `.expectFailure` shorthands
+		(same callables as the module-level helpers below; the module export is
+		the `test` function).
+
 		@see https://nodejs.org/docs/latest-v24.x/api/test.html#testname-options-fn
 	**/
-	@:selfCall
-	@:overload(function(fn:TestCallback):Promise<Void> {})
-	@:overload(function(name:String, fn:TestCallback):Promise<Void> {})
-	@:overload(function(options:TestOptions, fn:TestCallback):Promise<Void> {})
-	static function test(?name:String, ?options:TestOptions, ?fn:TestCallback):Promise<Void>;
+	static var test(default, never):ItFunction;
 
 	/**
 		Shorthand for skipping a test: `test(name, { skip: true }[, fn])`.
+
+		Same function as `test.skip` / `it.skip`.
 
 		@see https://nodejs.org/docs/latest-v24.x/api/test.html#testskipname-options-fn
 	**/
@@ -77,6 +86,8 @@ extern class Test {
 	/**
 		Shorthand for marking a test as `TODO`: `test(name, { todo: true }[, fn])`.
 
+		Same function as `test.todo` / `it.todo`.
+
 		@see https://nodejs.org/docs/latest-v24.x/api/test.html#testtodoname-options-fn
 	**/
 	@:overload(function(fn:TestCallback):Promise<Void> {})
@@ -86,6 +97,8 @@ extern class Test {
 
 	/**
 		Shorthand for marking a test as `only`: `test(name, { only: true }[, fn])`.
+
+		Same function as `test.only` / `it.only`.
 
 		@see https://nodejs.org/docs/latest-v24.x/api/test.html#testonlyname-options-fn
 	**/
@@ -382,9 +395,9 @@ typedef RunOptions = {
 	@:optional var inspectPort:EitherType<Int, Void->Int>;
 
 	/**
-		Test isolation: `'process'` (default) or `'none'`.
+		Test isolation. Default: `Process`.
 	**/
-	@:optional var isolation:String;
+	@:optional var isolation:RunIsolation;
 
 	/**
 		If truthy, only run tests with the `only` option set.
@@ -486,6 +499,23 @@ typedef RunOptions = {
 		Incompatible with `isolation: 'none'`.
 	**/
 	@:optional var env:DynamicAccess<String>;
+}
+
+/**
+	Process isolation mode for `RunOptions.isolation`.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/test.html#runoptions
+**/
+enum abstract RunIsolation(String) from String to String {
+	/**
+		Each test file runs in a separate child process (default).
+	**/
+	var Process = "process";
+
+	/**
+		All test files run in the current process.
+	**/
+	var None = "none";
 }
 
 /**

--- a/src/js/node/test/ItFunction.hx
+++ b/src/js/node/test/ItFunction.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/test/MockTimers.hx
+++ b/src/js/node/test/MockTimers.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -69,7 +69,11 @@ extern class MockTimers {
 	/**
 		Restore default behavior of all mocks created by this instance.
 
+		Also available as `Symbol.dispose` (aliases this method). Disposable
+		typing is not modeled yet; call `reset()` explicitly in Haxe.
+
 		@see https://nodejs.org/docs/latest-v24.x/api/test.html#timersreset
+		@see https://nodejs.org/docs/latest-v24.x/api/test.html#timerssymboldispose
 	**/
 	function reset():Void;
 

--- a/src/js/node/test/MockTracker.hx
+++ b/src/js/node/test/MockTracker.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/test/Reporters.hx
+++ b/src/js/node/test/Reporters.hx
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C)2014-2026 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package js.node.test;
+
+/**
+	Built-in reporters from `node:test/reporters`.
+
+	Values are compatible with `stream.compose` / `TestsStream.compose`, e.g.
+	`Test.run().compose(Reporters.tap)`.
+
+	`dot` / `tap` / `junit` are also callable as
+	`(source:AsyncIterable) -> AsyncIterator<String>`.
+	`spec` / `lcov` are Transform constructor wrappers (callable / `new`).
+
+	Exact reporter text output is not a stable programmatic API; prefer
+	`TestsStream` events when aggregating results in code.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/test.html#test-reporters
+**/
+@:jsRequire("node:test/reporters")
+extern class Reporters {
+	/**
+		Compact format: `.` for pass, `X` for fail.
+	**/
+	static var dot(default, never):Any;
+
+	/**
+		Human-readable default reporter.
+	**/
+	static var spec(default, never):Any;
+
+	/**
+		TAP format reporter.
+	**/
+	static var tap(default, never):Any;
+
+	/**
+		jUnit XML reporter.
+	**/
+	static var junit(default, never):Any;
+
+	/**
+		LCOV coverage reporter (used with coverage collection).
+	**/
+	static var lcov(default, never):Any;
+}

--- a/src/js/node/test/SuiteContext.hx
+++ b/src/js/node/test/SuiteContext.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/test/SuiteContext.hx
+++ b/src/js/node/test/SuiteContext.hx
@@ -63,6 +63,8 @@ extern class SuiteContext {
 	/**
 		Whether the suite and all of its subtests have passed.
 
+		Added in: v24.16.0
+
 		@see https://nodejs.org/docs/latest-v24.x/api/test.html#contextpassed-1
 	**/
 	var passed(default, null):Bool;
@@ -70,12 +72,16 @@ extern class SuiteContext {
 	/**
 		Zero-based attempt number when using `--test-rerun-failures`.
 
+		Added in: v24.16.0
+
 		@see https://nodejs.org/docs/latest-v24.x/api/test.html#contextattempt-1
 	**/
 	var attempt(default, null):Int;
 
 	/**
 		Output a diagnostic message for the suite.
+
+		Added in: v24.16.0
 
 		@see https://nodejs.org/docs/latest-v24.x/api/test.html#contextdiagnosticmessage-1
 	**/

--- a/src/js/node/test/SuiteFunction.hx
+++ b/src/js/node/test/SuiteFunction.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/test/TestContext.hx
+++ b/src/js/node/test/TestContext.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/js/node/test/TestContext.hx
+++ b/src/js/node/test/TestContext.hx
@@ -131,7 +131,7 @@ extern class TestContext {
 	/**
 		Zero-based attempt number when using `--test-rerun-failures`.
 
-		Added in: v25.0.0 (documented on the Node 24 test page for newer runtimes).
+		Added in: v25.0.0
 
 		@see https://nodejs.org/docs/latest-v24.x/api/test.html#contextattempt
 	**/
@@ -140,6 +140,8 @@ extern class TestContext {
 	/**
 		Unique worker id for the current test file process, or `undefined`
 		outside a test context.
+
+		Added in: v24.15.0
 
 		@see https://nodejs.org/docs/latest-v24.x/api/test.html#contextworkerid
 	**/

--- a/src/js/node/test/TestsStream.hx
+++ b/src/js/node/test/TestsStream.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
## Summary
- Add missing `node:test/reporters` externs (`js.node.test.Reporters`: `dot` / `spec` / `tap` / `junit` / `lcov`) for use with `Test.run().compose(...)`.
- Model `Test.test` as `ItFunction` (enables `test.skip` / `test.expectFailure` like `it`), typed `RunIsolation` for `run({ isolation })`, and document `MockTimers` `Symbol.dispose` as an alias of `reset()`.
- Refresh copyright headers to 2014–2026; clarify Node 24 dual-LTS version notes (`workerId` v24.15, SuiteContext `passed`/`attempt`/`diagnostic` v24.16, `attempt` v25).

## Findings
- Core `node:test` surface (test/suite/it, hooks, mock, snapshot, assert.register, run options, TestContext / SuiteContext / TestsStream) already matched Node 24 after #214 / #225 / #234.
- Intentionally omitted Current-only APIs: test `tags` / `context.tags` / `testTagFilters` (added in Node v26.2.0).
- Haxe 3 `#if haxe4` / `js.html.AbortSignal` cleanup already on master.
- OpenTelemetry `tracing:node.test:*` diagnostics channels are docs-only (use existing `diagnostics_channel`); no new extern needed in this package.

## Test plan
- [x] `haxe build.hxml` (ImportAll) succeeds
- [ ] CI matrix on the PR