### PR TITLE
Audit perf_hooks for Node 24 / Haxe 4

### DIFF
--- a/src/js/node/PerfHooks.hx
+++ b/src/js/node/PerfHooks.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -44,19 +44,19 @@ extern class PerfHooks {
 
 		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#perf_hooksperformance
 	**/
-	static var performance(default, never):Performance;
+	static final performance:Performance;
 
 	/**
 		Constants for garbage collection kinds and flags.
 
 		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#perf_hooksconstants
 	**/
-	static var constants(default, never):PerfHooksConstants;
+	static final constants:PerfHooksConstants;
 
 	/**
 		Returns a `RecordableHistogram`.
 
-		@see https://nodejs.org/api/perf_hooks.html#perf_hookscreatehistogramoptions
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#perf_hookscreatehistogramoptions
 	**/
 	static function createHistogram(?options:CreateHistogramOptions):RecordableHistogram;
 
@@ -66,7 +66,7 @@ extern class PerfHooks {
 
 		This property is an extension by Node.js. It is not available in Web browsers.
 
-		@see https://nodejs.org/api/perf_hooks.html#perf_hooksmonitoreventloopdelayoptions
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#perf_hooksmonitoreventloopdelayoptions
 	**/
 	static function monitorEventLoopDelay(?options:EventLoopMonitorOptions):IntervalHistogram;
 
@@ -78,7 +78,7 @@ extern class PerfHooks {
 		Added in Node.js v24.12.0 (Active LTS). On earlier versions (including Node.js 22 LTS)
 		this is `undefined` at module level; use `PerfHooks.performance.eventLoopUtilization` instead.
 
-		@see https://nodejs.org/api/perf_hooks.html#perf_hookseventlooputilizationutilization1-utilization2
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#perf_hookseventlooputilizationutilization1-utilization2
 	**/
 	static function eventLoopUtilization(?utilization1:EventLoopUtilization, ?utilization2:EventLoopUtilization):EventLoopUtilization;
 
@@ -93,7 +93,7 @@ extern class PerfHooks {
 		Added in Node.js v24.12.0 (Active LTS). On earlier versions (including Node.js 22 LTS)
 		this is `undefined` at module level; use `PerfHooks.performance.timerify` instead.
 
-		@see https://nodejs.org/api/perf_hooks.html#perf_hookstimerifyfn-options
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#perf_hookstimerifyfn-options
 	**/
 	static function timerify<T:Function>(fn:T, ?options:TimerifyOptions):T;
 }
@@ -102,17 +102,17 @@ extern class PerfHooks {
 	Constants exported by `perf_hooks.constants`.
 **/
 typedef PerfHooksConstants = {
-	var NODE_PERFORMANCE_GC_MAJOR(default, never):Int;
-	var NODE_PERFORMANCE_GC_MINOR(default, never):Int;
-	var NODE_PERFORMANCE_GC_INCREMENTAL(default, never):Int;
-	var NODE_PERFORMANCE_GC_WEAKCB(default, never):Int;
-	var NODE_PERFORMANCE_GC_FLAGS_NO(default, never):Int;
-	var NODE_PERFORMANCE_GC_FLAGS_CONSTRUCT_RETAINED(default, never):Int;
-	var NODE_PERFORMANCE_GC_FLAGS_FORCED(default, never):Int;
-	var NODE_PERFORMANCE_GC_FLAGS_SYNCHRONOUS_PHANTOM_PROCESSING(default, never):Int;
-	var NODE_PERFORMANCE_GC_FLAGS_ALL_AVAILABLE_GARBAGE(default, never):Int;
-	var NODE_PERFORMANCE_GC_FLAGS_ALL_EXTERNAL_MEMORY(default, never):Int;
-	var NODE_PERFORMANCE_GC_FLAGS_SCHEDULE_IDLE(default, never):Int;
+	final NODE_PERFORMANCE_GC_MAJOR:Int;
+	final NODE_PERFORMANCE_GC_MINOR:Int;
+	final NODE_PERFORMANCE_GC_INCREMENTAL:Int;
+	final NODE_PERFORMANCE_GC_WEAKCB:Int;
+	final NODE_PERFORMANCE_GC_FLAGS_NO:Int;
+	final NODE_PERFORMANCE_GC_FLAGS_CONSTRUCT_RETAINED:Int;
+	final NODE_PERFORMANCE_GC_FLAGS_FORCED:Int;
+	final NODE_PERFORMANCE_GC_FLAGS_SYNCHRONOUS_PHANTOM_PROCESSING:Int;
+	final NODE_PERFORMANCE_GC_FLAGS_ALL_AVAILABLE_GARBAGE:Int;
+	final NODE_PERFORMANCE_GC_FLAGS_ALL_EXTERNAL_MEMORY:Int;
+	final NODE_PERFORMANCE_GC_FLAGS_SCHEDULE_IDLE:Int;
 }
 
 /**

--- a/src/js/node/perf_hooks/Histogram.hx
+++ b/src/js/node/perf_hooks/Histogram.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -27,60 +27,79 @@ package js.node.perf_hooks;
 
 	The constructor of this class is not exposed to users.
 
-	@see https://nodejs.org/api/perf_hooks.html#class-histogram
+	@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#class-histogram
 **/
 extern class Histogram {
 	/**
 		The number of samples recorded by the histogram.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#histogramcount
 	**/
-	var count(default, null):Float;
+	final count:Float;
 
 	/**
 		The number of samples recorded by the histogram (as a BigInt).
 
 		// TODO: type as BigInt when hxnodejs provides one.
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#histogramcountbigint
 	**/
-	var countBigInt(default, null):Dynamic;
+	final countBigInt:Dynamic;
 
 	/**
 		The number of times the event loop delay exceeded the maximum 1 hour event loop delay threshold.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#histogramexceeds
 	**/
-	var exceeds(default, null):Float;
+	final exceeds:Float;
 
 	/**
 		The number of times the event loop delay exceeded the maximum 1 hour event loop delay threshold (as a BigInt).
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#histogramexceedsbigint
 	**/
-	var exceedsBigInt(default, null):Dynamic;
+	final exceedsBigInt:Dynamic;
 
 	/**
 		The maximum recorded event loop delay.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#histogrammax
 	**/
-	var max(default, null):Float;
+	final max:Float;
 
 	/**
 		The maximum recorded event loop delay (as a BigInt).
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#histogrammaxbigint
 	**/
-	var maxBigInt(default, null):Dynamic;
+	final maxBigInt:Dynamic;
 
 	/**
 		The mean of the recorded event loop delays.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#histogrammean
 	**/
-	var mean(default, null):Float;
+	final mean:Float;
 
 	/**
 		The minimum recorded event loop delay.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#histogrammin
 	**/
-	var min(default, null):Float;
+	final min:Float;
 
 	/**
 		The minimum recorded event loop delay (as a BigInt).
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#histogramminbigint
 	**/
-	var minBigInt(default, null):Dynamic;
+	final minBigInt:Dynamic;
 
 	/**
 		Returns the value at the given percentile.
 
 		@param percentile A percentile value in the range (0, 100].
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#histogrampercentilepercentile
 	**/
 	function percentile(percentile:Float):Float;
 
@@ -88,28 +107,37 @@ extern class Histogram {
 		Returns the value at the given percentile (as a BigInt).
 
 		@param percentile A percentile value in the range (0, 100].
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#histogrampercentilebigintpercentile
 	**/
 	function percentileBigInt(percentile:Float):Dynamic;
 
 	/**
 		Returns a `Map` object detailing the accumulated percentile distribution.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#histogrampercentiles
 	**/
-	var percentiles(default, null):js.lib.Map<Float, Float>;
+	final percentiles:js.lib.Map<Float, Float>;
 
 	/**
 		Returns a `Map` object detailing the accumulated percentile distribution (BigInt keys/values).
 
 		// TODO: type as Map<BigInt, BigInt> when hxnodejs provides BigInt.
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#histogrampercentilesbigint
 	**/
-	var percentilesBigInt(default, null):Dynamic;
+	final percentilesBigInt:Dynamic;
 
 	/**
 		Resets the collected histogram data.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#histogramreset
 	**/
 	function reset():Void;
 
 	/**
 		The standard deviation of the recorded event loop delays.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#histogramstddev
 	**/
-	var stddev(default, null):Float;
+	final stddev:Float;
 }

--- a/src/js/node/perf_hooks/IntervalHistogram.hx
+++ b/src/js/node/perf_hooks/IntervalHistogram.hx
@@ -25,9 +25,6 @@ package js.node.perf_hooks;
 /**
 	A `Histogram` that is periodically updated on a given interval.
 
-	As of Node.js v24.2.0, also implements `[Symbol.dispose]()` which calls `disable()`.
-	// TODO: model `[Symbol.dispose]()` / Web IDL `Disposable` when hxnodejs supports it.
-
 	@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#class-intervalhistogram-extends-histogram
 **/
 extern class IntervalHistogram extends Histogram {
@@ -46,4 +43,15 @@ extern class IntervalHistogram extends Histogram {
 		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#histogramenable
 	**/
 	function enable():Bool;
+
+	/**
+		Disables the update interval timer when the histogram is disposed.
+
+		Corresponds to JavaScript `histogram[Symbol.dispose]()`. Added in Node.js v24.2.0.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#histogramsymboldispose
+	**/
+	public inline function dispose():Void {
+		js.Syntax.code("{0}[Symbol.dispose]()", this);
+	}
 }

--- a/src/js/node/perf_hooks/IntervalHistogram.hx
+++ b/src/js/node/perf_hooks/IntervalHistogram.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,18 +25,25 @@ package js.node.perf_hooks;
 /**
 	A `Histogram` that is periodically updated on a given interval.
 
-	@see https://nodejs.org/api/perf_hooks.html#class-intervalhistogram-extends-histogram
+	As of Node.js v24.2.0, also implements `[Symbol.dispose]()` which calls `disable()`.
+	// TODO: model `[Symbol.dispose]()` / Web IDL `Disposable` when hxnodejs supports it.
+
+	@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#class-intervalhistogram-extends-histogram
 **/
 extern class IntervalHistogram extends Histogram {
 	/**
 		Disables the update interval timer. Returns `true` if the timer was stopped,
 		`false` if it was already stopped.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#histogramdisable
 	**/
 	function disable():Bool;
 
 	/**
 		Enables the update interval timer. Returns `true` if the timer was started,
 		`false` if it was already started.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#histogramenable
 	**/
 	function enable():Bool;
 }

--- a/src/js/node/perf_hooks/Performance.hx
+++ b/src/js/node/perf_hooks/Performance.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -23,7 +23,6 @@
 package js.node.perf_hooks;
 
 import haxe.Constraints.Function;
-import haxe.extern.EitherType;
 import js.node.PerfHooks.EventLoopUtilization;
 import js.node.PerfHooks.TimerifyOptions;
 import js.node.web.Event;
@@ -44,7 +43,7 @@ enum abstract PerformanceEvent(String) from String to String {
 		`performance.clearResourceTimings()` in the event listener to allow more entries
 		to be added to the performance timeline buffer.
 
-		@see https://nodejs.org/api/perf_hooks.html#event-resourcetimingbufferfull
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#event-resourcetimingbufferfull
 	**/
 	var ResourceTimingBufferFull = "resourcetimingbufferfull";
 }
@@ -55,26 +54,31 @@ enum abstract PerformanceEvent(String) from String to String {
 
 	Extends `EventTarget` (not `EventEmitter`).
 
-	@see https://nodejs.org/api/perf_hooks.html#class-performance
-	@see https://nodejs.org/api/globals.html#performance
+	@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#perf_hooksperformance
 **/
 @:jsRequire("perf_hooks", "Performance")
 extern class Performance extends EventTarget {
 	/**
 		If `name` is not provided, removes all `PerformanceMark` objects from the Performance Timeline.
 		If `name` is provided, removes only the named mark.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performanceclearmarksname
 	**/
 	function clearMarks(?name:String):Void;
 
 	/**
 		If `name` is not provided, removes all `PerformanceMeasure` objects from the Performance Timeline.
 		If `name` is provided, removes only the named measure.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performanceclearmeasuresname
 	**/
 	function clearMeasures(?name:String):Void;
 
 	/**
 		If `name` is not provided, removes all `PerformanceResourceTiming` objects from the Resource Timeline.
 		If `name` is provided, removes only the named resource.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performanceclearresourcetimingsname
 	**/
 	function clearResourceTimings(?name:String):Void;
 
@@ -86,12 +90,16 @@ extern class Performance extends EventTarget {
 
 		Prefer this over the module-level `PerfHooks.eventLoopUtilization` when targeting
 		Node.js 22 LTS as well as Node.js 24; the module-level alias was only added in v24.12.0.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performanceeventlooputilizationutilization1-utilization2
 	**/
 	function eventLoopUtilization(?utilization1:EventLoopUtilization, ?utilization2:EventLoopUtilization):EventLoopUtilization;
 
 	/**
 		Returns a list of `PerformanceEntry` objects in chronological order with respect to
 		`performanceEntry.startTime`.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performancegetentries
 	**/
 	function getEntries():Array<PerformanceEntry>;
 
@@ -99,17 +107,23 @@ extern class Performance extends EventTarget {
 		Returns a list of `PerformanceEntry` objects in chronological order with respect to
 		`performanceEntry.startTime` whose `performanceEntry.name` is equal to `name`, and optionally,
 		whose `performanceEntry.entryType` is equal to `type`.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performancegetentriesbynamename-type
 	**/
 	function getEntriesByName(name:String, ?type:PerformanceEntryType):Array<PerformanceEntry>;
 
 	/**
 		Returns a list of `PerformanceEntry` objects in chronological order with respect to
 		`performanceEntry.startTime` whose `performanceEntry.entryType` is equal to `type`.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performancegetentriesbytypetype
 	**/
 	function getEntriesByType(type:PerformanceEntryType):Array<PerformanceEntry>;
 
 	/**
 		Creates a new `PerformanceMark` entry in the Performance Timeline.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performancemarkname-options
 	**/
 	function mark(name:String, ?options:PerformanceMarkOptions):PerformanceMark;
 
@@ -117,12 +131,16 @@ extern class Performance extends EventTarget {
 		Creates a new `PerformanceResourceTiming` entry in the Resource Timeline.
 
 		This property is an extension by Node.js. It is not available in Web browsers.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performancemarkresourcetimingtiminginfo-requestedurl-initiatortype-global-cachemode-bodyinfo-responsestatus-deliverytype
 	**/
 	function markResourceTiming(timingInfo:Dynamic, requestedUrl:String, initiatorType:String, global:Dynamic, cacheMode:String, bodyInfo:Dynamic,
 		responseStatus:Int, ?deliveryType:String):PerformanceResourceTiming;
 
 	/**
 		Creates a new `PerformanceMeasure` entry in the Performance Timeline.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performancemeasurename-startmarkoroptions-endmark
 	**/
 	@:overload(function(name:String, options:PerformanceMeasureOptions):PerformanceMeasure {})
 	function measure(name:String, ?startMark:String, ?endMark:String):PerformanceMeasure;
@@ -132,12 +150,16 @@ extern class Performance extends EventTarget {
 		specific Node.js operational milestones.
 
 		This property is an extension by Node.js. It is not available in Web browsers.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performancenodetiming
 	**/
-	var nodeTiming(default, null):PerformanceNodeTiming;
+	final nodeTiming:PerformanceNodeTiming;
 
 	/**
 		Returns the current high resolution millisecond timestamp, where 0 represents the start
 		of the current `node` process.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performancenow
 	**/
 	function now():Float;
 
@@ -146,14 +168,18 @@ extern class Performance extends EventTarget {
 		"resource" type performance entry objects.
 
 		By default the max buffer size is set to 250.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performancesetresourcetimingbuffersizemaxsize
 	**/
 	function setResourceTimingBufferSize(maxSize:Int):Void;
 
 	/**
 		The timeOrigin specifies the high resolution millisecond timestamp at which the current
 		`node` process began, measured in Unix time.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performancetimeorigin
 	**/
-	var timeOrigin(default, null):Float;
+	final timeOrigin:Float;
 
 	/**
 		Wraps a function within a new function that measures the running time of the wrapped function.
@@ -164,16 +190,20 @@ extern class Performance extends EventTarget {
 
 		Prefer this over the module-level `PerfHooks.timerify` when targeting Node.js 22 LTS as well
 		as Node.js 24; the module-level alias was only added in v24.12.0.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performancetimerifyfn-options
 	**/
 	function timerify<T:Function>(fn:T, ?options:TimerifyOptions):T;
 
 	/**
 		An object which is JSON representation of the `performance` object.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performancetojson
 	**/
 	function toJSON():Dynamic;
 
 	/**
 		Event handler for the `'resourcetimingbufferfull'` event.
 	**/
-	var onresourcetimingbufferfull:EitherType<Event->Void, Function>;
+	var onresourcetimingbufferfull:Null<(event:Event) -> Void>;
 }

--- a/src/js/node/perf_hooks/PerformanceEntry.hx
+++ b/src/js/node/perf_hooks/PerformanceEntry.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,30 +25,38 @@ package js.node.perf_hooks;
 /**
 	The constructor of this class is not exposed to users directly.
 
-	@see https://nodejs.org/api/perf_hooks.html#class-performanceentry
+	@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#class-performanceentry
 **/
 @:jsRequire("perf_hooks", "PerformanceEntry")
 extern class PerformanceEntry {
 	/**
 		The total number of milliseconds elapsed for this entry.
 		This value will not be meaningful for all Performance Entry types.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performanceentryduration
 	**/
-	var duration(default, null):Float;
+	final duration:Float;
 
 	/**
 		The type of the performance entry.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performanceentryentrytype
 	**/
-	var entryType(default, null):PerformanceEntryType;
+	final entryType:PerformanceEntryType;
 
 	/**
 		The name of the performance entry.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performanceentryname
 	**/
-	var name(default, null):String;
+	final name:String;
 
 	/**
 		The high resolution millisecond timestamp marking the starting time of the Performance Entry.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performanceentrystarttime
 	**/
-	var startTime(default, null):Float;
+	final startTime:Float;
 
 	/**
 		Returns a JSON representation of the `PerformanceEntry` object.

--- a/src/js/node/perf_hooks/PerformanceEntryType.hx
+++ b/src/js/node/perf_hooks/PerformanceEntryType.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,7 +25,7 @@ package js.node.perf_hooks;
 /**
 	Type of a performance entry (`performanceEntry.entryType`).
 
-	@see https://nodejs.org/api/perf_hooks.html#performanceentryentrytype
+	@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performanceentryentrytype
 **/
 enum abstract PerformanceEntryType(String) from String to String {
 	/** Node.js only **/

--- a/src/js/node/perf_hooks/PerformanceMark.hx
+++ b/src/js/node/perf_hooks/PerformanceMark.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -25,7 +25,7 @@ package js.node.perf_hooks;
 /**
 	Exposes marks created via the `Performance.mark()` method.
 
-	@see https://nodejs.org/api/perf_hooks.html#class-performancemark
+	@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#class-performancemark
 **/
 @:jsRequire("perf_hooks", "PerformanceMark")
 extern class PerformanceMark extends PerformanceEntry {
@@ -33,8 +33,10 @@ extern class PerformanceMark extends PerformanceEntry {
 
 	/**
 		Additional detail specified when creating with `Performance.mark()` method.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performancemarkdetail
 	**/
-	var detail(default, null):Dynamic;
+	final detail:Dynamic;
 }
 
 /**

--- a/src/js/node/perf_hooks/PerformanceMeasure.hx
+++ b/src/js/node/perf_hooks/PerformanceMeasure.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -29,14 +29,16 @@ import haxe.extern.EitherType;
 
 	The constructor of this class is not exposed to users directly.
 
-	@see https://nodejs.org/api/perf_hooks.html#class-performancemeasure
+	@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#class-performancemeasure
 **/
 @:jsRequire("perf_hooks", "PerformanceMeasure")
 extern class PerformanceMeasure extends PerformanceEntry {
 	/**
 		Additional detail specified when creating with `Performance.measure()` method.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performancemeasuredetail
 	**/
-	var detail(default, null):Dynamic;
+	final detail:Dynamic;
 }
 
 /**

--- a/src/js/node/perf_hooks/PerformanceNodeEntry.hx
+++ b/src/js/node/perf_hooks/PerformanceNodeEntry.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -29,29 +29,35 @@ package js.node.perf_hooks;
 
 	The constructor of this class is not exposed to users directly.
 
-	@see https://nodejs.org/api/perf_hooks.html#class-performancenodeentry
+	@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#class-performancenodeentry
 **/
 extern class PerformanceNodeEntry extends PerformanceEntry {
 	/**
 		Additional detail specific to the `entryType`.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performancenodeentrydetail
 	**/
-	var detail(default, null):Dynamic;
+	final detail:Dynamic;
 
 	/**
 		Stability: 0 - Deprecated: Use `detail` instead.
 
 		When `entryType` is equal to `'gc'`, contains additional information about
 		garbage collection operation.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performancenodeentryflags
 	**/
 	@:deprecated("Use detail instead")
-	var flags(default, null):Int;
+	final flags:Int;
 
 	/**
 		Stability: 0 - Deprecated: Use `detail` instead.
 
 		When `entryType` is equal to `'gc'`, identifies the type of garbage collection
 		operation that occurred.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performancenodeentrykind
 	**/
 	@:deprecated("Use detail instead")
-	var kind(default, null):Int;
+	final kind:Int;
 }

--- a/src/js/node/perf_hooks/PerformanceNodeTiming.hx
+++ b/src/js/node/perf_hooks/PerformanceNodeTiming.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -28,43 +28,55 @@ package js.node.perf_hooks;
 	Provides timing details for Node.js itself. The constructor of this class is
 	not exposed to users.
 
-	@see https://nodejs.org/api/perf_hooks.html#class-performancenodetiming
+	@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#class-performancenodetiming
 **/
 extern class PerformanceNodeTiming extends PerformanceEntry {
 	/**
 		The high resolution millisecond timestamp at which the Node.js process completed bootstrapping.
 		If bootstrapping has not yet finished, the property has the value of -1.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performancenodetimingbootstrapcomplete
 	**/
-	var bootstrapComplete(default, null):Float;
+	final bootstrapComplete:Float;
 
 	/**
 		The high resolution millisecond timestamp at which the Node.js environment was initialized.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performancenodetimingenvironment
 	**/
-	var environment(default, null):Float;
+	final environment:Float;
 
 	/**
 		The high resolution millisecond timestamp of the amount of time the event loop has been idle
 		within the event loop's event provider (e.g. `epoll_wait`). This does not take CPU usage into
 		consideration. If the event loop has not yet started, the property has the value of 0.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performancenodetimingidletime
 	**/
-	var idleTime(default, null):Float;
+	final idleTime:Float;
 
 	/**
 		The high resolution millisecond timestamp at which the Node.js event loop exited.
 		If the event loop has not yet exited, the property has the value of -1.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performancenodetimingloopexit
 	**/
-	var loopExit(default, null):Float;
+	final loopExit:Float;
 
 	/**
 		The high resolution millisecond timestamp at which the Node.js event loop started.
 		If the event loop has not yet started, the property has the value of -1.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performancenodetimingloopstart
 	**/
-	var loopStart(default, null):Float;
+	final loopStart:Float;
 
 	/**
 		The high resolution millisecond timestamp at which the Node.js process was initialized.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performancenodetimingnodestart
 	**/
-	var nodeStart(default, null):Float;
+	final nodeStart:Float;
 
 	/**
 		A wrapper to the `uv_metrics_info` function. Returns the current set of event loop metrics.
@@ -72,13 +84,17 @@ extern class PerformanceNodeTiming extends PerformanceEntry {
 		It is recommended to use this property inside a function whose execution was scheduled using
 		`setImmediate` to avoid collecting metrics before finishing all operations scheduled during
 		the current loop iteration.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performancenodetiminguvmetricsinfo
 	**/
-	var uvMetricsInfo(default, null):UVMetrics;
+	final uvMetricsInfo:UVMetrics;
 
 	/**
 		The high resolution millisecond timestamp at which the V8 platform was initialized.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performancenodetimingv8start
 	**/
-	var v8Start(default, null):Float;
+	final v8Start:Float;
 }
 
 /**

--- a/src/js/node/perf_hooks/PerformanceObserver.hx
+++ b/src/js/node/perf_hooks/PerformanceObserver.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -26,36 +26,46 @@ package js.node.perf_hooks;
 	`PerformanceObserver` objects provide notifications when new `PerformanceEntry`
 	instances have been added to the Performance Timeline.
 
-	@see https://nodejs.org/api/perf_hooks.html#class-performanceobserver
+	@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#class-performanceobserver
 **/
 @:jsRequire("perf_hooks", "PerformanceObserver")
 extern class PerformanceObserver {
 	/**
 		Get supported entry types.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performanceobserversupportedentrytypes
 	**/
-	static var supportedEntryTypes(default, never):Array<PerformanceEntryType>;
+	static final supportedEntryTypes:Array<PerformanceEntryType>;
 
 	/**
 		Creates a new `PerformanceObserver`.
 
 		The `callback` is invoked when a `PerformanceObserver` is notified about new
 		`PerformanceEntry` instances.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#new-performanceobservercallback
 	**/
 	function new(callback:PerformanceObserverCallback);
 
 	/**
 		Disconnects the `PerformanceObserver` instance from all notifications.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performanceobserverdisconnect
 	**/
 	function disconnect():Void;
 
 	/**
 		Subscribes the instance to notifications of new instances identified either by
 		`options.entryTypes` or `options.type`.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performanceobserverobserveoptions
 	**/
 	function observe(options:PerformanceObserverObserveOptions):Void;
 
 	/**
 		Returns the current list of entries stored in the performance observer, emptying it out.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performanceobservertakerecords
 	**/
 	function takeRecords():Array<PerformanceEntry>;
 }
@@ -63,7 +73,7 @@ extern class PerformanceObserver {
 /**
 	Callback invoked when a `PerformanceObserver` is notified about new entries.
 **/
-typedef PerformanceObserverCallback = PerformanceObserverEntryList->PerformanceObserver->Void;
+typedef PerformanceObserverCallback = (list:PerformanceObserverEntryList, observer:PerformanceObserver) -> Void;
 
 /**
 	Options for `PerformanceObserver.observe`.

--- a/src/js/node/perf_hooks/PerformanceObserverEntryList.hx
+++ b/src/js/node/perf_hooks/PerformanceObserverEntryList.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -26,13 +26,15 @@ package js.node.perf_hooks;
 	Used to provide access to the `PerformanceEntry` instances passed to a `PerformanceObserver`.
 	The constructor of this class is not exposed to users.
 
-	@see https://nodejs.org/api/perf_hooks.html#class-performanceobserverentrylist
+	@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#class-performanceobserverentrylist
 **/
 @:jsRequire("perf_hooks", "PerformanceObserverEntryList")
 extern class PerformanceObserverEntryList {
 	/**
 		Returns a list of `PerformanceEntry` objects in chronological order with respect to
 		`performanceEntry.startTime`.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performanceobserverentrylistgetentries
 	**/
 	function getEntries():Array<PerformanceEntry>;
 
@@ -40,12 +42,16 @@ extern class PerformanceObserverEntryList {
 		Returns a list of `PerformanceEntry` objects in chronological order with respect to
 		`performanceEntry.startTime` whose `performanceEntry.name` is equal to `name`, and optionally,
 		whose `performanceEntry.entryType` is equal to `type`.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performanceobserverentrylistgetentriesbynamename-type
 	**/
 	function getEntriesByName(name:String, ?type:PerformanceEntryType):Array<PerformanceEntry>;
 
 	/**
 		Returns a list of `PerformanceEntry` objects in chronological order with respect to
 		`performanceEntry.startTime` whose `performanceEntry.entryType` is equal to `type`.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performanceobserverentrylistgetentriesbytypetype
 	**/
 	function getEntriesByType(type:PerformanceEntryType):Array<PerformanceEntry>;
 }

--- a/src/js/node/perf_hooks/PerformanceResourceTiming.hx
+++ b/src/js/node/perf_hooks/PerformanceResourceTiming.hx
@@ -111,6 +111,12 @@ extern class PerformanceResourceTiming extends PerformanceEntry {
 	final requestStart:Float;
 
 	/**
+		The high resolution millisecond timestamp representing the time immediately after the first byte of
+		the response is received from the server.
+	**/
+	final responseStart:Float;
+
+	/**
 		The high resolution millisecond timestamp representing the time immediately after Node.js receives
 		the last byte of the resource or immediately before the transport connection is closed, whichever
 		comes first.
@@ -144,9 +150,32 @@ extern class PerformanceResourceTiming extends PerformanceEntry {
 	final decodedBodySize:Float;
 
 	/**
+		A string representing the type of resource fetch that initiated this timing entry
+		(for example `'fetch'` or `'xmlhttprequest'`).
+	**/
+	final initiatorType:String;
+
+	/**
+		A string representing the network protocol used to fetch the resource
+		(for example `'http/1.1'` or `'h2'`).
+	**/
+	final nextHopProtocol:String;
+
+	/**
+		A number representing the HTTP response status code returned when fetching the resource.
+	**/
+	final responseStatus:Float;
+
+	/**
+		A string representing how the resource was delivered (for example cache delivery type).
+		Empty string when not applicable.
+	**/
+	final deliveryType:String;
+
+	/**
 		Returns an object that is the JSON representation of the `PerformanceResourceTiming` object.
 
 		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performanceresourcetimingtojson
 	**/
-	override function toJSON():Dynamic;
+	override function toJSON():Any;
 }

--- a/src/js/node/perf_hooks/PerformanceResourceTiming.hx
+++ b/src/js/node/perf_hooks/PerformanceResourceTiming.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -27,96 +27,126 @@ package js.node.perf_hooks;
 
 	The constructor of this class is not exposed to users directly.
 
-	@see https://nodejs.org/api/perf_hooks.html#class-performanceresourcetiming
+	@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#class-performanceresourcetiming
 **/
 @:jsRequire("perf_hooks", "PerformanceResourceTiming")
 extern class PerformanceResourceTiming extends PerformanceEntry {
 	/**
 		The high resolution millisecond timestamp at immediately before dispatching the `fetch` request.
 		If the resource is not intercepted by a worker the property will always return 0.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performanceresourcetimingworkerstart
 	**/
-	var workerStart(default, null):Float;
+	final workerStart:Float;
 
 	/**
 		The high resolution millisecond timestamp that represents the start time of the fetch which
 		initiates the redirect.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performanceresourcetimingredirectstart
 	**/
-	var redirectStart(default, null):Float;
+	final redirectStart:Float;
 
 	/**
 		The high resolution millisecond timestamp that will be created immediately after receiving the
 		last byte of the response of the last redirect.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performanceresourcetimingredirectend
 	**/
-	var redirectEnd(default, null):Float;
+	final redirectEnd:Float;
 
 	/**
 		The high resolution millisecond timestamp immediately before the Node.js starts to fetch the resource.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performanceresourcetimingfetchstart
 	**/
-	var fetchStart(default, null):Float;
+	final fetchStart:Float;
 
 	/**
 		The high resolution millisecond timestamp immediately before the Node.js starts the domain name
 		lookup for the resource.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performanceresourcetimingdomainlookupstart
 	**/
-	var domainLookupStart(default, null):Float;
+	final domainLookupStart:Float;
 
 	/**
 		The high resolution millisecond timestamp representing the time immediately after the Node.js
 		finished the domain name lookup for the resource.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performanceresourcetimingdomainlookupend
 	**/
-	var domainLookupEnd(default, null):Float;
+	final domainLookupEnd:Float;
 
 	/**
 		The high resolution millisecond timestamp representing the time immediately before Node.js starts
 		to establish the connection to the server to retrieve the resource.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performanceresourcetimingconnectstart
 	**/
-	var connectStart(default, null):Float;
+	final connectStart:Float;
 
 	/**
 		The high resolution millisecond timestamp representing the time immediately after Node.js finishes
 		establishing the connection to the server to retrieve the resource.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performanceresourcetimingconnectend
 	**/
-	var connectEnd(default, null):Float;
+	final connectEnd:Float;
 
 	/**
 		The high resolution millisecond timestamp representing the time immediately before Node.js starts
 		the handshake process to secure the current connection.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performanceresourcetimingsecureconnectionstart
 	**/
-	var secureConnectionStart(default, null):Float;
+	final secureConnectionStart:Float;
 
 	/**
 		The high resolution millisecond timestamp representing the time immediately before Node.js receives
 		the first byte of the response from the server.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performanceresourcetimingrequeststart
 	**/
-	var requestStart(default, null):Float;
+	final requestStart:Float;
 
 	/**
 		The high resolution millisecond timestamp representing the time immediately after Node.js receives
 		the last byte of the resource or immediately before the transport connection is closed, whichever
 		comes first.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performanceresourcetimingresponseend
 	**/
-	var responseEnd(default, null):Float;
+	final responseEnd:Float;
 
 	/**
 		A number representing the size (in octets) of the fetched resource. The size includes the response
 		header fields plus the response payload body.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performanceresourcetimingtransfersize
 	**/
-	var transferSize(default, null):Float;
+	final transferSize:Float;
 
 	/**
 		A number representing the size (in octets) received from the fetch (HTTP or cache), of the payload
 		body, before removing any applied content-codings.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performanceresourcetimingencodedbodysize
 	**/
-	var encodedBodySize(default, null):Float;
+	final encodedBodySize:Float;
 
 	/**
 		A number representing the size (in octets) received from the fetch (HTTP or cache), of the message
 		body, after removing any applied content-codings.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performanceresourcetimingdecodedbodysize
 	**/
-	var decodedBodySize(default, null):Float;
+	final decodedBodySize:Float;
 
 	/**
 		Returns an object that is the JSON representation of the `PerformanceResourceTiming` object.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#performanceresourcetimingtojson
 	**/
 	override function toJSON():Dynamic;
 }

--- a/src/js/node/perf_hooks/RecordableHistogram.hx
+++ b/src/js/node/perf_hooks/RecordableHistogram.hx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2014-2020 Haxe Foundation
+ * Copyright (C)2014-2026 Haxe Foundation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -27,11 +27,13 @@ import haxe.extern.EitherType;
 /**
 	A `Histogram` that can record values.
 
-	@see https://nodejs.org/api/perf_hooks.html#class-recordablehistogram-extends-histogram
+	@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#class-recordablehistogram-extends-histogram
 **/
 extern class RecordableHistogram extends Histogram {
 	/**
 		Adds the values from `other` to this histogram.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#histogramaddother
 	**/
 	function add(other:RecordableHistogram):Void;
 
@@ -39,12 +41,15 @@ extern class RecordableHistogram extends Histogram {
 		Records `val` in the histogram.
 
 		// TODO: allow BigInt when hxnodejs gains a BigInt type (Node accepts number | bigint).
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#histogramrecordval
 	**/
 	function record(val:EitherType<Float, Dynamic>):Void;
 
 	/**
 		Calculates the amount of time (in nanoseconds) that has passed since the previous call
 		to `recordDelta()` and records that amount in the histogram.
+
+		@see https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html#histogramrecorddelta
 	**/
 	function recordDelta():Void;
 }


### PR DESCRIPTION
## Summary
- Align `perf_hooks` externs with Node.js 24: add `IntervalHistogram.dispose` (`Symbol.dispose`, v24.2.0) and missing `PerformanceResourceTiming` fields (`responseStart`, `responseStatus`, `initiatorType`, `nextHopProtocol`, `deliveryType`).
- Haxe 4 modernization: `static final` / `final` for readonly surfaces, named-arg observer callback type; point `@see` links at `latest-v24.x`.
- Refresh copyright headers to 2014–2026.

## Test plan
- [x] `haxe -js dummy -cp src --macro 'ImportAll.run("src")' --no-output` succeeds
- [ ] Spot-check against https://nodejs.org/docs/latest-v24.x/api/perf_hooks.html
- [ ] CI: Haxe 4.0.5 / 4.3.x / latest